### PR TITLE
update mimemagic 0.3.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,9 @@ gem "newrelic_rpm"
 
 gem "decidim-user_extension", path: "decidim-user_extension"
 
+# When rails >= 5.2.5 or 6.0.3.6, you can remove this gem.
+gem "mimemagic", "~> 0.3.10"
+
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
   gem "figaro"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -523,7 +523,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.6)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -830,6 +832,7 @@ DEPENDENCIES
   fog-aws
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
+  mimemagic (~> 0.3.10)
   newrelic_rpm
   puma (>= 4.3.5)
   rspec-rails


### PR DESCRIPTION
#### :tophat: What? Why?

mimemagicを0.3.10に更新します。
このバージョンでは、`freedesktop.org.xml` が適切なディレクトリに設置されている必要があります（が、現在の環境ではすでにインストールされているようです）。

#### :pushpin: Related Issues
- Fixes #203

#### :clipboard: Subtasks
