### PR TITLE
Use `円` instead of YEN mark

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -48,7 +48,7 @@ Decidim.configure do |config|
   # end
 
   # Currency unit
-  config.currency_unit = "¥"
+  config.currency_unit = "円"
 
   # Defines the quality of image uploads after processing. Image uploads are
   # processed by Decidim, this value helps reduce the size of the files.


### PR DESCRIPTION
#### :tophat: What? Why?

予算の表記ですが、記号は後置のようなので `¥` ではなく `円` にします。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

修正後:

<img width="128" alt="スクリーンショット 2021-10-18 20 07 12" src="https://user-images.githubusercontent.com/10401/137719670-b7da6669-db21-4b68-8faf-610dd407c262.png">


