### PR TITLE
Fix an error when destorying user without user_extension

### DIFF
--- a/decidim-user_extension/app/commands/concerns/decidim/user_extension/destroy_commands_overrides.rb
+++ b/decidim-user_extension/app/commands/concerns/decidim/user_extension/destroy_commands_overrides.rb
@@ -31,11 +31,14 @@ module Decidim
           user: @user,
           name: "user_extension"
         )
-        authorization.attributes = {
-          unique_id: nil,
-          metadata: {}
-        }
-        authorization.save!
+        # should be removed privacy data even if current_organization.available_authorization_handlers is empty
+        if authorization
+          authorization.attributes = {
+            unique_id: nil,
+            metadata: {}
+          }
+          authorization.save!
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

ユーザー拡張属性を無効にした段階でユーザーを削除するとエラーになる件を修正します
