### PR TITLE
centerize a message in social button

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -1,0 +1,9 @@
+/* fix decidim-core/app/assets/stylesheets/decidim/modules/_buttons.scss */
+.button--social{
+  padding: 0;
+}
+.button--social__icon,
+.button--social__text{
+  text-align: center;
+  margin: 0;
+}


### PR DESCRIPTION
#### :tophat: What? Why?
#46 の修正ですが、`/app/assets/stylesheets/decidim.css`はいじらず別ファイルに切り出して追加しました。

#### :pushpin: Related Issues
- Fixes #46

#### :clipboard: Subtasks
- [ ] Add tests

### :camera: Screenshots (optional)
Before:
![before-social-button](https://user-images.githubusercontent.com/10401/97579200-1ef69f00-1a35-11eb-8ff9-a944fb6dfaae.png)

After:
![after-social-button](https://user-images.githubusercontent.com/10401/97579239-26b64380-1a35-11eb-9bb7-deeb1bd646e1.png)

