### PR TITLE
Temporary fix for https://github.com/decidim/decidim/issues/6720

### DIFF
--- a/app/uploaders/decidim/application_uploader.rb
+++ b/app/uploaders/decidim/application_uploader.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This class deals with uploading files to Decidim. It is intended to just
+  # hold the uploads configuration, so you should inherit from this class and
+  # then tweak any configuration you need.
+  class ApplicationUploader < CarrierWave::Uploader::Base
+    process :validate_inside_organization
+
+    # Override the directory where uploaded files will be stored.
+    # This is a sensible default for uploaders that are meant to be mounted:
+    def store_dir
+      default_path = "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+
+      return File.join(Decidim.base_uploads_path, default_path) if Decidim.base_uploads_path.present?
+      default_path
+    end
+
+    protected
+
+    # Validates that the associated model is always within an organization in
+    # order to pass the organization specific settings for the file upload
+    # checks (e.g. file extension, mime type, etc.).
+    def validate_inside_organization
+      return if model.is_a?(Decidim::Organization)
+      return if model.respond_to?(:organization) && model.organization.is_a?(Decidim::Organization)
+
+      # HACK: Temporary fix for https://github.com/decidim/decidim/issues/6720
+      # If this is fixed by decidim, this file (application_uploader.rb)
+      # should be deleted to keep in sync with upstream!
+      return if model.class.to_s == 'decidim/hero_homepage_content_block'
+
+      raise CarrierWave::IntegrityError, I18n.t("carrierwave.errors.not_inside_organization")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
アドミンUIにある設定→ホームページ→ヒーロー画像からアップロードしたら`IntegrityError: The file is not attached to any organization`エラーが`application_uploader.rb`の`validate_inside_organization`に発生します。このPRはこの問題の一部を直します。

暫定的な解決なので、decidimの側ではこのエラー直したら`application_uploader.rb`を削除すべきだと思います。

#### :pushpin: Related Issues
- Related to https://github.com/codeforjapan/decidim-cfj/issues/18 and https://github.com/decidim/decidim/issues/6720

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/20507948/97103663-fd7a7800-1701-11eb-89bd-3b0555bbb885.png)
