### PR TITLE
画像のフォルダ分けへの対応案

### DIFF
--- a/app/views/decidim/application/_collection.html.erb
+++ b/app/views/decidim/application/_collection.html.erb
@@ -1,0 +1,20 @@
+<% unless attachment_collection.unused? %>
+  <div class="docs__container">
+    <span data-toggle="docs-collection-<%= attachment_collection.id %>"><%= icon "caret-right", class: "icon--small", role: "img", "aria-hidden": true %>&nbsp;
+      <strong><%= translated_attribute(attachment_collection.name) %></strong>
+
+      <% attachment_collection_documents_count =  attachment_collection.attachments.select(&:document?).count %>
+      <small>(<%= attachment_collection_documents_count %> <%= t("decidim.application.collection.documents", count: attachment_collection_documents_count) %>)</small>
+    </span>
+
+    <div id="docs-collection-<%= attachment_collection.id %>" class="docs__content hide" data-toggler=".hide">
+      <p><%= translated_attribute(attachment_collection.description) %></p>
+
+      <div class="card card--list">
+        <% documents.each do |document| %>
+          <%= render partial: "decidim/application/document.html", locals: { document: document } %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/decidim/application/_collection_photos.html.erb
+++ b/app/views/decidim/application/_collection_photos.html.erb
@@ -1,0 +1,14 @@
+<% unless attachment_collection.unused? %>
+  <div class="docs__container">
+    <span data-toggle="docs-collection-<%= attachment_collection.id %>"><%= icon "caret-right", class: "icon--small", role: "img", "aria-hidden": true %>&nbsp;
+      <strong><%= translated_attribute(attachment_collection.name) %></strong>
+      <small>(<%= attachment_collection.attachments.count %> <%= t(".documents", count: attachment_collection.attachments.count) %>)</small>
+    </span>
+    <div id="docs-collection-<%= attachment_collection.id %>" class="docs__content hide" data-toggler=".hide">
+      <p><%= translated_attribute(attachment_collection.description) %></p>
+      <div class="card card--list">
+        <%= render partial: "document", collection: documents %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/decidim/application/_collection_photos.html.erb
+++ b/app/views/decidim/application/_collection_photos.html.erb
@@ -1,14 +1,19 @@
 <% unless attachment_collection.unused? %>
   <div class="docs__container">
-    <span data-toggle="docs-collection-<%= attachment_collection.id %>"><%= icon "caret-right", class: "icon--small", role: "img", "aria-hidden": true %>&nbsp;
+    <span data-toggle="photos-collection-<%= attachment_collection.id %>"><%= icon "caret-right", class: "icon--small", role: "img", "aria-hidden": true %>&nbsp;
       <strong><%= translated_attribute(attachment_collection.name) %></strong>
-      <small>(<%= attachment_collection.attachments.count %> <%= t(".documents", count: attachment_collection.attachments.count) %>)</small>
     </span>
-    <div id="docs-collection-<%= attachment_collection.id %>" class="docs__content hide" data-toggler=".hide">
-      <p><%= translated_attribute(attachment_collection.description) %></p>
-      <div class="card card--list">
-        <%= render partial: "document", collection: documents %>
-      </div>
+
+    <div id="photos-collection-<%= attachment_collection.id %>" class="gallery row hide" data-toggler=".hide">
+      <% photos.in_groups_of(3, false).each do |group| %>
+        <% group.each_with_index do |photo, index| %>
+          <div class="columns small-6 medium-4 <%= (index == 2 || photo == group.last ? "end" : "") %>">
+            <%= link_to photo.big_url, target: "_blank", rel: "noopener" do %>
+              <%= image_tag photo.thumbnail_url, class:"thumbnail", alt: strip_tags(translated_attribute(photo.title)) %>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/decidim/application/_photos.html.erb
+++ b/app/views/decidim/application/_photos.html.erb
@@ -1,0 +1,16 @@
+<% if photos.any? %>
+  <div class="section images">
+    <h3 class="section-heading"><%= t(".related_photos") %></h3>
+    <div class="gallery row">
+      <% photos.in_groups_of(3, false).each do |group| %>
+        <% group.each_with_index do |photo, index| %>
+          <div class="columns small-6 medium-4 <%= (index == 2 || photo == group.last ? "end" : "") %>">
+            <%= link_to photo.big_url, target: "_blank", rel: "noopener" do %>
+              <%= image_tag photo.thumbnail_url, class:"thumbnail", alt: strip_tags(translated_attribute(photo.title)) %>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/decidim/application/_photos.html.erb
+++ b/app/views/decidim/application/_photos.html.erb
@@ -2,15 +2,20 @@
   <div class="section images">
     <h3 class="section-heading"><%= t(".related_photos") %></h3>
     <div class="gallery row">
-      <% photos.in_groups_of(3, false).each do |group| %>
-        <% group.each_with_index do |photo, index| %>
-          <div class="columns small-6 medium-4 <%= (index == 2 || photo == group.last ? "end" : "") %>">
-            <%= link_to photo.big_url, target: "_blank", rel: "noopener" do %>
-              <%= image_tag photo.thumbnail_url, class:"thumbnail", alt: strip_tags(translated_attribute(photo.title)) %>
-            <% end %>
-          </div>
+      <% if (photos_without_collection = photos.reject(&:attachment_collection_id?)).any? %>
+        <% photos_without_collection.in_groups_of(3, false).each do |group| %>
+          <% group.each_with_index do |photo, index| %>
+            <div class="columns small-6 medium-4 <%= (index == 2 || photo == group.last ? "end" : "") %>">
+              <%= link_to photo.big_url, target: "_blank", rel: "noopener" do %>
+                <%= image_tag photo.thumbnail_url, class:"thumbnail", alt: strip_tags(translated_attribute(photo.title)) %>
+              <% end %>
+            </div>
+          <% end %>
         <% end %>
       <% end %>
     </div>
+    <% photos.select(&:attachment_collection_id?).group_by(&:attachment_collection).sort_by { |c, d| c.weight }.each do |collection, photos| %>
+      <%= render partial: "collection_photos", locals: { attachment_collection: collection, photos: photos } %>
+    <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

#192 の対応のため、画像についてもフォルダごとに表示するように修正したものです。

#### :pushpin: Related Issues
- Fixes #192 

#### :clipboard: Subtasks
- [ ] Add tests

### :camera: Screenshots (optional)

画像とドキュメントをそれぞれcollection1フォルダに入れたものとそうでないものを1つずつ用意した場合の表示は以下のとおりです。

<img width="600" alt="photo-collection" src="https://user-images.githubusercontent.com/10401/111901589-7e088f00-8a7c-11eb-804f-09f63de7babd.png">

ドキュメント数については、decidim/decidimの最新版のファイルをそのままコピーしてきています。
