### PR TITLE
fix: delete public docker volume for cache

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - ./etc/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./etc/nginx/conf.d:/etc/nginx/conf.d
       - /var/log/nginx:/var/log/nginx
-      - static-public:/app/public
     environment:
       TZ: Asia/Tokyo
     ports:
@@ -19,8 +18,6 @@ services:
 
   app:
     image: "{RepositoryName}"
-    volumes:
-      - static-public:/app/public
     environment:
       NEW_RELIC_APP_NAME: decidim-app({EBEnvironment})
     env_file:
@@ -33,6 +30,3 @@ services:
       NEW_RELIC_APP_NAME: decidim-sidekiq({EBEnvironment})
     env_file:
       - .env
-
-volumes:
-  static-public:

--- a/deployments/etc/nginx/conf.d/default.conf
+++ b/deployments/etc/nginx/conf.d/default.conf
@@ -14,11 +14,7 @@ server {
     access_log /var/log/nginx/access.log main;
     access_log /var/log/nginx/healthd/application.log.$year-$month-$day-$hour healthd;
 
-    root /app/public;
-
-    try_files  $uri $uri @app;
-
-    location @app {
+    location / {
         proxy_pass          http://app:3000;
         proxy_http_version  1.1;
         proxy_set_header    Connection             $connection_upgrade;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     volumes:
       - ./deployments/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./deployments/etc/nginx/conf.d:/etc/nginx/conf.d
-      - ./public:/app/public
     environment:
       TZ: Asia/Tokyo
     ports:


### PR DESCRIPTION
#### :tophat: What? Why?

デプロイ時に、public配下をdocker volumeで共有する機構の削除。インスタンスが更新されない場合、public配下が更新されないケースがあるため。

Cloud Front導入もある。それを踏まえキャッシュはそちらに全て寄せて、nginxではコンテンツを持たないようにした。

#### :pushpin: Related Issues
- Fixes #274
