### PR TITLE
拡張属性項目の有無をシステム管理画面から選択できるようにする

### DIFF
--- a/app/controllers/decidim/devise/registrations_controller.rb
+++ b/app/controllers/decidim/devise/registrations_controller.rb
@@ -15,7 +15,7 @@ module Decidim
       invisible_captcha
 
       def new
-        @form = if need_user_extension?
+        @form = if need_user_extension_by_organization?
                   form(ExtendedRegistrationForm).from_params(
                     user: { sign_up_as: "user" },
                     user_extension: UserExtensionForm.new
@@ -28,7 +28,7 @@ module Decidim
       end
 
       def create
-        if need_user_extension?
+        if need_user_extension_by_organization?
           registration_command = CreateExtendedRegistration
           @form = form(ExtendedRegistrationForm).from_params(params[:user].merge(current_locale: current_locale))
         else
@@ -63,7 +63,7 @@ module Decidim
       end
 
       def configure_permitted_parameters
-        if need_user_extension?
+        if need_user_extension_by_organization?
           devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :tos_agreement, user_extension: [:address, :birth_year, :occupation, :gender]])
         else
           devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :tos_agreement])
@@ -76,7 +76,7 @@ module Decidim
         resource.organization = current_organization
       end
 
-      def need_user_extension?
+      def need_user_extension_by_organization?
         current_organization.available_authorization_handlers&.include?("user_extension")
       end
     end

--- a/app/views/decidim/account/show.html.erb
+++ b/app/views/decidim/account/show.html.erb
@@ -17,7 +17,9 @@
       <%= f.url_field :personal_url %>
       <%= f.text_area :about, rows: 5 %>
 
+      <% if current_organization.available_authorization_handlers&.include?("user_extension") %>
       <%= render partial: "user_extension", locals: {f: f} %>
+      <% end %>
 
       <% if @account.errors[:password].any? || @account.errors[:password_confirmation].any? %>
         <%= render partial: "password_fields", locals: { form: f } %>

--- a/app/views/decidim/devise/registrations/new.html.erb
+++ b/app/views/decidim/devise/registrations/new.html.erb
@@ -59,7 +59,9 @@
             </div>
 
             <!-- extension begin -->
+            <% if current_organization.available_authorization_handlers&.include?("user_extension") %>
             <%= render partial: "user_extension", locals: {f: f} %>
+            <% end %>
             <!-- extension end -->
           </div>
         </div>


### PR DESCRIPTION
#### :tophat: What? Why?

システム管理画面で、User Extensionを有効にした場合のみ、実名等が登録・修正できるようにします。

（まだ途中です）

#### :pushpin: Related Issues
- Fixes #150

#### :clipboard: Subtasks
- [ ] Add/modify seeds
- [ ] Add tests

### :camera: Screenshots (optional)

新規登録画面

<img width="500" alt="registration" src="https://user-images.githubusercontent.com/10401/107144435-7edadb00-697e-11eb-91ec-5d0159cdd070.png">

プロフィール修正画面

<img width="500" alt="edit" src="https://user-images.githubusercontent.com/10401/107144474-b9dd0e80-697e-11eb-8784-34376a60eedb.png">

