### PR TITLE
Force to redirect account page if user_extension not found

### DIFF
--- a/app/controllers/concerns/decidim/needs_user_extension.rb
+++ b/app/controllers/concerns/decidim/needs_user_extension.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  # A concern with the features needed when user exntesions are not registered
+  module NeedsUserExtension
+    extend ActiveSupport::Concern
+
+    ALLOWS_WITHOUT_USER_EXTENSION = %w(account homepage pages tos)
+
+    included do
+      before_action :needs_user_extension
+    end
+
+    private
+
+    def needs_user_extension
+      logger.info("controller_name: #{controller_name}")
+      return true unless current_user
+      return true if ALLOWS_WITHOUT_USER_EXTENSION.include?(controller_name)
+      metadata = authorization.attributes["metadata"] || {}
+
+      ## TODO: validate all metadata; only exsistance now
+      if !metadata["real_name"] || !metadata["address"] || !metadata["birth_year"] || !metadata["gender"]
+        flash[:error] = t("errors.messages.needs_user_extension")
+        redirect_to decidim.account_path
+      end
+    end
+
+    def authorization
+      @authorization ||= Decidim::Authorization.find_or_initialize_by(
+        user: current_user,
+        name: "user_extension"
+      )
+    end
+  end
+end

--- a/app/controllers/concerns/decidim/needs_user_extension.rb
+++ b/app/controllers/concerns/decidim/needs_user_extension.rb
@@ -7,7 +7,7 @@ module Decidim
   module NeedsUserExtension
     extend ActiveSupport::Concern
 
-    ALLOWS_WITHOUT_USER_EXTENSION = %w(account homepage pages tos)
+    ALLOWS_WITHOUT_USER_EXTENSION = %w(account homepage pages tos).freeze
 
     included do
       before_action :needs_user_extension
@@ -19,6 +19,7 @@ module Decidim
       logger.info("controller_name: #{controller_name}")
       return true unless current_user
       return true if ALLOWS_WITHOUT_USER_EXTENSION.include?(controller_name)
+
       metadata = authorization.attributes["metadata"] || {}
 
       ## TODO: validate all metadata; only exsistance now

--- a/app/controllers/decidim_controller.rb
+++ b/app/controllers/decidim_controller.rb
@@ -4,4 +4,5 @@
 # entry point, but you can change what controller it inherits from
 # so you can customize some methods.
 class DecidimController < ApplicationController
+  include Decidim::NeedsUserExtension
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -38,6 +38,7 @@ ja:
   errors:
     messages:
       already_confirmed: が確認されました。ログインしてみてください
+      needs_user_extension: "登録されていないユーザー属性情報が見つかりました。"
   decidim:
     admin:
       admin_terms_of_use:

--- a/spec/sytem/admin_officializations_user_extension_spec.rb
+++ b/spec/sytem/admin_officializations_user_extension_spec.rb
@@ -11,6 +11,11 @@ describe "Admin manages officializations", type: :system do
   let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
   let!(:user) { create(:user, :confirmed, organization: organization) }
 
+  let!(:admin_authorization) do
+    admin_metadata = {real_name: "admin", address: "admin address", gender: 1, birth_year: 2000, occupation: "administrator"}
+    create(:authorization, user: admin, name: "user_extension", metadata: admin_metadata)
+  end
+
   context "when signed in as user, not admin" do
     before do
       Capybara.raise_server_errors = false

--- a/spec/sytem/admin_officializations_user_extension_spec.rb
+++ b/spec/sytem/admin_officializations_user_extension_spec.rb
@@ -12,7 +12,7 @@ describe "Admin manages officializations", type: :system do
   let!(:user) { create(:user, :confirmed, organization: organization) }
 
   let!(:admin_authorization) do
-    admin_metadata = {real_name: "admin", address: "admin address", gender: 1, birth_year: 2000, occupation: "administrator"}
+    admin_metadata = { real_name: "admin", address: "admin address", gender: 1, birth_year: 2000, occupation: "administrator" }
     create(:authorization, user: admin, name: "user_extension", metadata: admin_metadata)
   end
 

--- a/spec/sytem/needs_user_extension_spec.rb
+++ b/spec/sytem/needs_user_extension_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Need user extension", type: :system do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :confirmed, organization: organization) }
+
+  context "when signed in as user" do
+    before do
+      Capybara.raise_server_errors = false
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+    end
+
+    context "without user extension" do
+      it "redirect to account page" do
+        visit decidim.notifications_path
+        expect(page).to have_current_path(decidim.account_path)
+      end
+
+      it "not redirect in root page" do
+        visit decidim.root_path
+        expect(page).to have_current_path(decidim.root_path)
+      end
+    end
+
+    context "with user extension" do
+      before do
+        user_extension = {
+          real_name: "#{user.nickname}_real",
+          address: "Faker::Lorem.characters(number: 4)",
+          gender: [0, 1, 2].shuffle,
+          birth_year: (1990..2010).to_a.shuffle,
+          occupation: "会社員"
+        }
+        create(:authorization, user: user, name: "user_extension", metadata: user_extension)
+      end
+
+      it "not redirect in notifications page" do
+        visit decidim.notifications_path
+        expect(page).to have_current_path(decidim.notifications_path)
+      end
+
+      it "not redirect in root page" do
+        visit decidim.root_path
+        expect(page).to have_current_path(decidim.root_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

#79, #134 のバグの修正として、Facebookから登録した場合など、ユーザー属性情報が登録されていない人がログインした場合、`登録されていないユーザー属性情報が見つかりました。` というメッセージを表示して、アカウント設定ページに強制的にリダイレクトさせます。
アカウント設定ページで必須項目を登録すると、通常通りにアクセスできるようになります。また、ログインしていない人も影響はありません。

なお、以下のページについてはリダイレクトさせないようにしています。

* 利用規約ページ（これは許可しないとリダイレクトループします）
* アカウント設定ページ（これも許可しないとリダイレクトループします）
* ヘルプページ（これは読めないと困りそうです）
* トップページ（これは許可しなくても良いような気もしますが、なんとなくトップページくらいは読めた方がいいかと思って許可してみました）

#### :pushpin: Related Issues
- Fixes #79, #134

#### :clipboard: Subtasks
- [x] Add tests

### :camera: Screenshots (optional)
