### PR TITLE
show user extension data in admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem "faker", "~> 1.9"
 
 gem "wicked_pdf", "~> 1.4"
 
+gem "deface"
+
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
   gem "figaro"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,6 +335,11 @@ GEM
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
+    deface (1.5.3)
+      nokogiri (>= 1.6)
+      polyglot
+      rails (>= 4.1)
+      rainbow (>= 2.1.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (4.7.3)
@@ -569,6 +574,7 @@ GEM
     pg_search (2.3.4)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
+    polyglot (0.3.5)
     premailer (1.14.2)
       addressable
       css_parser (>= 1.6.0)
@@ -806,6 +812,7 @@ DEPENDENCIES
   byebug (~> 11.0)
   decidim!
   decidim-dev!
+  deface
   dotenv-rails
   factory_bot_rails
   faker (~> 1.9)

--- a/app/assets/javascripts/decidim/admin/officializations.js.es6
+++ b/app/assets/javascripts/decidim/admin/officializations.js.es6
@@ -1,3 +1,26 @@
+// from decidim/decidim-admin/app/assets/javascripts/decidim/admin/officializations.js.es6
+$(() => {
+  const $modal = $("#show-email-modal");
+
+  if ($modal.length === 0) {
+    return
+  }
+
+  const $button = $("[data-open=user_email]", $modal);
+  const $email = $("#user_email", $modal);
+  const $fullName = $("#user_full_name", $modal);
+
+  $("[data-toggle=show-email-modal]").on("click", (event) => {
+    event.preventDefault()
+
+    $button.show()
+    $button.attr("data-open-url", event.currentTarget.href)
+    $fullName.text($(event.currentTarget).data("full-name"))
+    $email.html("")
+  })
+})
+
+// added decidim-cfj
 $(() => {
   const $modal = $("#show-user-modal");
 
@@ -6,8 +29,8 @@ $(() => {
   }
 
   const $button = $("[data-open=user_extension]", $modal);
+  const $userExtension = $("#user_extension", $modal);
   const $fullName = $("#user_full_name2", $modal);
-  const $keyList = ["real_name", "address", "birth_year", "gender", "occupation"];
 
   $("[data-toggle=show-user-modal]").on("click", (event) => {
     event.preventDefault()
@@ -15,9 +38,6 @@ $(() => {
     $button.show()
     $button.attr("data-open-url", event.currentTarget.href)
     $fullName.text($(event.currentTarget).data("full-name"))
-    $keyList.forEach((key) => {
-      let $user_extension_item = $("#user_extension_" + key, $modal);
-      $user_extension_item.html("")
-    })
+    $userExtension.html("")
   })
 })

--- a/app/assets/javascripts/decidim/admin/officializations.js.es6
+++ b/app/assets/javascripts/decidim/admin/officializations.js.es6
@@ -1,0 +1,23 @@
+$(() => {
+  const $modal = $("#show-user-modal");
+
+  if ($modal.length === 0) {
+    return
+  }
+
+  const $button = $("[data-open=user_extension]", $modal);
+  const $fullName = $("#user_full_name2", $modal);
+  const $keyList = ["real_name", "address", "birth_year", "gender", "occupation"];
+
+  $("[data-toggle=show-user-modal]").on("click", (event) => {
+    event.preventDefault()
+
+    $button.show()
+    $button.attr("data-open-url", event.currentTarget.href)
+    $fullName.text($(event.currentTarget).data("full-name"))
+    $keyList.forEach((key) => {
+      let $user_extension_item = $("#user_extension_" + key, $modal);
+      $user_extension_item.html("")
+    })
+  })
+})

--- a/app/controllers/decidim/admin/officializations/user_extensions_controller.rb
+++ b/app/controllers/decidim/admin/officializations/user_extensions_controller.rb
@@ -13,7 +13,7 @@ module Decidim
 
           Decidim.traceability.perform_action! :show_user_extension, user, current_user
 
-          read_authorization
+          @user_extension = user_extension
 
           render :show, layout: false
         end
@@ -27,12 +27,12 @@ module Decidim
           )
         end
 
-        def read_authorization
+        def user_extension
           @authorization = Authorization.find_by(
             decidim_user_id: user.id,
             name: "user_extension"
           )
-          @user_extension = @authorization.metadata
+          @authorization&.metadata || {}
         end
       end
     end

--- a/app/controllers/decidim/admin/officializations/user_extensions_controller.rb
+++ b/app/controllers/decidim/admin/officializations/user_extensions_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Admin
+    module Officializations
+      class UserExtensionsController < Decidim::Admin::ApplicationController
+        include Decidim::Admin::Officializations::Filterable
+
+        helper_method :user
+
+        def show
+          enforce_permission_to :show_user_extension, :user, user: user
+
+          Decidim.traceability.perform_action! :show_user_extension, user, current_user
+
+          read_authorization
+
+          render :show, layout: false
+        end
+
+        private
+
+        def user
+          @user ||= Decidim::User.find_by(
+            id: params[:user_id],
+            organization: current_organization
+          )
+        end
+
+        def read_authorization
+          @authorization = Authorization.find_by(
+            decidim_user_id: user.id,
+            name: "user_extension"
+          )
+          @user_extension = @authorization.metadata
+        end
+      end
+    end
+  end
+end

--- a/app/overrides/decidim/admin/officializations/index/user_extension_modal_override.html.erb.deface
+++ b/app/overrides/decidim/admin/officializations/index/user_extension_modal_override.html.erb.deface
@@ -1,0 +1,2 @@
+<!-- insert_after "div#user-groups" -->
+<%= render "show_user_extension_modal" %>

--- a/app/overrides/decidim/admin/officializations/index/user_extension_override.html.erb.deface
+++ b/app/overrides/decidim/admin/officializations/index/user_extension_override.html.erb.deface
@@ -1,0 +1,5 @@
+<!-- insert_bottom "td.table-list__actions" -->
+<% if allowed_to? :show_user_extension, :user, user: user %>
+  <%= icon_link_to "person", main_app.user_extension_admin_officialization_path(user.id), t(".show_user_extension"), class: "action-icon action-icon--show-user", data: { full_name: user.name, toggle: "show-user-modal" } %>
+<% end %>
+

--- a/app/views/decidim/admin/officializations/_show_user_extension_modal.html.erb
+++ b/app/views/decidim/admin/officializations/_show_user_extension_modal.html.erb
@@ -14,13 +14,11 @@
       <div class="show_email">
         <h4><%= t(".full_name") %></h4>
         <div><p id="user_full_name2"></p></div>
-        <% %w(real_name address birth_year gender occupation).each do |key| %>
-        <h4><%= t(".#{key}") %></h4>
+        <h4><%= t(".user_extension") %></h4>
         <div>
-          <p id="user_extension_<%= key %>"></p>
+          <p id="user_extension"></p>
           <p><%= t(".hidden") %></p>
         </div>
-        <% end %>
       </div>
 
       <div class="button--double form-general-submit">
@@ -31,3 +29,14 @@
     </div>
   </div>
 </div>
+<script type="text/javascript">
+  var text = '.show_email #user_extension + p{display:none;color:#999;font-style: italic;}' +
+             '.show_email #user_extension:empty + p{display:block;}';
+  var rule = document.createTextNode(text);
+  var style = document.createElement('style');
+  style.media = 'screen';
+  style.type = 'text/css';
+  style.appendChild(rule);
+  var head = document.getElementsByTagName('head').item(0);
+  head.appendChild(style);
+</script>

--- a/app/views/decidim/admin/officializations/_show_user_extension_modal.html.erb
+++ b/app/views/decidim/admin/officializations/_show_user_extension_modal.html.erb
@@ -1,0 +1,33 @@
+<div class="reveal" id="show-user-modal" data-reveal>
+  <div class="reveal__header">
+    <h3 class="reveal__title"><%= t(".title") %></h3>
+    <button class="close-button" data-close aria-label="<%= t(".close_modal") %>"
+      type="button">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+
+  <div class="row">
+    <div class="columns medium-4 medium-centered">
+      <p><%= t(".description") %></p>
+
+      <div class="show_email">
+        <h4><%= t(".full_name") %></h4>
+        <div><p id="user_full_name2"></p></div>
+        <% %w(real_name address birth_year gender occupation).each do |key| %>
+        <h4><%= t(".#{key}") %></h4>
+        <div>
+          <p id="user_extension_<%= key %>"></p>
+          <p><%= t(".hidden") %></p>
+        </div>
+        <% end %>
+      </div>
+
+      <div class="button--double form-general-submit">
+        <button class="button" data-open="user_extension" data-open-url="">
+          <%= t(".show") %>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/decidim/admin/officializations/_show_user_extension_modal.html.erb
+++ b/app/views/decidim/admin/officializations/_show_user_extension_modal.html.erb
@@ -30,13 +30,17 @@
   </div>
 </div>
 <script type="text/javascript">
-  var text = '.show_email #user_extension + p{display:none;color:#999;font-style: italic;}' +
-             '.show_email #user_extension:empty + p{display:block;}';
-  var rule = document.createTextNode(text);
-  var style = document.createElement('style');
-  style.media = 'screen';
-  style.type = 'text/css';
-  style.appendChild(rule);
-  var head = document.getElementsByTagName('head').item(0);
-  head.appendChild(style);
+$(() => {
+  function appendStyleElement(text) {
+    var style = document.createElement('style');
+    style.media = 'screen';
+    style.type = 'text/css';
+    var rule = document.createTextNode(text);
+    style.appendChild(rule);
+    var head = document.getElementsByTagName('head').item(0);
+    head.appendChild(style);
+  }
+  appendStyleElement('.show_email #user_extension + p{display:none;color:#999;font-style: italic;}' +
+                     '.show_email #user_extension:empty + p{display:block;}');
+});
 </script>

--- a/app/views/decidim/admin/officializations/user_extensions/show.html.erb
+++ b/app/views/decidim/admin/officializations/user_extensions/show.html.erb
@@ -1,0 +1,2 @@
+<span>dummydummydummy</span>
+<script>$("#show-user-extension-modal button[data-open=user_extension]").hide()</script>

--- a/app/views/decidim/admin/officializations/user_extensions/show.html.erb
+++ b/app/views/decidim/admin/officializations/user_extensions/show.html.erb
@@ -1,2 +1,6 @@
-<span>dummydummydummy</span>
-<script>$("#show-user-extension-modal button[data-open=user_extension]").hide()</script>
+<p><%= t(".real_name") %>: <%= @user_extension["real_name"] %></p>
+<p><%= t(".address") %>: <%= @user_extension["address"] %></p>
+<p><%= t(".birth_year") %>: <%= @user_extension["birth_year"] %></p>
+<p><%= t(".gender") %>: <%= t("enums.user_extension.gender.#{Decidim::UserExtensionForm::GENDERS[@user_extension["gender"]]}") %></p>
+<p><%= t(".occupation") %>: <%= @user_extension["occupation"] %></p>
+<script>$("#show-user-modal button[data-open=user_extension]").hide()</script>

--- a/app/views/decidim/admin/officializations/user_extensions/show.html.erb
+++ b/app/views/decidim/admin/officializations/user_extensions/show.html.erb
@@ -1,6 +1,6 @@
 <p><%= t(".real_name") %>: <%= @user_extension["real_name"] %></p>
 <p><%= t(".address") %>: <%= @user_extension["address"] %></p>
 <p><%= t(".birth_year") %>: <%= @user_extension["birth_year"] %></p>
-<p><%= t(".gender") %>: <%= t("enums.user_extension.gender.#{Decidim::UserExtensionForm::GENDERS[@user_extension["gender"]]}") %></p>
+<p><%= t(".gender") %>: <%= @user_extension["gender"] ? t("enums.user_extension.gender.#{Decidim::UserExtensionForm::GENDERS[@user_extension["gender"]]}") : "" %></p>
 <p><%= t(".occupation") %>: <%= @user_extension["occupation"] %></p>
 <script>$("#show-user-modal button[data-open=user_extension]").hide()</script>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -53,18 +53,21 @@ ja:
         index:
           show_user_extension: ユーザー属性を表示
         show_user_extension_modal:
+          user_extension: ユーザー属性
           close_modal: モーダルを閉じる
           description: 直接参加者に連絡する必要がある場合は，表示ボタンをクリックしてメールアドレスを見ることができます．このアクションは記録されます．
           email_address: メールアドレス
           full_name: フルネーム
-          real_name: 本名
-          address: 住所
-          birth_year: 生年
-          gender: 性別
-          occupation: 職業
           hidden: hidden
           show: 表示
           title: 参加者の属性情報を表示
+        user_extensions:
+          show:
+            real_name: 本名
+            address: 住所
+            birth_year: 生年
+            gender: 性別
+            occupation: 職業
     components:
       components:
         comment:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -49,6 +49,22 @@ ja:
             nickname: アカウントID
         search_placeholder:
           name_or_nickname_or_email_cont: "%{collection} をメール、表示名、アカウントIDで検索します。"
+      officializations:
+        index:
+          show_user_extension: ユーザー属性を表示
+        show_user_extension_modal:
+          close_modal: モーダルを閉じる
+          description: 直接参加者に連絡する必要がある場合は，表示ボタンをクリックしてメールアドレスを見ることができます．このアクションは記録されます．
+          email_address: メールアドレス
+          full_name: フルネーム
+          real_name: 本名
+          address: 住所
+          birth_year: 生年
+          gender: 性別
+          occupation: 職業
+          hidden: hidden
+          show: 表示
+          title: 参加者の属性情報を表示
     components:
       components:
         comment:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,10 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => "/sidekiq"
   end
 
+  get "/admin/officializations/user_extensions/:user_id" =>
+      "decidim/admin/officializations/user_extensions#show",
+      constraints: (->(request) { Decidim::Admin::OrganizationDashboardConstraint.new(request).matches? }),
+      as: "user_extension_admin_officialization"
+
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/spec/sytem/admin_officializations_user_extension_spec.rb
+++ b/spec/sytem/admin_officializations_user_extension_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Admin manages officializations", type: :system do
+  let(:model_name) { Decidim::User.model_name }
+  let(:filterable_concern) { Decidim::Admin::Officializations::Filterable }
+
+  let(:organization) { create(:organization) }
+
+  let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+  let!(:user) { create(:user, :confirmed, organization: organization) }
+
+  context "not login" do
+    before do
+      Capybara.raise_server_errors = false
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+    end
+
+    it "cannot see admin dashboard page" do
+      visit decidim_admin.root_path
+      expect(page).to have_no_content("管理者ログ")
+    end
+
+    it "cannot see user_extension fragment" do
+      visit main_app.user_extension_admin_officialization_path(user.id)
+      expect(page).to have_no_content("参加者")
+    end
+  end
+
+  context "login as admin" do
+    before do
+      switch_to_host(organization.host)
+      login_as admin, scope: :user
+      visit decidim_admin.root_path
+      click_link "参加者"
+    end
+
+    describe "listing officializations" do
+      let!(:not_officialized) { create(:user, organization: organization) }
+
+      before do
+        within ".secondary-nav" do
+          click_link "参加者"
+        end
+      end
+
+      it "show users page" do
+        expect(page).to have_content("ステータス")
+        expect(page).to have_no_content("招待状が送信された日時")
+      end
+
+      it "has user_extension button" do
+        expect(page).to have_css(".action-icon--show-user")
+
+        anchor = first("a.action-icon--show-user")
+        expect(anchor["data-toggle"]).to eq "show-user-modal"
+        expect(anchor["title"]).to eq "ユーザー属性を表示"
+      end
+    end
+
+    describe "retrieving the user extensional information" do
+      let!(:users) { create_list(:user, 3, organization: organization) }
+
+      before do
+        users.each do |user|
+          user_extension = {
+            real_name: "#{user.nickname}_real",
+            address: "Faker::Lorem.characters(number: 4)",
+            gender: [0,1,2].shuffle,
+            birth_year: (1990..2010).to_a.shuffle,
+            occupation: "会社員"
+          }
+          create(:authorization, user: user, name: "user_extension", metadata: user_extension)
+        end
+
+        within ".secondary-nav" do
+          click_link "参加者"
+        end
+      end
+
+      it "shows the users emails to admin users and logs the action" do
+        users.each do |user|
+          within "tr[data-user-id=\"#{user.id}\"]" do
+            click_link "ユーザー属性を表示"
+          end
+
+          within "#show-user-modal" do
+            expect(page).to have_content("参加者の属性情報を表示")
+            expect(page).not_to have_content("本名")
+
+            click_button "表示"
+
+            expect(page).to have_content("本名")
+            expect(page).to have_content("#{user.nickname}_real")
+
+            find("button[data-close]").click
+          end
+        end
+
+        visit decidim_admin.root_path
+
+        users.each do |user|
+          expect(page).to have_content("#{admin.name} が #{user.name} にいくつかのアクションを実行しました")
+        end
+      end
+    end
+  end
+end

--- a/spec/sytem/admin_officializations_user_extension_spec.rb
+++ b/spec/sytem/admin_officializations_user_extension_spec.rb
@@ -11,7 +11,7 @@ describe "Admin manages officializations", type: :system do
   let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
   let!(:user) { create(:user, :confirmed, organization: organization) }
 
-  context "not login" do
+  context "when signed in as user, not admin" do
     before do
       Capybara.raise_server_errors = false
       switch_to_host(organization.host)
@@ -29,7 +29,7 @@ describe "Admin manages officializations", type: :system do
     end
   end
 
-  context "login as admin" do
+  context "when signed in as admin" do
     before do
       switch_to_host(organization.host)
       login_as admin, scope: :user
@@ -68,7 +68,7 @@ describe "Admin manages officializations", type: :system do
           user_extension = {
             real_name: "#{user.nickname}_real",
             address: "Faker::Lorem.characters(number: 4)",
-            gender: [0,1,2].shuffle,
+            gender: [0, 1, 2].shuffle,
             birth_year: (1990..2010).to_a.shuffle,
             occupation: "会社員"
           }


### PR DESCRIPTION
#### :tophat: What? Why?
追加の属性を管理画面から確認するための修正です。

管理画面の参加者一覧が下のような画面になって、右端に人のアイコンが追加されます。

![スクリーンショット 2020-11-03 15 19 28](https://user-images.githubusercontent.com/10401/97955113-c33b6580-1de8-11eb-8b29-7d20ba795987.png)

このアイコンをクリックすると、ダイアログが出てきます。

![スクリーンショット 2020-11-03 15 20 19](https://user-images.githubusercontent.com/10401/97955235-101f3c00-1de9-11eb-8ac1-64216ff2af33.png)

ダイアログの「表示」ボタンをクリックすると、追加の属性情報が表示されます。

![スクリーンショット 2020-11-03 15 20 29](https://user-images.githubusercontent.com/10401/97955264-1ca39480-1de9-11eb-81b0-ca2cd93da7fe.png)

属性情報を表示させると、線でくくったような履歴情報が登録されます（本当はその下の「メールを取得しました」のように表示ができればよいのですが、修正が難しいのでとりあえずは履歴だけ残しています）。

![スクリーンショット 2020-11-03 15 22 40](https://user-images.githubusercontent.com/10401/97955304-380e9f80-1de9-11eb-87af-2d3a1a1ea286.png)


#### :pushpin: Related Issues
- Fixes #65

#### :clipboard: Subtasks
- [x] Add tests

### :camera: Screenshots (optional)
上記の通りです。