### PR TITLE
fix login confirmation; overwrite `allow_unconfirmed_access_for`

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -92,6 +92,7 @@ Decidim.configure do |config|
 
   # Time window were users can access the website even if their email is not confirmed.
   # config.unconfirmed_access_for = 2.days
+  config.unconfirmed_access_for = 0.days
 
   # Etherpad configuration. Check the docs for more info.
   # config.etherpad = {
@@ -230,3 +231,6 @@ end
 
 Rails.application.config.i18n.available_locales = Decidim.available_locales
 Rails.application.config.i18n.default_locale = Decidim.default_locale
+
+# Overwrite Devise.allow_unconfirmed_access_for
+Devise.allow_unconfirmed_access_for = Decidim.unconfirmed_access_for


### PR DESCRIPTION
#### :tophat: What? Why?

メールアドレス未確認のままログインできてしまう問題ですが、`config/initializers/decidim.rb`の`config.unconfirmed_access_for`を設定するだけでは駄目なようでした。

実際に使われる値は`Devise.allow_unconfirmed_access_for`で、アプリケーション初期化時に`Devise.allow_unconfirmed_access_for = Decidim.unconfirmed_access_for`を実行するのですが、どうも`config/initializers/decidim.rb`を実行する前にこの代入が行われてしまっている（！）ようでした。
そのため、`Decidim.unconfirmed_access_for`を設定したあと、改めて代入しなおさないと反映されない、という挙動のようです。

#### :pushpin: Related Issues
- Fixes #4 

#### :clipboard: Subtasks

### :camera: Screenshots (optional)

この修正を反映させると、新規ユーザー登録後は未ログインの状態になって、そのままログインしようとすると、以下の画面になります。

![image](https://user-images.githubusercontent.com/10401/107140516-e0db1680-6965-11eb-885c-d3b2d590cc9c.png)
