### PR TITLE
chore: enabled spot instance on staging environment

### DIFF
--- a/deployments/staging/00_options.config
+++ b/deployments/staging/00_options.config
@@ -3,7 +3,10 @@ option_settings:
     MinSize: 1
     MaxSize: 2
   "aws:ec2:instances":
+    EnableSpot: true
     InstanceTypes: t2.small
+    SpotFleetOnDemandBase: 0
+    SpotMaxPrice: 0.1
   "aws:elasticbeanstalk:cloudwatch:logs":
     StreamLogs: true
     DeleteOnTerminate: true


### PR DESCRIPTION
#### :tophat: What? Why?
コスト削減のためstaging環境で、Spotインスタンスの有効化

#### :pushpin: Related Issues
- Related to #?
- Fixes #?