### PR TITLE
chore: remove glacier life cycle on cloud front log s3

### DIFF
--- a/.cloudformation/cloud_front.yml
+++ b/.cloudformation/cloud_front.yml
@@ -40,8 +40,7 @@ Resources:
             Transitions:
               - StorageClass: STANDARD_IA
                 TransitionInDays: 30
-              - StorageClass: GLACIER
-                TransitionInDays: 90
+
   # ------------------------------------------------------------#
   #  CloudFront
   # ------------------------------------------------------------#


### PR DESCRIPTION
#### :tophat: What? Why?
cloud frontのログバケットに対して、athenaのテーブルを作成した。

Glacierに移行してしまうとスキャン対象外になる。そのため90日後にGlacierに移動するライフサイクルを削除した

#### :pushpin: Related Issues
- Related to #185 