### PR TITLE
Fix #304; ignore seeds of DecidimAwesome

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,6 +11,19 @@
 
 require_relative "../lib/monkey_patching_faker"
 
+# Seeds of DecidimAwesome 0.7.0 and 0.7.2 support Faker 2.x, not 1.9.x.
+# So Decidim 0.23.5 (using Faker 1.9.6) should ignore seeds of them.
+#
+map_component = Decidim.find_component_manifest("awesome_map")
+map_component.seeds do |participatory_space|
+  # noop
+end
+
+iframe_component = Decidim.find_component_manifest("awesome_iframe")
+iframe_component.seeds do |participatory_space|
+  # noop
+end
+
 Decidim.seed!
 
 if !Rails.env.production? || ENV["SEED"]


### PR DESCRIPTION
#### :tophat: What? Why?

#304 の修正で、`rails db:seed`が(少なくともmacOSでは)正常に動作するようにします。

DecidimAwesomeで追加されているmapとiframeのseedは（なくても特に困らないため）作らないようにしています。

#### :pushpin: Related Issues
- Fixes #304

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [x] Add/modify seeds
- [ ] Add tests
- [x] Another subtask

### :camera: Screenshots (optional)
