### PR TITLE
chore: add cloud formation of waf

### DIFF
--- a/.cloudformation/waf.yml
+++ b/.cloudformation/waf.yml
@@ -1,0 +1,89 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: "Create webAcl"
+
+Parameters:
+  AppEnvironment:
+    Description: Type of app environment.
+    Type: String
+    Default: staging
+    AllowedValues:
+      - staging
+      - production
+
+Resources:
+# ------------------------------------------------------------#
+# AWS WAFv2
+# ------------------------------------------------------------#
+  WebAclCloudFront:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      DefaultAction:
+        Allow: {}
+      Description: WebACL for CloudFront
+      Name: !Sub ${AppEnvironment}-cfj-decidim-web-acl
+      Rules:
+        - Name: !Sub ${AppEnvironment}-AWSManagedRulesCommonRuleSet
+          Priority: 0
+          OverrideAction:
+            Count: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesCommonRuleSetMetric
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+        - Name: !Sub ${AppEnvironment}-AWSManagedRulesKnownBadInputsRuleSet
+          Priority: 1
+          OverrideAction:
+            Count: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesKnownBadInputsRuleSetMetric
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesKnownBadInputsRuleSet
+        - Name: !Sub ${AppEnvironment}-AWSManagedRulesAmazonIpReputationList
+          Priority: 2
+          OverrideAction:
+            Count: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesAmazonIpReputationListMetric
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesAmazonIpReputationList
+        - Name: !Sub ${AppEnvironment}-AWSManagedRulesLinuxRuleSet
+          Priority: 3
+          OverrideAction:
+            Count: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesLinuxRuleSetMetric
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesLinuxRuleSet
+        - Name: !Sub ${AppEnvironment}-AWSManagedRulesSQLiRuleSet
+          Priority: 4
+          OverrideAction:
+            Count: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesSQLiRuleSetMetric
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesSQLiRuleSet
+      Scope: CLOUDFRONT
+      VisibilityConfig:
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName: !Sub ${AppEnvironment}-cfj-decidim-web-acl

--- a/docs/INFRA.md
+++ b/docs/INFRA.md
@@ -45,6 +45,19 @@ https://github.com/awsdocs/elastic-beanstalk-samples/blob/main/cfn-templates/vpc
 
 - staging-decidim-app-cloud-front
 
+## WAF
+
+Cloud frontに合わせてus-east-1にあります。
+
+### Template file
+
+[.cloudformation/waf.yml](/.cloudformation/waf.yml)
+
+### Stack Name
+
+- staging-decidim-waf
+- production-decidim-waf
+
 ## ECR
 
 staging用と本番は同じリポジトリです。Dockerイメージのタグで区別します。


### PR DESCRIPTION
#### :tophat: What? Why?

セキュリティ向上のため、カウントモードでwafを追加する

ルールは、オーソドックスな下記5つ

- AWSManagedRulesCommonRuleSet
- AWSManagedRulesKnownBadInputsRuleSet
- AWSManagedRulesAmazonIpReputationList
- AWSManagedRulesLinuxRuleSet
- AWSManagedRulesSQLiRuleSet

https://docs.aws.amazon.com/ja_jp/waf/latest/developerguide/aws-managed-rule-groups-list.html

#### :pushpin: Related Issues
- Related to #180
