### PR TITLE
added custom stylesheet

### DIFF
--- a/app/assets/stylesheets/kakogawa.scss
+++ b/app/assets/stylesheets/kakogawa.scss
@@ -1,0 +1,3 @@
+.logo-wrapper {
+  width: 20%;
+}

--- a/app/views/layouts/decidim/_head_extra.html.erb
+++ b/app/views/layouts/decidim/_head_extra.html.erb
@@ -1,0 +1,1 @@
+<%=stylesheet_link_tag 'kakogawa' %>


### PR DESCRIPTION
#### :tophat: What? Why?
Create custom css as `/assets/stylesheets/kakogawa.scss`

管理画面で<head>内のカスタム項目を追加できるはずだったが、なぜか追加できなかったので暫定対応

#### :pushpin: Related Issues
- Fixes #25

