### PR TITLE
Redirect https://www.diycities.jp/ to Metadecidim Japan

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@
 
 require "sidekiq/web"
 Rails.application.routes.draw do
+  # Redirect to Metadecidim Japan
+  get "/", to: redirect("https://meta.diycities.jp/"), constraints: { host: "www.diycities.jp" }
+
   mount Decidim::Core::Engine => "/"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   authenticate :user, ->(u) { u.admin? } do


### PR DESCRIPTION
#### :tophat: What? Why?

wwwのトップページに来た場合のみ、https://meta.diycities.jp/ にリダイレクトさせるようにしてみます。

#### :pushpin: Related Issues
なし

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask
