### PR TITLE
Add CookieOrderable; store proposals orders in cookies

### DIFF
--- a/app/controllers/concerns/decidim/proposals/cookie_orderable.rb
+++ b/app/controllers/concerns/decidim/proposals/cookie_orderable.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    module CookieOrderable
+      private
+
+      def default_order
+        order_by_cookie || super
+      end
+
+      def order_by_cookie
+        cookie = cookies[order_cookie_name]
+        cookie if cookie && available_orders.include?(cookie)
+      end
+
+      def order_cookie_name
+        "proposal_default_order"
+      end
+
+      def detect_order(candidate)
+        detected = available_orders.detect { |order| order == candidate }
+        cookies[order_cookie_name] = detected if detected
+
+        detected
+      end
+    end
+  end
+end

--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Override Decidim::Orderable
+#
+# Use cookies to store default orders
+Decidim::Proposals::ProposalsController.prepend Decidim::Proposals::CookieOrderable

--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -3,4 +3,7 @@
 # Override Decidim::Orderable
 #
 # Use cookies to store default orders
-Decidim::Proposals::ProposalsController.prepend Decidim::Proposals::CookieOrderable
+#
+Rails.application.config.to_prepare do
+  Decidim::Proposals::ProposalsController.prepend Decidim::Proposals::CookieOrderable
+end


### PR DESCRIPTION
#### :tophat: What? Why?

提案コンポーネントのユーザー用一覧画面でのソート順をクッキーに保存できるようにします。

#### 合わせて検討するべきこと

* [x] 他のコンポーネントでも同様に保存できるようにするか？ →まずは提案コンポーネントのみ適用する
* [x] 同様の修正を行う場合、コンポーネント間でデフォルトのソート順を共有できなくても良いか？（ソート順の選択肢が完全に共通ではないため、共有はしない方が良さそう） →コンポーネントが異なっていれば違っていて良さそう

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [x] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
