### PR TITLE
Fix limit for Decidim::Comments::SortedCommments

### DIFF
--- a/decidim-comments/app/queries/decidim/comments/sorted_comments.rb
+++ b/decidim-comments/app/queries/decidim/comments/sorted_comments.rb
@@ -48,7 +48,7 @@ module Decidim
                 end
 
         if @options[:limit] && @options[:limit].to_i.positive?
-          if scope.kind_of?(Array)
+          if scope.is_a?(Array)
             scope.take(@options[:limit])
           else
             scope.limit(@options[:limit])

--- a/decidim-comments/app/queries/decidim/comments/sorted_comments.rb
+++ b/decidim-comments/app/queries/decidim/comments/sorted_comments.rb
@@ -48,7 +48,11 @@ module Decidim
                 end
 
         if @options[:limit] && @options[:limit].to_i.positive?
-          scope.limit(@options[:limit])
+          if scope.kind_of?(Array)
+            scope.take(@options[:limit])
+          else
+            scope.limit(@options[:limit])
+          end
         else
           scope
         end


### PR DESCRIPTION
#### :tophat: What? Why?

`undefined method `limit' for#<Array:XXXX>`といったエラーが出るようなので確認してみたところ、scopeの結果がArrayになっていることがあるようだったため、その場合は`Enumerable#take`を使うように修正してみました。

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [ ] Add tests
- [x] Another subtask
