### PR TITLE
Fix #268; add locale for debate_closed

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -87,6 +87,13 @@ ja:
           email_outro: '"%{resource_title}" 、またはその参加者をフォローしているためこの通知を受け取りました。前のリンクからフォローを解除することができます。'
           email_subject: "%{author_name} から %{resource_title} に対して新しいコメントがあります"
           notification_title: <a href="%{author_path}">%{author_name} %{author_nickname}</a> から <a href="%{resource_path}">%{resource_title} に対して新しいコメントがあります</a>
+      debates:
+        debate_closed:
+          follower:
+            email_intro: '「%{resource_title}」のディベートは終了しました。そのページから結論を読むことができます。'
+            email_outro: '%{resource_title} をフォローしているため、この通知を受け取りました。前のリンクから通知の受信を停止することができます。'
+            email_subject: '「%{resource_title}」のディベートは終了しました'
+            notification_title: <a href="%{resource_path}">%{resource_title}</a> のディベートは終了しました。
       gamification:
         badge_earned:
           email_outro: サイトでの活動によって、この通知を受け取りました。


### PR DESCRIPTION
#### :tophat: What? Why?

ディベート終了時のメールで訳文抜けが出るので、追加します。

#### :pushpin: Related Issues
- Fixes #268 

#### :clipboard: Subtasks
