### PR TITLE
Reset `Decidim::ApplicationUploader#validate_inside_organization` to original definition

### DIFF
--- a/app/uploaders/decidim/application_uploader.rb
+++ b/app/uploaders/decidim/application_uploader.rb
@@ -61,13 +61,6 @@ module Decidim
       return if model.is_a?(Decidim::Organization)
       return if model.respond_to?(:organization) && model.organization.is_a?(Decidim::Organization)
 
-      # HACK: Temporary fix for https://github.com/decidim/decidim/issues/6720
-      # If this is fixed by decidim, this file (application_uploader.rb)
-      # should be deleted to keep in sync with upstream!
-      return if model.class.to_s == "decidim/hero_homepage_content_block"
-      #      Fix for https://github.com/codeforjapan/decidim-cfj/issues/101
-      return if model.nil?
-
       raise CarrierWave::IntegrityError, I18n.t("carrierwave.errors.not_inside_organization")
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

#323 の対応で、`Decidim::ApplicationUploader#validate_inside_organization`を本家の定義に戻します。

#### :pushpin: Related Issues
- Related to #323

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
