### PR TITLE
Fix l10n: decidim.components.add_comment_form.account_message

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -44,6 +44,8 @@ ja:
         search_placeholder:
           name_or_nickname_or_email_cont: "%{collection} をメール、表示名、アカウントIDで検索します。"
     components:
+      add_comment_form:
+        account_message: <a href="%{sign_in_url}">ログイン</a> または <a href="%{sign_up_url}">新規登録</a> することでコメントできます。
       components:
         comment:
           deleted_user: 退会者

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -46,10 +46,8 @@ ja:
     components:
       add_comment_form:
         account_message: <a href="%{sign_in_url}">ログイン</a> または <a href="%{sign_up_url}">新規登録</a> することでコメントできます。
-      components:
-        comment:
-          deleted_user: 退会者
       comment:
+        deleted_user: 退会者
         report:
           reasons:
             spam: 本来の内容に関係が無い広告、詐欺や悪意のある処理などが含まれています。


### PR DESCRIPTION
#### :tophat: What? Why?

#160 のメッセージの翻訳を修正します。

ログインと新規登録の順番は元々の（英語版等の）順番に合わせてみました。

（ただ、ローカルの開発環境ではこのメッセージをうまく有効にできてなくて確認できてないです…）

追記: #165 も合わせて対応してみます。

#### :pushpin: Related Issues
- Fixes #160
- Fixes #165

#### :clipboard: Subtasks
- [ ] Add tests

