### PR TITLE
Fix fallbacks of i18n; use both :ja and :en

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,7 +73,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [:ja, :en]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
#### :tophat: What? Why?

日本語のlocaleファイルの抜けがあった場合に、production環境では英語にfallbackするようにする修正です。
探索順序は以下になるはずです。

* 設定が日本語だった場合: まず日本語で探して、見つからなければ英語で探す
* 設定が英語だった場合: まず英語で探して、見つからなければ日本語で探す
* 設定がそれ以外だった場合: まずそのロケールで探して、見つからなければ日本語で探して、それでも見つからなければ英語で探す

日本語でも英語でもない場合は、missing: xxxといった表示になるのは現状と同じです。

#### :clipboard: Subtasks
