### PR TITLE
fix rails db:seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,7 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 # You can remove the 'faker' gem if you don't want Decidim seeds.
+
+require_relative '../lib/monkey_patching_faker'
+
 Decidim.seed!

--- a/lib/monkey_patching_faker.rb
+++ b/lib/monkey_patching_faker.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# This monkey patch force the output of `Faker::Internet.slug()` to be in English.
+module FakerInternetEnglishExtension
+  if Gem::Version.create(Faker::VERSION) < Gem::Version.create('2.0.0')
+
+    def slug(words = nil, glue = nil)
+      with_locale(:en) do
+        glue ||= sample(%w[- _])
+        (words || Faker::Lorem.words(2).join(' ')).delete(',.').gsub(' ', glue).downcase
+      end
+    end
+
+  else
+
+    def slug(legacy_words = NOT_GIVEN, legacy_glue = NOT_GIVEN, words: nil, glue: nil)
+      super
+      with_locale(:en) do
+        glue ||= sample(%w[- _])
+        (words || Faker::Lorem.words(number: 2).join(' ')).delete(',.').gsub(' ', glue).downcase
+      end
+    end
+
+  end
+end
+
+Faker::Internet.singleton_class.prepend(FakerInternetEnglishExtension)


### PR DESCRIPTION
#### :tophat: What? Why?

bin/rails db:seed のコマンドに失敗する #14 の件ですが、原因が気になったので調べたところ、

* slugの生成でlocaleが:jaのときには日本語の文言が使われる（！）
* 一方で、Decidimではslugは英数字しか許さない（以下を参考）

https://github.com/decidim/decidim/blob/8e237fb075418a840b94275f5dafba7b374dc828/decidim-core/lib/decidim/participable.rb#L97-L99

という理由でエラーになっていることが分かりました。

これはその回避案で、Faker::Internet.slugでlocaleに関わらずenにして出力するよう修正するpatchです。

#### :pushpin: Related Issues
- Related to #14

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
