### PR TITLE
fix: change cache policy name to by environment

### DIFF
--- a/.cloudformation/cloud_front.yml
+++ b/.cloudformation/cloud_front.yml
@@ -23,15 +23,6 @@ Parameters:
     Description: Type of this SSL id
     Type: String
 
-Metadata:
-  "AWS::CloudFormation::Interface":
-    ParameterGroups:
-      - Label:
-          default: "CloudFront"
-        Parameters:
-          - AlbDnsName
-          - ErrorCacheTTL
-
 Resources:
   # ------------------------------------------------------------#
   #  S3 Bucket
@@ -52,7 +43,7 @@ Resources:
         DefaultTTL: 600
         MinTTL: 60
         MaxTTL: 3600
-        Name: Decidim-Static-Cache-Policy
+        Name: !Sub ${AppEnvironment}-decidim-static-cache-policy
         ParametersInCacheKeyAndForwardedToOrigin:
           CookiesConfig:
             CookieBehavior: none

--- a/.cloudformation/cloud_front.yml
+++ b/.cloudformation/cloud_front.yml
@@ -32,7 +32,16 @@ Resources:
     Properties:
       BucketName: !Sub ${AppEnvironment}-cfj-decidim-cloudfront-log
       AccessControl: LogDeliveryWrite
-
+      LifecycleConfiguration:
+        Rules:
+          - Id: !Sub ${AppEnvironment}-cfj-decidim-cloudfront-log-life-cycle
+            Status: Enabled
+            Prefix: logs/
+            Transitions:
+              - StorageClass: STANDARD_IA
+                TransitionInDays: 30
+              - StorageClass: GLACIER
+                TransitionInDays: 90
   # ------------------------------------------------------------#
   #  CloudFront
   # ------------------------------------------------------------#

--- a/docs/INFRA.md
+++ b/docs/INFRA.md
@@ -17,9 +17,12 @@ https://github.com/awsdocs/elastic-beanstalk-samples/blob/main/cfn-templates/vpc
 
 [.cloudformation/vpc_subnets.yml](/.cloudformation/vpc_subnets.yml)
 
+ログ出力用のs3バケットも作成してます。
+
 ### Stack Name
 
 - staging-decidim-app-cloud-front
+- production-decidim-app-cloud-front
 
 ## Redis
 


### PR DESCRIPTION
#### :tophat: What? Why?
本番環境のcloud frontを作成するにあたり、依存するcache policyが環境ごとに作られるように修正しました。
また一定期間後に、ログのストレージタイプを変更するライフサイクルを設定しました。

#### :pushpin: Related Issues
- Related to #185
