### PR TITLE
Fix messages in locales: remove `someone`

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -175,6 +175,8 @@ ja:
         ignore: |-
           招待を受け入れたくない場合は、このメールを無視してください。<br />
           上記のリンクにアクセスし、アカウントIDとパスワードを設定するまで、あなたのアカウントは作成されません。
+        someone_invited_you: "%{application}にあなたを招待しました。以下のリンクから受け入れることができます。"
+        someone_invited_you_as_admin: "%{application}の管理者としてあなたを招待しました。以下のリンクから承認できます。"
       password_change:
         greeting: こんにちは、 %{recipient} さん!
       reset_password_instructions:


### PR DESCRIPTION
#### :tophat: What? Why?

メールの文言にある「誰かが(someone)」という日本語翻訳メッセージが不自然なので、削除します。

#### :pushpin: Related Issues
- Fixes #195

### :camera: Screenshots (optional)
