### PR TITLE
Bind postgres image from latest to v12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     links:
       - pg
   pg:
-    image: postgres
+    image: postgres:12
     volumes:
       - pg-data:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
#### :tophat: What? Why?
- Docker開発環境のpostgresのversionをv12で固定する
  - 本番環境がv12.3だったので、それに合わせる
  - 公式のdocker hubにv12.3はなかったので、v12
- 前のvolumeが残っている場合は、下記のようなエラーで起動できないので、削除してください。

```
taki@tari:~/develop/decidim-cfj$ docker-compose logs pg
Attaching to decidim-cfj_pg_1
pg_1   |
pg_1   | PostgreSQL Database directory appears to contain a database; Skipping initialization
pg_1   |
pg_1   | 2020-11-03 06:07:05.828 UTC [1] FATAL:  database files are incompatible with server
pg_1   | 2020-11-03 06:07:05.828 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 13, which is not compatible with this version 12.4 (Debian 12.4-1.pgdg100+1).
```

#### :pushpin: Related Issues
- Related to #122 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
