### PR TITLE
Add Cloud Formation template for create ECR

### DIFF
--- a/.cloudformation/ecr.yml
+++ b/.cloudformation/ecr.yml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Create decidim-fcj ECR
+
+Resources:
+  TestEcrPoc:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: decidim-cfj
+      ImageScanningConfiguration:
+        scanOnPush: "true"
+      ImageTagMutability: "MUTABLE"


### PR DESCRIPTION
#### :tophat: What? Why?
- CI/CDの作成で、AWS ECRリソースの作成に使用したCloud Formationを追加します。
 - 普段は見えなくてもいいので、.始まりのフォルダ名にしてみました。

#### :pushpin: Related Issues
- Related to #56 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
