### PR TITLE
update CHANGELOG v0.23.0-2021-06-22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [v0.23.0-2021-06-22](https://github.com/codeforjapan/decidim-cfj/releases/tag/v0.23.0-2021-06-22)
+
+### Developer improvements
+
+- update ecr lifecycle policy to expire old tag [#243](https://github.com/codeforjapan/decidim-cfj/pull/243)
+- enabled auto eb platform update on staging [#242](https://github.com/codeforjapan/decidim-cfj/pull/242)
+- decrease sidekiq worker 6 -> 3 [#244](https://github.com/codeforjapan/decidim-cfj/pull/244)
+- add sidkiq&nginx docker image on eb [#235](https://github.com/codeforjapan/decidim-cfj/pull/235)
+- Add Changelog (CHANGELOG.md) [#238](https://github.com/codeforjapan/decidim-cfj/pull/238)
+
 ## [v0.23.0-2021-5-31](https://github.com/codeforjapan/decidim-cfj/releases/tag/v0.23.0-2021-5-31)
 
 ### Fixed


### PR DESCRIPTION
#### :tophat: What? Why?
release v0.23.0-2021-06-22 のCHANGELOGのupdate

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
