### PR TITLE
Fix db:seed in docker

### DIFF
--- a/config/initializers/fileutils.rb
+++ b/config/initializers/fileutils.rb
@@ -1,0 +1,1 @@
+require_relative "../../lib/monkey_patching_fileutils"

--- a/config/initializers/fileutils.rb
+++ b/config/initializers/fileutils.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require_relative "../../lib/monkey_patching_fileutils"

--- a/lib/monkey_patching_fileutils.rb
+++ b/lib/monkey_patching_fileutils.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 # ref. https://github.com/docker/for-linux/issues/1015#issuecomment-811453779
 module FileUtilsDockerPatch
   def copy_file(dest)
-    FileUtils.touch(path())
+    FileUtils.touch(path)
     super
   end
 end
 
 module FileUtils
-  class Entry_
+  class Entry_ # rubocop:disable Naming/ClassAndModuleCamelCase
     prepend FileUtilsDockerPatch
   end
 end

--- a/lib/monkey_patching_fileutils.rb
+++ b/lib/monkey_patching_fileutils.rb
@@ -1,0 +1,13 @@
+# ref. https://github.com/docker/for-linux/issues/1015#issuecomment-811453779
+module FileUtilsDockerPatch
+  def copy_file(dest)
+    FileUtils.touch(path())
+    super
+  end
+end
+
+module FileUtils
+  class Entry_
+    prepend FileUtilsDockerPatch
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This patch is from https://github.com/docker/for-linux/issues/1015#issuecomment-811453779

DockerでFileUtilsのcopy_fileを使うと0バイトのファイルができることがある（！？）ようなので、それをtouchで回避するworkaroundを入れてみます。
touchでファイルがなければ作るだけなので、Docker以外でも特に問題はないはずです。

#### :pushpin: Related Issues
- Fixes #253 , #302 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask
