### PR TITLE
ドキュメント数の表示のみを修正（関連画像は現状のまま）

### DIFF
--- a/app/views/decidim/application/_collection.html.erb
+++ b/app/views/decidim/application/_collection.html.erb
@@ -1,0 +1,20 @@
+<% unless attachment_collection.unused? %>
+  <div class="docs__container">
+    <span data-toggle="docs-collection-<%= attachment_collection.id %>"><%= icon "caret-right", class: "icon--small", role: "img", "aria-hidden": true %>&nbsp;
+      <strong><%= translated_attribute(attachment_collection.name) %></strong>
+
+      <% attachment_collection_documents_count =  attachment_collection.attachments.select(&:document?).count %>
+      <small>(<%= attachment_collection_documents_count %> <%= t("decidim.application.collection.documents", count: attachment_collection_documents_count) %>)</small>
+    </span>
+
+    <div id="docs-collection-<%= attachment_collection.id %>" class="docs__content hide" data-toggler=".hide">
+      <p><%= translated_attribute(attachment_collection.description) %></p>
+
+      <div class="card card--list">
+        <% documents.each do |document| %>
+          <%= render partial: "decidim/application/document.html", locals: { document: document } %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

#192 の対応で、とりあえずドキュメント数の表示を正しくするべく最新のテンプレートファイルを持ってきたものです。
関連画像の表示は変更していません。

元ファイルは以下になります。

* decidim-core/app/views/decidim/application/_collection.html.erb

#### :pushpin: Related Issues
- Related to #192 

### :camera: Screenshots (optional)
<img width="600" alt="document-fix-192" src="https://user-images.githubusercontent.com/10401/113568493-9fa47180-964b-11eb-9cd7-016f645b87de.png">

