### PR TITLE
Fix user registration form

### DIFF
--- a/decidim-user_extension/lib/decidim/user_extension/concerns/controllers/add_user_extension_form.rb
+++ b/decidim-user_extension/lib/decidim/user_extension/concerns/controllers/add_user_extension_form.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module UserExtension
+    module Concerns
+      module Controllers
+        # This module overrides Decidim::Devise::RegistrationController.
+        # Adds an instance of UserExtensionForm when initializing RegistrationForm.
+        module AddUserExtensionForm
+          def new
+            @form = form(RegistrationForm).from_params(
+              user: { sign_up_as: "user" },
+              user_extension: UserExtensionForm.new
+              )
+          end
+
+          ### Should we overwrite this as well?　It appears to work without it.
+          # def configure_permitted_parameters
+          #   devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :tos_agreement, user_extension: [:address, :birth_year, :occupation, :gender]])
+          # end
+        end
+      end
+    end
+  end
+end

--- a/decidim-user_extension/lib/decidim/user_extension/concerns/controllers/add_user_extension_form.rb
+++ b/decidim-user_extension/lib/decidim/user_extension/concerns/controllers/add_user_extension_form.rb
@@ -11,7 +11,7 @@ module Decidim
             @form = form(RegistrationForm).from_params(
               user: { sign_up_as: "user" },
               user_extension: UserExtensionForm.new
-              )
+            )
           end
 
           ### Should we overwrite this as well?　It appears to work without it.

--- a/decidim-user_extension/lib/decidim/user_extension/engine.rb
+++ b/decidim-user_extension/lib/decidim/user_extension/engine.rb
@@ -4,6 +4,7 @@ require "rails"
 require "decidim/core"
 require "deface"
 require "decidim/user_extension/concerns/controllers/needs_user_extension"
+require "decidim/user_extension/concerns/controllers/add_user_extension_form"
 
 module Decidim
   module UserExtension
@@ -47,6 +48,10 @@ module Decidim
 
         DecidimController.class_eval do
           include Decidim::UserExtension::Concerns::Controllers::NeedsUserExtension
+        end
+
+        Decidim::Devise::RegistrationsController.class_eval do
+          prepend Decidim::UserExtension::Concerns::Controllers::AddUserExtensionForm
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
#170 について、新規登録時に現象が再現していたので、追加で修正します。

いったん入力した後は正しいエラー表示になるということだったため、新規登録画面の最初の表示の際にも空の拡張属性情報を追加するように修正したものです。

※このフォームの入力チェックはブラウザ側の(JavaScriptによる)チェックとサーバ側のチェックの両方があって、今回のものは未入力時のチェックの際にサーバ側のチェックしか行われていなかった、というものです。

#### :pushpin: Related Issues
- Fixes #170 

#### :clipboard: Subtasks
- [ ] Add tests

### :camera: Screenshots (optional)
<img width="619" alt="registration_form" src="https://user-images.githubusercontent.com/10401/109613019-f104a100-7b73-11eb-936f-2c72068f42d6.png">
