### PR TITLE
fix url & remove OriginPath

### DIFF
--- a/.cloudformation/cloud_front.yml
+++ b/.cloudformation/cloud_front.yml
@@ -62,7 +62,7 @@ Resources:
             Principal:
               AWS: !Sub "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${OriginAccessIdentity}"
             Action: "s3:GetObject"
-            Resource: !Sub "arn:aws:s3:::${AppEnvironment}-cfj-decidim/uploads/decidim/*"
+            Resource: !Sub "arn:aws:s3:::${AppEnvironment}-cfj-decidim/*"
 
 
   # ------------------------------------------------------------#
@@ -107,7 +107,6 @@ Resources:
             OriginReadTimeout: 60
         - Id: !Sub "${AppEnvironment}-cfj-decidim.s3.ap-northeast-1.amazonaws.com"
           DomainName: !Sub "${AppEnvironment}-cfj-decidim.s3.ap-northeast-1.amazonaws.com"
-          OriginPath: /uploads/decidim
           S3OriginConfig:
             OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${OriginAccessIdentity}"
         DefaultCacheBehavior:

--- a/app/uploaders/decidim/application_uploader.rb
+++ b/app/uploaders/decidim/application_uploader.rb
@@ -23,7 +23,7 @@ module Decidim
       if path.nil?
         default_url(*args)
       else
-        encoded_path = encode_path(path.sub(File.expand_path(root), ''))
+        encoded_path = encode_path(path.sub(File.expand_path(root), ""))
         if (host = asset_host)
           if host.respond_to? :call
             "#{host.call(self)}/#{encoded_path}"

--- a/app/uploaders/decidim/application_uploader.rb
+++ b/app/uploaders/decidim/application_uploader.rb
@@ -19,12 +19,20 @@ module Decidim
 
     # Overwrite: If the content block is in preview mode, then we show the
     # URL using the asset_host domain
-    def url(*)
-      encoded_path = encode_path(path)
-      if asset_host.respond_to? :call
-        "#{asset_host.call(self)}/#{encoded_path}"
+    def url(*args)
+      if path.nil?
+        default_url(*args)
       else
-        "#{asset_host}/#{encoded_path}"
+        encoded_path = encode_path(path.sub(File.expand_path(root), ''))
+        if (host = asset_host)
+          if host.respond_to? :call
+            "#{host.call(self)}/#{encoded_path}"
+          else
+            "#{host}/#{encoded_path}"
+          end
+        else
+          (base_path || "") + encoded_path
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
#317 で修正したcloud formationと、url関数の修正
Staging 環境で動かした場合に、Origin Pathが邪魔して読み込めないものがあった。
また、decidimのデフォルトアイコンが表示されないため修正

#### :pushpin: Related Issues
- Fixes #317 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
