### PR TITLE
Add ElasticBeanstalk extensions config options

### DIFF
--- a/.ebextensions/00_options.config
+++ b/.ebextensions/00_options.config
@@ -1,7 +1,28 @@
 option_settings:
-  "aws:autoscaling:launchconfiguration" :
+  "aws:autoscaling:launchconfiguration":
     IamInstanceProfile : "aws-elasticbeanstalk-ec2-role"
     EC2KeyName : "aws-eb"
-    InstanceType : "t2.micro"
     RootVolumeSize : "100"
     RootVolumeType : "gp2"
+  "aws:autoscaling:updatepolicy:rollingupdate":
+    MaxBatchSize: "1"
+    MinInstancesInService: "1"
+    RollingUpdateEnabled: "true"
+    RollingUpdateType: "Health"
+  "aws:autoscaling:trigger":
+    LowerThreshold: "10"
+    MeasureName: "CPUUtilization"
+    Unit: "Percent"
+    UpperThreshold: "200"
+  "aws:rds:dbinstance":
+    DBDeletionPolicy: "Snapshot"
+    DBAllocatedStorage: "10"
+    DBEngine: "postgres"
+    DBEngineVersion: "12.3"
+    DBInstanceClass: "db.t2.small"
+  "aws:elasticbeanstalk:environment":
+    LoadBalancerType: "application"
+  "aws:elasticbeanstalk:command":
+    BatchSize: "30"
+  "aws:ec2:instances":
+    InstanceTypes: "t2.small"


### PR DESCRIPTION
#### :tophat: What? Why?

- 検証環境構築の際に確認した、本番との設定の差分を取り込むためです。
  - インスタイプタイプは、本番に合わせてます。
  - ローカルからの、本番デプロイも問題なくできると思いますが、自信ないです。（試してないです）お手数ですが、確認お願いします。CI上からのstagingデプロイは問題なくできました。
  - おそらくですが、これで設定の差分がなくなるので、 #130  で上がっていた、下記エラーも消えると思います。

>Failed Environment update activity. Reason: Configuration validation exception: RDS DB Engine Version option setting is not allowed to changed

#### :pushpin: Related Issues
- Related to #110