### PR TITLE
Add postgres password environment setting in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM decidim/decidim:0.23.0.dev
+FROM decidim/decidim:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,10 @@
 version: '3'
+
+x-custom:
+  postgres:
+    - &postgres_user "${DATABASE_USERNAME:-postgres}"
+    - &postgres_password "${DATABASE_PASSWORD:-password}"
+
 services:
   app:
     image: decidim/decidim:latest
@@ -7,10 +13,11 @@ services:
       - bundle:/usr/local/bundle
       - node_modules:/app/node_modules
     environment:
-      - PORT=3000
-      - DATABASE_HOST=pg
-      - DATABASE_USERNAME=postgres
-      - RAILS_ENV=development
+      PORT: 3000
+      DATABASE_HOST: pg
+      DATABASE_USERNAME: *postgres_user
+      DATABASE_PASSWORD: *postgres_password
+      RAILS_ENV: development
     ports:
       - 3000:3000
     links:
@@ -20,6 +27,10 @@ services:
     image: postgres
     volumes:
       - pg-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: *postgres_user
+      POSTGRES_PASSWORD: *postgres_password
+
 volumes:
   node_modules: {}
   bundle: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   app:
-    image: decidim/decidim:0.23.0.dev
+    image: decidim/decidim:latest
     volumes:
       - .:/app
       - bundle:/usr/local/bundle


### PR DESCRIPTION
#### :tophat: What? Why?
- 環境構築のため

dokcerコンテナで、外部からの接続には、ポスグレのコンテナにパスワードの設定が必要
アプリ側にもissueの通り必要。

>POSTGRES_PASSWORD
>
>This environment variable is required for you to use the PostgreSQL image. It must not be empty or undefined. T

現状、appのコンテナのポスグレユーザー名がデフォルトのため、ポスグレ側にユーザー名は設定しなくても問題ない。
しかし可読性の観点から、意識的に設定するようにした。

https://hub.docker.com/_/postgres

>POSTGRES_USER
>
>This optional environment variable is used in conjunction with POSTGRES_PASSWORD to set a user and its password. This variable will create the specified user with superuser power and a database with the same name. If it is not specified, then the default user of postgres will be used.

Dependency commit : https://github.com/codeforjapan/decidim-cfj/pull/10/commits/ec4647855ebc6030b3169fce337f9ec703ca1a9d

#### :pushpin: Related Issues
- Related to #9 
