### PR TITLE
Fix translation `versions.resource_version.of_version`

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -181,6 +181,9 @@ ja:
           pending_authorizations:
             index:
               username: アカウントID
+    versions:
+      resource_version:
+        of_versions: / %{number}
     welcome_notification:
       default_body: <p>こんにちは {{name}} さん, {{organization}} へご参加いただきありがとうございます。</p><ul><li>もし、このサイトの使い方は、 <a href="{{help_url}}">ヘルプ</a> セクションをご参照ください。</li><li>目を通していただけると、最初のバッジを獲得できます。<a href="{{badges_url}}">全てのバッジの一覧</a> から、この {{organization}} への参加で獲得できるバッジを見ることができます。</li><li>他の人と一緒に参加し、この {{organization}} へ参加した経験をシェアしましょう。 提案を作り、コメントし、議論し、共通善への貢献の仕方について考え、議論に説得力をもたせ、主張を聞いたり読んだりしながら納得し、具体的かつ直接的な方法であなたの考えを表明し、忍耐と決断を持って対応し、 自らの考えを守り、他人の考えを取り入れて協力し合いましょう。</li></ul>
   devise:


### PR DESCRIPTION
#### :tophat: What? Why?

履歴表示のところの翻訳が不適切だったので修正します。

現状:
<img width="316" alt="of_version_before" src="https://user-images.githubusercontent.com/10401/136929394-d0f1fadf-304f-4922-affa-ab6fea06f292.png">

修正後:
<img width="280" alt="of_version_after" src="https://user-images.githubusercontent.com/10401/136929471-1ffd3be2-1b6f-49f2-9d9f-0f683c919d15.png">

（日本語で表現するのが悩ましい感じだったので分数的な表記にしました）
