### PR TITLE
Cloud Watch のアプリケーションログ保持期間の延長

### DIFF
--- a/deployments/production-v0-23-5/00_options.config
+++ b/deployments/production-v0-23-5/00_options.config
@@ -7,4 +7,4 @@ option_settings:
   "aws:elasticbeanstalk:cloudwatch:logs":
     StreamLogs: true
     DeleteOnTerminate: false
-    RetentionInDays: 7
+    RetentionInDays: 30

--- a/deployments/staging/00_options.config
+++ b/deployments/staging/00_options.config
@@ -10,7 +10,7 @@ option_settings:
   "aws:elasticbeanstalk:cloudwatch:logs":
     StreamLogs: true
     DeleteOnTerminate: true
-    RetentionInDays: 3
+    RetentionInDays: 14
   "aws:elasticbeanstalk:managedactions":
     ManagedActionsEnabled: true
     PreferredStartTime: "Sun:18:00"


### PR DESCRIPTION
#### :tophat: What? Why?

Cloud Watch のアプリケーションログ保持期間を延長した

- 本番 7日-> 30日
- staging 3日 -> 14日

#### :pushpin: Related Issues
- Related to #?
- Fixes #307