### PR TITLE
Allow to change DB name in dev/test

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -29,7 +29,7 @@ default: &default
 
 development:
   <<: *default
-  database: decidim-app_development
+  database: <%= ENV.fetch("DATABASE_DBNAME_DEV") { "decidim-app_development" } %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -63,7 +63,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: decidim-app_test
+  database: <%= ENV.fetch("DATABASE_DBNAME_TEST") { "decidim-app_test" } %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -44,6 +44,14 @@ export DATABASE_USERNAME=<yourname>
 export DATABASE_PASSWORD=<yourpassword>
 ```
 
+なお、DBのhost、port、DB名も設定したい場合は、以下のように環境変数を指定します。
+
+```
+export DATABASE_HOST=<yourhost>
+export DATABASE_PORT=<yourport>
+export DATABASE_DBNAME_DEV=<yourdbname>
+```
+
 ### 2.6 bundle install
 ```
 bundle install


### PR DESCRIPTION
#### :tophat: What? Why?

開発時の都合でDB名も変更したい場合に、hostやportと同様に環境変数で上書き設定できるようにする修正です。
何もしなければこれまでと同様に`decidim-app_development`と`decidim-app_test`になります。

合わせてDEVELOPMENT.mdにhost等も含めて変更方法を書いておきました。

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask
