### PR TITLE
Put unnecessary directories on docker anonymous volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       - .:/app
       - bundle:/usr/local/bundle
       - node_modules:/app/node_modules
+      # exclude volumes
+      - /app/vendor
+      - /app/tmp
+      - /app/log
+      - /app/.git
     environment:
       PORT: 3000
       DATABASE_HOST: pg


### PR DESCRIPTION
#### :tophat: What? Why?
開発効率改善のため

環境変数`RAILS_LOG_TO_STDOUT` によりrailsのログが、標準出力にでています。しかし、rails自体の挙動か
/log/development.logにも出力されていました。

dockerはホストとのioの速度が遅いため、このあたりの挙動がボトルネックになっていると考えられます。

よって、下記を参考に不要なディレクトリを匿名ボリュームに入れました。匿名ボリュームだと、関連コンテナが削除された際に自動で削除されるので、名前付きボリュームより取り回しやすいと判断しました。

https://qiita.com/shotat/items/57d049793605ffc20135

計測してませんが、体感では許容できるくらいまで速くなりました。 :rocket:

#### :pushpin: Related Issues
- Related to #19 
