### PR TITLE
性別欄と職業欄のマージンを修正

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -1,0 +1,3 @@
+.radio-buttons{
+  margin-bottom: 1rem;
+}

--- a/app/views/decidim/account/_user_extension.html.erb
+++ b/app/views/decidim/account/_user_extension.html.erb
@@ -7,9 +7,10 @@
   <%= f_ext.text_field :birth_year %>
 
   <%= f_ext.label :gender %>
-
-  <%= f_ext.collection_radio_buttons :gender, Decidim::UserExtensionForm::GENDERS, :first, :last do |elem| %>
-  <%= elem.label(class: "radio_button") { elem.radio_button(class: "radio_button") + I18n.t(".#{elem.text}", scope: "enums.user_extension.gender") } %>
+  <%= field_set_tag nil, class: 'radio-buttons' do %>
+    <%= f_ext.collection_radio_buttons :gender, Decidim::UserExtensionForm::GENDERS, :first, :last do |elem| %>
+      <%= elem.label(class: "radio_button") { elem.radio_button(class: "radio_button") + I18n.t(".#{elem.text}", scope: "enums.user_extension.gender") } %>
+    <% end %>
   <% end %>
 
   <%= f_ext.text_field :occupation %>

--- a/app/views/decidim/devise/registrations/_user_extension.html.erb
+++ b/app/views/decidim/devise/registrations/_user_extension.html.erb
@@ -1,0 +1,26 @@
+            <%= f.fields_for :user_extension, f.object.user_extension do |f_ext| %>
+              <div class="field">
+                <%= f_ext.text_field :real_name %>
+              </div>
+
+              <div class="field">
+                <%= f_ext.text_field :address %>
+              </div>
+
+              <div class="field">
+                <%= f_ext.text_field :birth_year %>
+              </div>
+
+              <div class="field">
+                <%= f_ext.label :gender %>
+                  <%= field_set_tag nil, class: 'radio-buttons' do %>
+                    <%= f_ext.collection_radio_buttons :gender, Decidim::UserExtensionForm::GENDERS, :first, :last do |elem| %>
+                    <%= elem.label(class: "radio_button") { elem.radio_button(class: "radio_button") + I18n.t(".#{elem.text}", scope: "enums.user_extension.gender") } %>
+                  <% end %>
+                <% end %>
+              </div>
+
+              <div class="field">
+                <%= f_ext.text_field :occupation %>
+              </div>
+            <% end %>

--- a/app/views/decidim/devise/registrations/new.html.erb
+++ b/app/views/decidim/devise/registrations/new.html.erb
@@ -72,8 +72,10 @@
 
               <div class="field">
                 <%= f_ext.label :gender %>
-                <%= f_ext.collection_radio_buttons :gender, Decidim::UserExtensionForm::GENDERS, :first, :last do |elem| %>
-                <%= elem.label(class: "radio_button") { elem.radio_button(class: "radio_button") + I18n.t(".#{elem.text}", scope: "enums.user_extension.gender") } %>
+                  <%= field_set_tag nil, class: 'radio-buttons' do %>
+                    <%= f_ext.collection_radio_buttons :gender, Decidim::UserExtensionForm::GENDERS, :first, :last do |elem| %>
+                    <%= elem.label(class: "radio_button") { elem.radio_button(class: "radio_button") + I18n.t(".#{elem.text}", scope: "enums.user_extension.gender") } %>
+                  <% end %>
                 <% end %>
               </div>
 

--- a/app/views/decidim/devise/registrations/new.html.erb
+++ b/app/views/decidim/devise/registrations/new.html.erb
@@ -57,32 +57,7 @@
             </div>
 
             <!-- extension begin -->
-            <%= f.fields_for :user_extension, f.object.user_extension do |f_ext| %>
-              <div class="field">
-                <%= f_ext.text_field :real_name %>
-              </div>
-
-              <div class="field">
-                <%= f_ext.text_field :address %>
-              </div>
-
-              <div class="field">
-                <%= f_ext.text_field :birth_year %>
-              </div>
-
-              <div class="field">
-                <%= f_ext.label :gender %>
-                  <%= field_set_tag nil, class: 'radio-buttons' do %>
-                    <%= f_ext.collection_radio_buttons :gender, Decidim::UserExtensionForm::GENDERS, :first, :last do |elem| %>
-                    <%= elem.label(class: "radio_button") { elem.radio_button(class: "radio_button") + I18n.t(".#{elem.text}", scope: "enums.user_extension.gender") } %>
-                  <% end %>
-                <% end %>
-              </div>
-
-              <div class="field">
-                <%= f_ext.text_field :occupation %>
-              </div>
-            <% end %>
+            <%= render partial: "user_extension", locals: {f: f} %>
             <!-- extension end -->
           </div>
         </div>


### PR DESCRIPTION
#### :tophat: What? Why?
#78 の対応として、ラジオボタンを`<fieldset>`でくくった上、そのマージンをテキストボックスと揃えてみました。
ついでにpartialを使って拡張部分を別ファイルに切り出しています。

#### :pushpin: Related Issues
- Fixes #78 

#### :clipboard: Subtasks
- [ ] Add tests

### :camera: Screenshots (optional)

修正後の画面は以下です：

![fix-decidim-gender](https://user-images.githubusercontent.com/10401/97577405-bb6b7200-1a32-11eb-913a-d93cc85a13f0.png)
