### PR TITLE
use LetterOpener in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,13 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Use LetterOpener to send e-mail
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.default_url_options = {
+    host: 'localhost',
+    port: 3000
+  }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,8 @@ Rails.application.routes.draw do
   authenticate :user, ->(u) { u.admin? } do
     mount Sidekiq::Web => "/sidekiq"
   end
+
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

ローカルの開発環境で、LetterOpener(とLetterOpenerWeb)を使ってメールの確認ができるようにするものです。

これを使えば、実際にメールは送信されなくなり、Webで確認できるため、架空のメールアドレスを使って動作確認ができます。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![letter-opener](https://user-images.githubusercontent.com/10401/97098266-43155180-16be-11eb-9678-a70deb71ebcb.png)
