### PR TITLE
chore: disabled SQLi_BODY rule on waf for uploading image

### DIFF
--- a/.cloudformation/waf.yml
+++ b/.cloudformation/waf.yml
@@ -87,6 +87,8 @@ Resources:
             MetricName: AWSManagedRulesSQLiRuleSetMetric
           Statement:
             ManagedRuleGroupStatement:
+              ExcludedRules:
+                - Name: SQLi_BODY
               VendorName: AWS
               Name: AWSManagedRulesSQLiRuleSet
       Scope: CLOUDFRONT


### PR DESCRIPTION
#### :tophat: What? Why?

画像アップロード時に誤検知されることがあるので、WAFのルールでSQLi_BODYを無効化します。

staging, production反映済みです。

#### :pushpin: Related Issues
- Fixes #336

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
