### PR TITLE
長いコメント（アルファベット等）を適切に改行させる

### DIFF
--- a/app/assets/stylesheets/comment_content.scss
+++ b/app/assets/stylesheets/comment_content.scss
@@ -1,0 +1,5 @@
+/* Fix https://github.com/codeforjapan/decidim-cfj/issues/288 */
+.comment__content {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}


### PR DESCRIPTION
#### :tophat: What? Why?

#288 に対応するためのCSSの修正で、適切に改行するようにします。

どこまで設定するかは要検討ではありますが、とりあえずdeicidim-commentsのコメント本文のクラスのみ適用しています。

#### :pushpin: Related Issues
- Fixes #288

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
<img width="875" alt="word-break2" src="https://user-images.githubusercontent.com/10401/152761270-857da5c4-f03b-42f3-954f-d053ddd2d2df.png">

