### PR TITLE
Fix an error when destorying user without user_extension

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -31,6 +31,10 @@ ja:
             nickname: アカウントID
         search_placeholder:
           name_or_nickname_or_email_cont: "%{collection} をメール、表示名、アカウントIDで検索します。"
+    authorization_handlers:
+      user_extension_authorization_handler:
+        explanation: 'ユーザー拡張属性保持用'
+        name: 'ユーザー拡張属性'
     components:
       add_comment_form:
         account_message: <a href="%{sign_in_url}">ログイン</a> または <a href="%{sign_up_url}">新規登録</a> することでコメントできます。

--- a/decidim-user_extension/app/commands/concerns/decidim/user_extension/destroy_commands_overrides.rb
+++ b/decidim-user_extension/app/commands/concerns/decidim/user_extension/destroy_commands_overrides.rb
@@ -31,11 +31,14 @@ module Decidim
           user: @user,
           name: "user_extension"
         )
-        authorization.attributes = {
-          unique_id: nil,
-          metadata: {}
-        }
-        authorization.save!
+        # should be removed privacy data even if current_organization.available_authorization_handlers is empty
+        if authorization
+          authorization.attributes = {
+            unique_id: nil,
+            metadata: {}
+          }
+          authorization.save!
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
ユーザー拡張属性を無効にした段階でユーザーを削除するとエラーになる件の修正
