### PR TITLE
画像のファイルサイズではなく画像の縦横サイズの文言も追加

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -108,6 +108,10 @@ ja:
       initiatives:
         vote_cabin:
           votes_blocked: ログインが無効になっています
+    forms:
+      file_help:
+        image:
+          message_1: "テキストを含まない風景画像が適しています（推奨サイズ: 縦横どちらも3800ピクセル以下程度）"
     meetings:
       meetings:
         filters:


### PR DESCRIPTION
#### :tophat: What? Why?

#59 の修正として画像アップロードの文言を修正します。

#### :pushpin: Related Issues
- Fixes #59

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional
<img width="610" alt="スクリーンショット 2021-10-18 18 43 08" src="https://user-images.githubusercontent.com/10401/137707601-b7c6932a-9ab4-4e32-a24e-32ab8a22225b.png">
)
