### PR TITLE
upgrade instance type to t2.medium

### DIFF
--- a/deployments/production/00_options.config
+++ b/deployments/production/00_options.config
@@ -3,7 +3,7 @@ option_settings:
     MinSize: 3
     MaxSize: 5
   "aws:ec2:instances":
-    InstanceTypes: t2.small
+    InstanceTypes: t2.medium
   "aws:elasticbeanstalk:cloudwatch:logs":
     StreamLogs: true
     DeleteOnTerminate: false


### PR DESCRIPTION
#### :tophat: What? Why?
#286 の対応
productionの環境のみインスタンスタイプを一つ上のものに変更する

#### :pushpin: Related Issues
- Fixes #286 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
