### PR TITLE
change Decidim settings; use `,` as default_csv_col_sep

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -190,7 +190,7 @@ Decidim.configure do |config|
   # }
 
   # Sets Decidim::Exporters::CSV's default column separator
-  # config.default_csv_col_sep = ";"
+  config.default_csv_col_sep = ","
 
   # The list of roles a user can have, not considering the space-specific roles.
   # config.user_roles = %w(admin user_manager)


### PR DESCRIPTION
#### :tophat: What? Why?

issueでは見つからなかったのですが、ダウンロードしたCSVがセミコロン区切りだった、という問題がありましたよね…？
この設定は`config/initializers/decidim.rb`の`config.default_csv_col_sep`で変更できるようだったので、カンマに修正してみます。

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 

どこかに設定について書いておいた方がいいかもしれません（というissueを作成するといいかも？）