### PR TITLE
chore: fix cloud front CustomOrigin timeout 30s -> 60s

### DIFF
--- a/.cloudformation/cloud_front.yml
+++ b/.cloudformation/cloud_front.yml
@@ -80,6 +80,7 @@ Resources:
             HTTPPort: 80
             HTTPSPort: 443
             OriginProtocolPolicy: https-only
+            OriginReadTimeout: 60
         DefaultCacheBehavior:
           AllowedMethods:
             - GET


### PR DESCRIPTION
#### :tophat: What? Why?

decidim 0.23.5のアップデートでタイムアウトが伸びたので、それに合わせてcloud frontも変更する。

https://aws.amazon.com/jp/about-aws/whats-new/2020/06/amazon-cloudfront-enables-configurable-origin-connection-attempts-and-origin-connection-timeouts/

#### :pushpin: Related Issues
- Related to #223
- Fixes #185