### PR TITLE
db:seed: add user_extension

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,3 +12,26 @@
 require_relative "../lib/monkey_patching_faker"
 
 Decidim.seed!
+
+if !Rails.env.production? || ENV["SEED"]
+  print "Creating seeds for decidim-cfj...\n" unless Rails.env.test?
+
+  require "decidim/faker/localized"
+
+  seeds_root = File.join(__dir__, "seeds")
+
+  Decidim::User.find_each do |user|
+    user_extension = {
+      real_name: "#{user.name}_実名",
+      address: Faker::Lorem.words(4).join(""),
+      gender: [0, 1, 2].sample,
+      birth_year: (1980..2010).to_a.sample,
+      occupation: ["会社員", "学生", "公務員", "自営業", "無職", nil].sample
+    }
+    Decidim::Authorization.create!(
+      user: user,
+      name: "user_extension",
+      metadata: user_extension
+    )
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,8 +18,6 @@ if !Rails.env.production? || ENV["SEED"]
 
   require "decidim/faker/localized"
 
-  seeds_root = File.join(__dir__, "seeds")
-
   Decidim::User.find_each do |user|
     user_extension = {
       real_name: "#{user.name}_実名",


### PR DESCRIPTION
#### :tophat: What? Why?
追加されたユーザーの属性情報も、`rails db:seed`で作られるダミーデータに含めるものです。

#86 で管理画面が改修されたあと、データを見るのに便利（ないと何も表示されないのでうれしくない）です。

#### :pushpin: Related Issues
- Related to #86 

#### :clipboard: Subtasks

### :camera: Screenshots (optional)
