### PR TITLE
Add Github workflow job for deploy to Elastic Beanstalk

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 .github
 .git
 
+deployments
 log
 node_modules
 spec

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Docker image build & ECR push
+name: Deploy to Elastic Beanstalk
 
 on:
   schedule:
@@ -6,13 +6,13 @@ on:
     - cron: '0 9 * * *'
 
 jobs:
-  build-and-push:
+  deploy:
 
     runs-on: ubuntu-latest
-    timeout-minutes: 900
+    timeout-minutes: 1200
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -33,3 +33,23 @@ jobs:
       run: |
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+    - uses: actions/setup-python@master
+      with:
+        python-version: '3.7'
+
+    - name: Install awsebcli
+      run: pip install -U awsebcli
+
+    - name: Deploy to Elastic Beanstalk
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPO_NAME }}
+        IMAGE_TAG: staging
+        EB_ENVIRONMENT_NAME: staging
+      run: |
+        cp -r .ebextensions/ deployments/.ebextensions
+        cd deployments
+        sed -i -e "s|t2.small|t2.micro|g" .ebextensions/00_options.config
+        sed -i -e "s|{RepositoryName}|$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG|g" Dockerrun.aws.json
+        eb deploy ${EB_ENVIRONMENT_NAME}

--- a/deployments/.ebignore
+++ b/deployments/.ebignore
@@ -1,0 +1,1 @@
+./elasticbeanstalk

--- a/deployments/.elasticbeanstalk/config.yml
+++ b/deployments/.elasticbeanstalk/config.yml
@@ -1,0 +1,14 @@
+branch-defaults:
+  default:
+    environment: staging
+global:
+  application_name: decidim-app
+  default_ec2_keyname: null
+  default_platform: Docker running on 64bit Amazon Linux 2
+  default_region: ap-northeast-1
+  include_git_submodules: true
+  instance_profile: null
+  platform_name: null
+  platform_version: null
+  sc: git
+  workspace_type: Application

--- a/deployments/Dockerrun.aws.json
+++ b/deployments/Dockerrun.aws.json
@@ -1,0 +1,13 @@
+{
+    "AWSEBDockerrunVersion": "1",
+    "Logging": "/app/log",
+    "Image": {
+        "Name": "{RepositoryName}",
+        "Update": "true"
+    },
+    "Ports": [
+        {
+            "ContainerPort": "3000"
+        }
+    ]
+}


### PR DESCRIPTION
#### :tophat: What? Why?
- CI/CD構築のため
  - コンテナ動作確認のため、一旦stagingのみ
  - わざわざ一弾下げているのは、zipの転送量を最小限にするためです。また、Dockerfileがあると、そちらが優先されてしまうので。

#### :pushpin: Related Issues
- Related to #110, #56 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
