### PR TITLE
生年や名前等の入力フォームを改善（入力制限・入力支援を追加）

### DIFF
--- a/decidim-user_extension/app/views/decidim/devise/registrations/_user_extension.html.erb
+++ b/decidim-user_extension/app/views/decidim/devise/registrations/_user_extension.html.erb
@@ -8,7 +8,7 @@
               </div>
 
               <div class="field">
-                <%= f_ext.text_field :birth_year, label: t(:birth_year, scope: "activemodel.attributes.user_extension") %>
+                <%= f_ext.text_field :birth_year, label: t(:birth_year, scope: "activemodel.attributes.user_extension"), help_text: t(".birth_year_help") %>
               </div>
 
               <div class="field">

--- a/decidim-user_extension/app/views/decidim/devise/registrations/_user_extension.html.erb
+++ b/decidim-user_extension/app/views/decidim/devise/registrations/_user_extension.html.erb
@@ -1,10 +1,10 @@
             <%= f.fields_for :user_extension, f.object.user_extension do |f_ext| %>
               <div class="field">
-                <%= f_ext.text_field :real_name, label: t(:real_name, scope: "activemodel.attributes.user_extension") %>
+                <%= f_ext.text_field :real_name, label: t(:real_name, scope: "activemodel.attributes.user_extension"), autocomplete: 'name' %>
               </div>
 
               <div class="field">
-                <%= f_ext.text_field :address, label: t(:address, scope: "activemodel.attributes.user_extension") %>
+                <%= f_ext.text_field :address, label: t(:address, scope: "activemodel.attributes.user_extension"), autocomplete: 'street-address' %>
               </div>
 
               <div class="field">

--- a/decidim-user_extension/app/views/decidim/devise/registrations/_user_extension.html.erb
+++ b/decidim-user_extension/app/views/decidim/devise/registrations/_user_extension.html.erb
@@ -8,7 +8,7 @@
               </div>
 
               <div class="field">
-                <%= f_ext.text_field :birth_year, label: t(:birth_year, scope: "activemodel.attributes.user_extension"), help_text: t(".birth_year_help") %>
+                <%= f_ext.text_field :birth_year, label: t(:birth_year, scope: "activemodel.attributes.user_extension"), help_text: t(".birth_year_help"), inputmode: 'numeric', maxlength: 4 %>
               </div>
 
               <div class="field">

--- a/decidim-user_extension/config/locales/ja.yml
+++ b/decidim-user_extension/config/locales/ja.yml
@@ -13,6 +13,10 @@ ja:
       officializations:
         index:
           show_user_extension: ユーザー属性を表示
+    devise:
+      registrations:
+        user_extension:
+          birth_year_help: 数値4桁で入力してください。例) 1997
     user_extension:
       admin:
         officializations:


### PR DESCRIPTION
#### :tophat: What? Why?

#333 の対応として、誕生年の入力欄に説明と例を追加し、inputmodeとmaxlengthによる入力制限を追加しました。
合わせて名前と住所の入力欄にもautocompleteを追加して補完されやすくしています。

#### :pushpin: Related Issues
- Fixes #333

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
