### PR TITLE
Fix translation: `Is visible` `duplicate`

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,6 +23,8 @@ ja:
       organization:
         primary_color: プライマリ
         secondary_color: セカンダリ
+      minutes:
+        visible: 表示する
   date:
     formats:
       decidim_short: "%Y/%m/%d"
@@ -32,6 +34,8 @@ ja:
       decidim_with_month_name_short: "%b %d"
   decidim:
     admin:
+      actions:
+        duplicate: 複製
       admin_terms_of_use:
         actions:
           refuse: 同意しない


### PR DESCRIPTION
#### :tophat: What? Why?

`Is visible`(が非表示になっていた件)と`duplicate`(が訳されてなかった件)の翻訳について、crowdinには反映済みですが、現状のバージョンでも対応されるよう修正しておきます。

#### :pushpin: Related Issues
- Related to #344

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
