### PR TITLE
Fix admin error

### DIFF
--- a/app/services/user_extension_authorization_handler.rb
+++ b/app/services/user_extension_authorization_handler.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "digest/md5"
+
+# (Dummy) Authorization Handler for Decidim::UserExtension
+#
+# In fact, the handler do not handle authorization; Decidim::UserExtension just uses Authorization as metadata storage.
+#
+class UserExtensionAuthorizationHandler < Decidim::AuthorizationHandler
+  validate :check_response
+
+  def metadata
+    super
+  end
+
+  def unique_id
+    nil
+  end
+
+  private
+
+  # Internal: Checks for the response status. It is valid only when the `"res"` field
+  # is `1`. All other values imply some different kind of errors, but in order to not
+  # leak private data we will not care about them.
+  #
+  # Returns nothing.
+  def check_response
+    errors.add(:base, :invalid)
+  end
+
+  def request_params
+    {
+    }
+  end
+end

--- a/config/initializers/decidim_verifications.rb
+++ b/config/initializers/decidim_verifications.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-Decidim::Verifications.register_workflow(:user_extension) do |workflow|
-  workflow.form = "UserExtensionForm"
+Decidim::Verifications.register_workflow(:user_extension_authorization_handler) do |workflow|
+  workflow.form = "UserExtensionAuthorizationHandler"
 end

--- a/decidim-user_extension/lib/decidim/user_extension/admin_engine.rb
+++ b/decidim-user_extension/lib/decidim/user_extension/admin_engine.rb
@@ -22,6 +22,12 @@ module Decidim
         end
       end
 
+      initializer "decidim_user_extension.admin_engine_additions" do
+        Decidim::Admin::ApplicationController.class_eval do
+          include Decidim::UserExtension::Concerns::Controllers::NeedsUserExtension
+        end
+      end
+
       def load_seed
         nil
       end

--- a/decidim-user_extension/lib/decidim/user_extension/engine.rb
+++ b/decidim-user_extension/lib/decidim/user_extension/engine.rb
@@ -20,7 +20,7 @@ module Decidim
         app.config.assets.precompile += %w(decidim_user_extension_manifest.js)
       end
 
-      initializer "decidim_user_extension.registration_additions" do
+      initializer "decidim_user_extension.engine_additions" do
         Decidim::RegistrationForm.class_eval do
           include UserExtension::FormsDefinitions
         end


### PR DESCRIPTION
#### :tophat: What? Why?
#152 のバグを修正するものです。

AuthorizationHandlerは元々提供していない（本人確認によるユーザー検証機能を提供していないため）のですが、ダミーのHandlerを実装してそれを設定するように変更しています。
（元々のエラーが出ていた原因は、管理画面用のコントローラでクラスが参照できなかったのと、handlerの名前探索に失敗していたためのようでした。）

#### :pushpin: Related Issues
- Fixes #152

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
