### PR TITLE
refs #107 fix blog layout when endorsements was off

### DIFF
--- a/app/views/decidim/blogs/posts/show.html.erb
+++ b/app/views/decidim/blogs/posts/show.html.erb
@@ -1,0 +1,57 @@
+<% provide(:title, translated_attribute(post.title)) %>
+
+<% add_decidim_meta_tags({
+  title: translated_attribute(post.title),
+  description: translated_attribute(post.body),
+  url: post_url(post.id)
+}) %>
+
+<%
+  edit_link(
+    resource_locator(post).edit,
+    :update,
+    :blogpost,
+    blogpost: post
+  )
+%>
+
+<div class="row column view-header">
+  <%= link_to :posts, class: "small hollow" do %>
+    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= t(".back") %>
+  <% end %>
+  <h2 class="heading2"><%= translated_attribute post.title %></h2>
+  <%= cell "decidim/author", present(post.author), from: post %>
+</div>
+<div class="row">
+  <div class="columns section view-side mediumlarge-4 mediumlarge-push-8 large-3 large-push-9">
+    <% if show_endorsements_card? %>
+      <div class="card">
+        <div class="card__content">
+          <div class="row collapse buttons__row">
+            <% if endorsements_enabled? %>
+              <div class="column small-9 collapse">
+                <%= endorsement_buttons_cell(post) %>
+              </div>
+            <% end %>
+            <div class="column collapse <%= endorsements_enabled? ? "small-3" : "" %>">
+              <%= link_to "#comments", class: "button small compact hollow button--nomargin expanded" do %>
+                  <%= icon "comment-square", class: "icon--small", aria_label: t(".comments"), role: "img" %> <%= post.comments_count %>
+              <% end %>
+            </div>
+          </div>
+          <br>
+          <%= follow_button_for(post) %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+  <div class="columns mediumlarge-8 mediumlarge-pull-4">
+    <div class="section">
+      <%= decidim_sanitize translated_attribute post.body %>
+    </div>
+    <%= cell "decidim/endorsers_list", post %>
+  </div>
+</div>
+<%= attachments_for post %>
+<%= comments_for post %>


### PR DESCRIPTION
#### :tophat: What? Why?

「投票を支持」がoffの場合に、ブログ詳細ページのレイアウトが崩れる問題の対応。

cssで直せないかとも思いましたが、Foundationでグリッドレイアウトが組まれているようでしたので、一部の要素だけ上書きするのは影響が大きいかと思いました。

そこで、

```
<% if show_endorsements_card? %>
  <div class="columns section view-side mediumlarge-4 mediumlarge-push-8 large-3 large-push-9">
```

のように 「投票を支持」がoffの際には カラム自体が表示されなかったのを

```
<div class="columns section view-side mediumlarge-4 mediumlarge-push-8 large-3 large-push-9">
　<% if show_endorsements_card? %>
```

空のカラムを表示することでレイアウト崩れを防止するようにしています。



#### :pushpin: Related Issues
- Related to #?
- Fixes #107

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

before

<img width="928" alt="譜面_鈍器_防犯_天井_そだてる。_-_ブログ_-_えきびょう_ぐん_はんそう_かぶしきしじょう_先週。_-_合名会社村上建設" src="https://user-images.githubusercontent.com/662084/98037246-9fb30200-1e5e-11eb-98c9-2fa886c0937d.png">

after

<img width="923" alt="譜面_鈍器_防犯_天井_そだてる。_-_ブログ_-_えきびょう_ぐん_はんそう_かぶしきしじょう_先週。_-_合名会社村上建設" src="https://user-images.githubusercontent.com/662084/98037268-a5a8e300-1e5e-11eb-887f-bd275179a627.png">
