### PR TITLE
DEVELOPMENT.mdにテストアカウント情報の追加

### DIFF
--- a/DEVLOPMENT.md
+++ b/DEVLOPMENT.md
@@ -110,3 +110,14 @@ docker-compose up -d
 ```
 ### 3.7 お疲れさまでした
 http://localhost:3000 にアクセス
+
+## 4. テスト用アカウント情報
+
+テストデータとして用意されているアカウントです。  
+※ いずれもパスワードは`decidim123456`です
+
+* 管理画面 (http://localhost:3000/system)
+  * system@example.org
+* サービス画面 (http://localhost:3000/users/sign_in?locale=ja)
+  * admin@example.org （組織管理者）
+  * user@example.org （通常ユーザ）


### PR DESCRIPTION
#### :tophat: What? Why?

テストアカウント情報は[公式ドキュメント内に記載されてはいる](https://docs.decidim.org/en/install/manual/#_configure_the_database)のですが、忘れがちなので。

また開発者が環境セットアップ後にテストする上で、アカウントにログインできるか試すのは有用なので。
