### PR TITLE
chore: change auto scale trigger to Average from Maximum

### DIFF
--- a/deployments/.ebextensions/02_common_options.config
+++ b/deployments/.ebextensions/02_common_options.config
@@ -12,7 +12,7 @@ option_settings:
   "aws:autoscaling:trigger":
     LowerThreshold: 30
     MeasureName: CPUUtilization
-    Statistic: Maximum
+    Statistic: Average
     Unit: Percent
     UpperThreshold: 60
   "aws:elasticbeanstalk:environment":


### PR DESCRIPTION
#### :tophat: What? Why?

アクセス等のCPUの負荷増により、オートスケーリングの設定がかみ合わなくなってきた。
そのため、最大から平均に変更する。

#### :pushpin: Related Issues
- Related to #264 