### PR TITLE
Fix docker tag from not exist version 0.23.0.dev to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM decidim/decidim:0.23.0.dev
+FROM decidim/decidim:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   app:
-    image: decidim/decidim:0.23.0.dev
+    image: decidim/decidim:latest
     volumes:
       - .:/app
       - bundle:/usr/local/bundle


### PR DESCRIPTION
#### :tophat: What? Why?

開発環境作成のため、Dockerのヴァージョンを0.23.0.dev のバージョンからlatestに変更

0.23.0.dev は存在しない。latestで追いかけて、本家のリリースが完了したら、0.23で固定する予定。

https://hub.docker.com/r/decidim/decidim/tags

#### :pushpin: Related Issues
- Related to #7 
