### PR TITLE
Fix facebook login with UserExtension

### DIFF
--- a/decidim-user_extension/app/commands/concerns/decidim/user_extension/create_omniauth_commands_overrides.rb
+++ b/decidim-user_extension/app/commands/concerns/decidim/user_extension/create_omniauth_commands_overrides.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module UserExtension
+    # Changes in methods to store user extended attributes in user profile
+    module CreateOmniauthCommandsOverrides
+      extend ActiveSupport::Concern
+
+      private
+
+      def create_or_find_user
+        generated_password = SecureRandom.hex
+
+        @user = User.find_or_initialize_by(
+          email: verified_email,
+          organization: organization
+        )
+
+        if @user.persisted?
+          # If user has left the account unconfirmed and later on decides to sign
+          # in with omniauth with an already verified account, the account needs
+          # to be marked confirmed.
+          @user.skip_confirmation! if !@user.confirmed? && @user.email == verified_email
+        else
+          @user.email = (verified_email || form.email)
+          @user.name = form.name
+          @user.nickname = form.normalized_nickname
+          @user.newsletter_notifications_at = nil
+          @user.email_on_notification = true
+          @user.password = generated_password
+          @user.password_confirmation = generated_password
+          @user.remote_avatar_url = form.avatar_url if form.avatar_url.present?
+          @user.skip_confirmation! if verified_email
+        end
+
+        @user.user_extension = form.user_extension if form.user_extension.present?
+        @user.tos_agreement = "1"
+        @user.save!
+      end
+
+      def trigger_omniauth_registration
+        ActiveSupport::Notifications.publish(
+          "decidim.user.omniauth_registration",
+          user_id: @user.id,
+          identity_id: @identity.id,
+          provider: form.provider,
+          uid: form.uid,
+          email: form.email,
+          name: form.name,
+          nickname: form.normalized_nickname,
+          avatar_url: form.avatar_url,
+          raw_data: form.raw_data,
+          user_extension: form.user_extension
+        )
+      end
+    end
+  end
+end

--- a/decidim-user_extension/app/forms/concerns/decidim/user_extension/forms_definitions.rb
+++ b/decidim-user_extension/app/forms/concerns/decidim/user_extension/forms_definitions.rb
@@ -27,7 +27,7 @@ module Decidim
       def user_extension_form_is_valid
         return true unless enable_user_extension?
 
-        merge_errors_for("user_extension") if user_extension.invalid?
+        merge_errors_for("user_extension") if user_extension&.invalid?
       end
 
       def enable_user_extension?

--- a/decidim-user_extension/lib/decidim/user_extension/concerns/controllers/omniauth_add_user_extension_form.rb
+++ b/decidim-user_extension/lib/decidim/user_extension/concerns/controllers/omniauth_add_user_extension_form.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  module UserExtension
+    module Concerns
+      module Controllers
+        # This module overrides Decidim::Devise::RegistrationController.
+        # Adds an instance of UserExtensionForm when initializing RegistrationForm.
+        module OmniauthAddUserExtensionForm
+          def new
+            user_params = params[:user]
+            user_params[:user_extension] ||= UserExtensionForm.new
+            @form = form(OmniauthRegistrationForm).from_params(user_params)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-user_extension/lib/decidim/user_extension/engine.rb
+++ b/decidim-user_extension/lib/decidim/user_extension/engine.rb
@@ -5,6 +5,7 @@ require "decidim/core"
 require "deface"
 require "decidim/user_extension/concerns/controllers/needs_user_extension"
 require "decidim/user_extension/concerns/controllers/add_user_extension_form"
+require "decidim/user_extension/concerns/controllers/omniauth_add_user_extension_form"
 
 module Decidim
   module UserExtension
@@ -46,12 +47,20 @@ module Decidim
           prepend UserExtension::DestroyCommandsOverrides
         end
 
+        Decidim::CreateOmniauthRegistration.class_eval do
+          prepend UserExtension::CreateOmniauthCommandsOverrides
+        end
+
         DecidimController.class_eval do
           include Decidim::UserExtension::Concerns::Controllers::NeedsUserExtension
         end
 
         Decidim::Devise::RegistrationsController.class_eval do
           prepend Decidim::UserExtension::Concerns::Controllers::AddUserExtensionForm
+        end
+
+        Decidim::Devise::OmniauthRegistrationsController.class_eval do
+          prepend Decidim::UserExtension::Concerns::Controllers::OmniauthAddUserExtensionForm
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Fix omniauth registration forms/commands.

Facebookログインについてはこれで修正されるのをローカルで確認しました。

#### :pushpin: Related Issues
- Fixes #177 

#### :clipboard: Subtasks
- [ ] Add tests
