### PR TITLE
execute RSpec and RuboCop for pull requests

### DIFF
--- a/.github/workflows/rails-test.yml
+++ b/.github/workflows/rails-test.yml
@@ -1,0 +1,54 @@
+name: Rails Tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      db:
+        image: postgres:12
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis
+        ports:
+        - 6379/tcp
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: apt-get
+      run: |
+        sudo apt-get update -y
+        sudo apt-get -yqq install libpq-dev postgresql-client
+    - name: Set up Ruby 2.6
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+        bundler-cache: true
+    - name: Build and Test with RSpec
+      env:
+        DATABASE_HOST: 127.0.0.1
+        DATABASE_PORT: 5432
+        DATABASE_USERNAME: postgres
+        DATABASE_PASSWORD: postgres
+        RAILS_ENV: test
+        REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+      run: |
+        bundle install --jobs 4 --retry 3
+        bundle exec rails db:create db:migrate
+        bundle exec rails spec
+    - name: Lint by RuboCop
+      run: |
+        bundle exec rubocop --parallel

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,11 +87,11 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
 
-  config.before(:each) do
-    I18n.available_locales = %i(en es ja)
+  config.before do
+    I18n.available_locales = [:en, :es, :ja]
     I18n.locale = :en
     I18n.default_locale = :ja
-    Decidim.available_locales = %i(en es ja)
+    Decidim.available_locales = [:en, :es, :ja]
     Decidim.default_locale = :ja
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
pull requestのタイミングでrspecとrubocopを実行させるGitHub Actionsです。

ついでにrubocopを動かしたらrspecの関連ファイルが引っかかったので、合わせて修正しておきます（そうしないとこのPRが通らない…）。

#### :pushpin: Related Issues
- Related to #117, #118 

#### :clipboard: Subtasks
(nothing)

### :camera: Screenshots (optional)
