### PR TITLE
chore: decrease sidekiq worker 6 -> 3

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:concurrency: 6
+:concurrency: 3
 :queues:
   - default
   - mailers


### PR DESCRIPTION
#### :tophat: What? Why?

sidekiqのワーカー数が、pumaのワーカー数5よりも多い。

かなり余裕があり、メモリ効率も良くないのでパフォーマンス観点で減らした。

これでも、本番はサーバーが現状3-5台なので、最大9-15が同時実行数となる。

#### :pushpin: Related Issues
- Related to #185 
- Fixes #?