### PR TITLE
chore: enabled auto eb platform update on staging

### DIFF
--- a/deployments/staging/00_options.config
+++ b/deployments/staging/00_options.config
@@ -10,7 +10,7 @@ option_settings:
     RetentionInDays: 3
   "aws:elasticbeanstalk:managedactions":
     ManagedActionsEnabled: true
-    PreferredStartTime: "Mon:00:00"
+    PreferredStartTime: "Sun:18:00"
   "aws:elasticbeanstalk:managedactions:platformupdate":
     UpdateLevel: minor
     InstanceRefreshEnabled: true

--- a/deployments/staging/00_options.config
+++ b/deployments/staging/00_options.config
@@ -8,3 +8,9 @@ option_settings:
     StreamLogs: true
     DeleteOnTerminate: true
     RetentionInDays: 3
+  "aws:elasticbeanstalk:managedactions":
+    ManagedActionsEnabled: true
+    PreferredStartTime: "Mon:00:00"
+  "aws:elasticbeanstalk:managedactions:platformupdate":
+    UpdateLevel: minor
+    InstanceRefreshEnabled: true


### PR DESCRIPTION
#### :tophat: What? Why?

プラットフォームバージョンが定期的に上がっているが、気づいたベースで手作業で更新している。

マネージドプラットフォーム更新を有効化することで、手作業が不要になる。

マイナー更新のみstaging環境なので問題無い。定期的にみて問題がなければ、本番に取り込む手助けにもなる。

自動メンテナンス時間はUTC  "Mon:00:00"
日本時間月曜日朝3時

### 有効化したオプションの説明
https://docs.aws.amazon.com/ja_jp/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-elasticbeanstalkmanagedactions

#### :pushpin: Related Issues
- Related to #241

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask