### PR TITLE
chore: enabled AWSManagedRulesCommonRuleSet on AWS WAF

### DIFF
--- a/.cloudformation/waf.yml
+++ b/.cloudformation/waf.yml
@@ -28,13 +28,17 @@ Resources:
         - Name: !Sub ${AppEnvironment}-AWSManagedRulesCommonRuleSet
           Priority: 0
           OverrideAction:
-            Count: {}
+            None: {}
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
             MetricName: AWSManagedRulesCommonRuleSetMetric
           Statement:
             ManagedRuleGroupStatement:
+              ExcludedRules:
+                - Name: CrossSiteScripting_BODY
+                - Name: SizeRestrictions_BODY
+                - Name: GenericRFI_BODY
               VendorName: AWS
               Name: AWSManagedRulesCommonRuleSet
         - Name: !Sub ${AppEnvironment}-AWSManagedRulesKnownBadInputsRuleSet
@@ -96,9 +100,7 @@ Resources:
       LogDestinationConfigs:
         - !Sub ${KinesisDeliveryStreamArn}
       RedactedFields:
-        - Method: {}
-        - QueryString: {}
-        - UriPath: {}
+        - SingleHeader: { Name: cookie }
       ResourceArn: !Sub "${WebAclCloudFront.Arn}"
       LoggingFilter:
         DefaultBehavior: DROP


### PR DESCRIPTION
#### :tophat: What? Why?

カウントモードでログ収集していたAWSManagedRulesCommonRuleSet を有効化します。

3週間分のログを分析した結果、日本から一定リクエストがあり、誤検知が疑われるルールが3つありました。よって下記をブロック対象から除外しました。

### ブロック除外ルール

- CrossSiteScripting_BODY
  - 管理画面でhtmlをおくってる箇所でひっかる
- SizeRestrictions_BODY
  - 時々話題になるrule展でリクエストが大きなってる箇所がひっかる
- GenericRFI_BODY
  - 管理画面ぽい

https://docs.aws.amazon.com/ja_jp/waf/latest/developerguide/aws-managed-rule-groups-list.html

### ログに落とす情報の調整

WAFをログに落としている箇所で、cookieが落ちていたので削除するように修正しました。ログから消すことでファイルサイズの圧縮が期待できます。基本的にcookieは調査には不要です。

#### :pushpin: Related Issues
- Related to #180
