### PR TITLE
Add nginx.conf for turn off server tokens

### DIFF
--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -1,0 +1,117 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /var/run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    server_tokens       off;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 4096;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+
+    index   index.html index.htm;
+
+    server {
+        listen       80;
+        listen       [::]:80;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+
+        # redirect server error pages to the static page /40x.html
+        #
+        error_page 404 /404.html;
+            location = /40x.html {
+        }
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+        }
+
+        # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+        #
+        #location ~ \.php$ {
+        #    proxy_pass   http://127.0.0.1;
+        #}
+
+        # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+        #
+        #location ~ \.php$ {
+        #    root           html;
+        #    fastcgi_pass   127.0.0.1:9000;
+        #    fastcgi_index  index.php;
+        #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+        #    include        fastcgi_params;
+        #}
+
+        # deny access to .htaccess files, if Apache's document root
+        # concurs with nginx's one
+        #
+        #location ~ /\.ht {
+        #    deny  all;
+        #}
+    }
+
+# Settings for a TLS enabled server.
+#
+#    server {
+#        listen       443 ssl http2;
+#        listen       [::]:443 ssl http2;
+#        server_name  _;
+#        root         /usr/share/nginx/html;
+#
+#        ssl_certificate "/etc/pki/nginx/server.crt";
+#        ssl_certificate_key "/etc/pki/nginx/private/server.key";
+#        # It is *strongly* recommended to generate unique DH parameters
+#        # Generate them with: openssl dhparam -out /etc/pki/nginx/dhparams.pem 2048
+#        #ssl_dhparam "/etc/pki/nginx/dhparams.pem";
+#        ssl_session_cache shared:SSL:1m;
+#        ssl_session_timeout  10m;
+#        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+#        ssl_ciphers HIGH:SEED:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!RSAPSK:!aDH:!aECDH:!EDH-DSS-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA:!SRP;
+#        ssl_prefer_server_ciphers on;
+#
+#        # Load configuration files for the default server block.
+#        include /etc/nginx/default.d/*.conf;
+#
+#        error_page 404 /404.html;
+#            location = /40x.html {
+#        }
+#
+#        error_page 500 502 503 504 /50x.html;
+#            location = /50x.html {
+#        }
+#    }
+
+}

--- a/deployments/.platform/nginx/nginx.conf
+++ b/deployments/.platform/nginx/nginx.conf
@@ -1,0 +1,54 @@
+# Elastic Beanstalk Nginx Configuration File
+
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log;
+pid        /var/run/nginx.pid;
+worker_rlimit_nofile    32137;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    access_log    /var/log/nginx/access.log;
+
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+    include  conf.d/*.conf;
+
+    map $http_upgrade $connection_upgrade {
+            default       "upgrade";
+    }
+
+    server_tokens off;
+
+    server {
+        listen 80 default_server;
+        gzip on;
+        gzip_comp_level 4;
+        gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+        access_log    /var/log/nginx/access.log main;
+
+        location / {
+            proxy_pass            http://docker;
+            proxy_http_version    1.1;
+
+            proxy_set_header    Connection             $connection_upgrade;
+            proxy_set_header    Upgrade                $http_upgrade;
+            proxy_set_header    Host                   $host;
+            proxy_set_header    X-Real-IP              $remote_addr;
+            proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
+        }
+
+        # Include the Elastic Beanstalk generated locations
+        include conf.d/elasticbeanstalk/*.conf;
+    }
+}


### PR DESCRIPTION
#### :tophat: What? Why?
Nginx.confのserver_tokensをoffにするために、nginx.confを追加しました。
stagingとproductionで、nginxの設定が異なるので、二つファイルを追加しています。

```
production: .platform/nginx/nginx.conf
staging: deployments/.platform/nginx/nginx.conf
```

二つの環境から`/etc/nginx/nginx.conf`にあるファイルをコピーして、`server_tokens off;`だけ追加しました。

参考: [Elastic Beanstalk Linux プラットフォームの拡張 - AWS Elastic Beanstalk](https://docs.aws.amazon.com/ja_jp/elasticbeanstalk/latest/dg/platforms-linux-extend.html)

#### :pushpin: Related Issues
- Related to #144 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

#### 修正前
![修正前](https://user-images.githubusercontent.com/39375566/101275677-c4e2b980-37ea-11eb-8cd8-a49b7e36b45f.JPG)

#### 修正後

![修正後](https://user-images.githubusercontent.com/39375566/101275679-c7451380-37ea-11eb-821b-b6e534cbf415.JPG)
