### PR TITLE
update mimemagic (for develop branch)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -523,7 +523,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)


### PR DESCRIPTION
#### :tophat: What? Why?

mimemagicにてライセンスの問題が見つかった影響で、古いバージョンのmimemagicが使えなくなったため、updateします。
このバージョンのmimemagicはGPL v2になっているのに注意が必要です（が、このリポジトリは公開でやっていますし、普通に運用している分には問題ないはずです）。

see: https://github.com/rails/rails/issues/41750

#### :pushpin: Related Issues
- Fixes #198 

#### :clipboard: Subtasks
- [x] master版も対応する
