### PR TITLE
chore: update ecr lifecycle policy to expire old tag

### DIFF
--- a/.cloudformation/ecr.yml
+++ b/.cloudformation/ecr.yml
@@ -25,6 +25,36 @@ Resources:
                 "action": {
                   "type": "expire"
                 }
+              },
+              {
+                "action": {
+                  "type": "expire"
+                },
+                "selection": {
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 7,
+                  "tagStatus": "tagged",
+                  "tagPrefixList": [
+                    "staging-"
+                  ]
+                },
+                "description": "stagingイメージの削除",
+                "rulePriority": 2
+              },
+              {
+                "action": {
+                  "type": "expire"
+                },
+                "selection": {
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 7,
+                  "tagStatus": "tagged",
+                  "tagPrefixList": [
+                    "production-"
+                  ]
+                },
+                "description": "productionイメージの削除",
+                "rulePriority": 3
               }
             ]
           }


### PR DESCRIPTION
#### :tophat: What? Why?

CI/CDを作成した際にタグの打ち方が変わったので、それに合わせて古いイメージを削除する設定を追加した。

下記のプレフィックスから始まるタグのイメージは7つのみ保持する。それ以上削除する設定とした。

- staging-
- production-

> imageCountMoreThan では、イメージは期間の新しいものから始めて最も古いものへと pushed_at_time に基づいて順に並べられた後、指定したカウントより大きいイメージはすべて期限切れとなります。

https://docs.aws.amazon.com/ja_jp/AmazonECR/latest/userguide/LifecyclePolicies.html

既にcloud formationには反映済み
[対象のstack](https://ap-northeast-1.console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/stackinfo?stackId=arn%3Aaws%3Acloudformation%3Aap-northeast-1%3A887442827229%3Astack%2Fdecidim-cfj-ecr-repository%2F5bd60330-9806-11eb-92aa-06c3336b4a0d&filteringStatus=active&filteringText=&viewNested=true&hideStacks=false)

#### :pushpin: Related Issues
- Related to #56 