### PR TITLE
refactor: fix from sed text replace to use environment variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,6 +120,7 @@ jobs:
         run: |
           cd deployments
           cp ${EB_ENVIRONMENT_NAME}/00_options.config .ebextensions/00_options.config
-          sed -i -e "s|{RepositoryName}|$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG|g" docker-compose.yml
-          sed -i -e "s|{EBEnvironment}|$EB_ENVIRONMENT_NAME|g" docker-compose.yml
+          export APP_REPOSITORY_NAME=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          sed -i -e "s|\$APP_REPOSITORY_NAME|$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG|g" docker-compose.yml
+          sed -i -e "s|\$EB_ENVIRONMENT_NAME|$EB_ENVIRONMENT_NAME|g" docker-compose.yml
           eb deploy ${EB_ENVIRONMENT_NAME} --timeout=20 --process

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -90,22 +90,21 @@ bundle install
 
 ## 4. Elastic Beanstalk に 環境をセットアップする
 
-1. [docker-compose.yml](deployments/docker-compose.yml)で`{RepositoryName}`をデプロイしたいECRのイメージパスに修正。
-1. [docker-compose.yml](deployments/docker-compose.yml)で`{EBEnvironment}}`をデプロイする環境名に修正。
-1. 作成したい環境の設定をコピー。
-
 [deployments/.elasticbeanstalk/config.yml](deployments/.elasticbeanstalk/config.yml)に設定があるので、基本的に何も聞かれないはずです。
 
+下記の環境変数を使用します。
+- EB_ENVIRONMENT_NAME デプロイしたいElastic Beanstalkの環境名
+- APP_REPOSITORY_NAME デプロイしたいECRのイメージパス
 
 ```bash
 cd deployments
 
-// production
-cp deployments/production/00_options.config .ebextensions/00_options.config
-// staging(台数とかログの保持期間が小さい)
-cp deployments/staging/00_options.config .ebextensions/00_options.config
+export EB_ENVIRONMENT_NAME=production # or staging(台数とかログの保持期間が小さい)
+export APP_REPOSITORY_NAME=
 
-eb create production
+cp $EB_ENVIRONMENT_NAME/00_options.config .ebextensions/00_options.config
+
+eb create $EB_ENVIRONMENT_NAME --process
 ```
 
 最後エラーで終わるがOK

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -18,19 +18,19 @@ services:
       - app
 
   app:
-    image: "{RepositoryName}"
+    image: $APP_REPOSITORY_NAME
     volumes:
       - static-public:/app/public
     environment:
-      NEW_RELIC_APP_NAME: decidem-app({EBEnvironment})
+      NEW_RELIC_APP_NAME: decidem-app($EB_ENVIRONMENT_NAME)
     env_file:
       - .env
 
   sidekiq:
-    image: "{RepositoryName}"
+    image: $APP_REPOSITORY_NAME
     command: bundle exec sidekiq -C /app/config/sidekiq.yml
     environment:
-      NEW_RELIC_APP_NAME: decidem-sidekiq({EBEnvironment})
+      NEW_RELIC_APP_NAME: decidem-sidekiq($EB_ENVIRONMENT_NAME)
     env_file:
       - .env
 


### PR DESCRIPTION
#### :tophat: What? Why?

docker-compose内の独自テンプレートを、環境変数でも使えるようにリファクタリングするものです。

環境変数を使用する方が新しく環境を作成するときなどに作業がしやすいと考えています。

ただしデプロイ時には、Elastic Beanstalk内で環境変数がないためsedで置換しています。

#### :pushpin: Related Issues
- Related to #227
