### PR TITLE
`Decidim::ResourceVersionsHelper.resource_version` でのクエリを最適化する

### DIFF
--- a/app/helpers/decidim/resource_versions_helper.rb
+++ b/app/helpers/decidim/resource_versions_helper.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Helper to print resource versions.
+  module ResourceVersionsHelper
+    include ResourceHelper
+
+    # Displays the localized version for the given resource.
+    #
+    # resource - the Resource that has the version to display.
+    # options - An optional hash of options
+    #         * class: A string of extra css classes
+    #
+    # Returns a String.
+    def resource_version(resource, options = {})
+      return unless resource.respond_to?(:versions) && resource.versions.present?
+
+      html = []
+      html << resource_version_number(resource.versions_count)
+      html << " "
+      html << resource_version_of(resource.versions_count)
+      html << " "
+      html << link_to_other_resource_versions(options[:versions_path]) if options[:versions_path]
+
+      content_tag(:div, safe_join(html), class: "tech-info #{options[:class]}")
+    end
+
+    def resource_version_number(count, css_class = "")
+      content_tag(:strong, t("version", scope: "decidim.versions.resource_version", number: count), class: css_class)
+    end
+
+    def resource_version_of(count)
+      t("of_versions", scope: "decidim.versions.resource_version", number: count)
+    end
+
+    def link_to_other_resource_versions(versions_path)
+      link_to(
+        t(
+          "see_other_versions",
+          scope: "decidim.versions.resource_version"
+        ),
+        versions_path
+      )
+    end
+  end
+end

--- a/app/helpers/decidim/resource_versions_helper.rb
+++ b/app/helpers/decidim/resource_versions_helper.rb
@@ -17,7 +17,7 @@ module Decidim
     #
     # Returns a String.
     def resource_version(resource, options = {})
-      return unless resource.respond_to?(:versions) && resource.versions_count > 0
+      return unless resource.respond_to?(:versions) && resource.versions_count.positive?
 
       html = []
       html << resource_version_number(resource.versions_count)

--- a/app/helpers/decidim/resource_versions_helper.rb
+++ b/app/helpers/decidim/resource_versions_helper.rb
@@ -5,6 +5,10 @@ module Decidim
   module ResourceVersionsHelper
     include ResourceHelper
 
+    # Override `Decidim::ResourceVersionsHelper.resource_version` to enhance performance.
+    #
+    # (Original Comment is below:)
+    #
     # Displays the localized version for the given resource.
     #
     # resource - the Resource that has the version to display.
@@ -13,7 +17,7 @@ module Decidim
     #
     # Returns a String.
     def resource_version(resource, options = {})
-      return unless resource.respond_to?(:versions) && resource.versions.present?
+      return unless resource.respond_to?(:versions) && resource.versions_count > 0
 
       html = []
       html << resource_version_number(resource.versions_count)


### PR DESCRIPTION
#### :tophat: What? Why?

ディベートのコメント一覧画面において、`versions` テーブルに対する不要な（重い）クエリを発行しないようにするための修正です。

ディベートのコメント一覧画面ではversionsテーブルは件数しか使用していないのですが、現状`SELECT "versions".* FROM "versions" WHERE ...`というクエリを発行するようになっています。そのため、これを`SELECT count(*) ...`にするものです。

ちなみに現状は上記クエリを発行した直後で `SELECT count(*) ...` を再度発行するのですが、2回目以降はキャッシュが使われる（のでDBアクセスそのものが1回分省ける）ようでした。