### PR TITLE
fix displaying images on second edit

### DIFF
--- a/app/assets/javascripts/decidim/editor.js.es6
+++ b/app/assets/javascripts/decidim/editor.js.es6
@@ -290,7 +290,8 @@
                     syntax: false // Show the HTML with syntax highlighting. Requires highlightjs on window.hljs (similar to Quill itself), default: false
                 }
             },
-            formats: quillFormats,
+            // Disabled to allow for more HTML tags!
+            //formats: quillFormats,
             theme: "snow"
         });
 


### PR DESCRIPTION
#### :tophat: What? Why?
Minor fix to https://github.com/codeforjapan/decidim-cfj/pull/85 to make sure images display on second edit.

#### :pushpin: Related Issues
- Related to https://github.com/codeforjapan/decidim-cfj/issues/11


