### PR TITLE
Add Decidim::TermCustomer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,8 @@ gem "decidim-comments", path: "decidim-comments"
 
 gem "decidim-decidim_awesome", "~> 0.7.0"
 
-gem "decidim-term_customizer", git: 'https://github.com/mainio/decidim-module-term_customizer.git', branch: '0.24-stable'
+## gem "decidim-term_customizer", git: 'https://github.com/mainio/decidim-module-term_customizer.git', branch: '0.24-stable'
+gem "decidim-term_customizer", git: 'https://github.com/takahashim/decidim-module-term_customizer.git', branch: '024-ja'
 
 gem "bootsnap", "~> 1.3"
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gem "decidim-comments", path: "decidim-comments"
 
 gem "decidim-decidim_awesome", "~> 0.7.0"
 
-## gem "decidim-term_customizer", git: 'https://github.com/mainio/decidim-module-term_customizer.git', branch: '0.24-stable'
-gem "decidim-term_customizer", git: 'https://github.com/takahashim/decidim-module-term_customizer.git', branch: '024-ja'
+## gem "decidim-term_customizer", git: "https://github.com/mainio/decidim-module-term_customizer.git", branch: "0.24-stable"
+gem "decidim-term_customizer", git: "https://github.com/takahashim/decidim-module-term_customizer.git", branch: "024-ja"
 
 gem "bootsnap", "~> 1.3"
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem "decidim-comments", path: "decidim-comments"
 
 gem "decidim-decidim_awesome", "~> 0.7.0"
 
+gem "decidim-term_customizer", git: 'https://github.com/mainio/decidim-module-term_customizer.git', branch: '0.24-stable'
+
 gem "bootsnap", "~> 1.3"
 
 gem "puma", ">= 5.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/mainio/decidim-module-term_customizer.git
+  revision: 4b385c55996e390406ac68a8b5ab68b9da2c8817
+  branch: 0.24-stable
+  specs:
+    decidim-term_customizer (0.24.0)
+      decidim-admin (~> 0.24.0)
+      decidim-core (~> 0.24.0)
+
 PATH
   remote: decidim-comments
   specs:
@@ -892,6 +901,7 @@ DEPENDENCIES
   decidim-comments!
   decidim-decidim_awesome (~> 0.7.0)
   decidim-dev (= 0.24.3)
+  decidim-term_customizer!
   decidim-user_extension!
   deface
   dotenv-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/mainio/decidim-module-term_customizer.git
-  revision: 4b385c55996e390406ac68a8b5ab68b9da2c8817
-  branch: 0.24-stable
+  remote: https://github.com/takahashim/decidim-module-term_customizer.git
+  revision: 769405ab054dda2981333eb7ad272388b759bfbb
+  branch: 024-ja
   specs:
     decidim-term_customizer (0.24.0)
       decidim-admin (~> 0.24.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/takahashim/decidim-module-term_customizer.git
-  revision: 769405ab054dda2981333eb7ad272388b759bfbb
+  revision: a244a4ddabf73a3d8b810311eb475b4274579243
   branch: 024-ja
   specs:
     decidim-term_customizer (0.24.0)

--- a/db/migrate/20220324111735_create_decidim_term_customizer_translation_sets.decidim_term_customizer.rb
+++ b/db/migrate/20220324111735_create_decidim_term_customizer_translation_sets.decidim_term_customizer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# This migration comes from decidim_term_customizer (originally 20190217132503)
+
+class CreateDecidimTermCustomizerTranslationSets < ActiveRecord::Migration[5.2]
+  def change
+    create_table :decidim_term_customizer_translation_sets do |t|
+      t.jsonb :name
+    end
+  end
+end

--- a/db/migrate/20220324111736_create_decidim_term_customizer_translations.decidim_term_customizer.rb
+++ b/db/migrate/20220324111736_create_decidim_term_customizer_translations.decidim_term_customizer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# This migration comes from decidim_term_customizer (originally 20190217132654)
+
+class CreateDecidimTermCustomizerTranslations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :decidim_term_customizer_translations do |t|
+      t.string :locale
+      t.string :key
+      t.text :value
+
+      t.references(
+        :translation_set,
+        null: false,
+        foreign_key: { to_table: :decidim_term_customizer_translation_sets },
+        index: { name: "decidim_term_customizer_translation_translation_set" }
+      )
+    end
+  end
+end

--- a/db/migrate/20220324111737_create_decidim_term_customizer_constraints.decidim_term_customizer.rb
+++ b/db/migrate/20220324111737_create_decidim_term_customizer_constraints.decidim_term_customizer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# This migration comes from decidim_term_customizer (originally 20190217132726)
+
+class CreateDecidimTermCustomizerConstraints < ActiveRecord::Migration[5.2]
+  def change
+    create_table :decidim_term_customizer_constraints do |t|
+      t.references :decidim_organization, null: false, foreign_key: true, index: { name: "decidim_term_customizer_constraint_organization" }
+      t.references :subject, polymorphic: true, index: { name: "decidim_term_customizer_constraint_subject" }
+
+      t.references(
+        :translation_set,
+        null: false,
+        foreign_key: { to_table: :decidim_term_customizer_translation_sets },
+        index: { name: "decidim_term_customizer_constraint_translation_set" }
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_21_050039) do
+ActiveRecord::Schema.define(version: 2022_03_24_111737) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -1313,6 +1313,28 @@ ActiveRecord::Schema.define(version: 2021_11_21_050039) do
     t.index ["reset_password_token"], name: "index_decidim_system_admins_on_reset_password_token", unique: true
   end
 
+  create_table "decidim_term_customizer_constraints", force: :cascade do |t|
+    t.bigint "decidim_organization_id", null: false
+    t.string "subject_type"
+    t.bigint "subject_id"
+    t.bigint "translation_set_id", null: false
+    t.index ["decidim_organization_id"], name: "decidim_term_customizer_constraint_organization"
+    t.index ["subject_type", "subject_id"], name: "decidim_term_customizer_constraint_subject"
+    t.index ["translation_set_id"], name: "decidim_term_customizer_constraint_translation_set"
+  end
+
+  create_table "decidim_term_customizer_translation_sets", force: :cascade do |t|
+    t.jsonb "name"
+  end
+
+  create_table "decidim_term_customizer_translations", force: :cascade do |t|
+    t.string "locale"
+    t.string "key"
+    t.text "value"
+    t.bigint "translation_set_id", null: false
+    t.index ["translation_set_id"], name: "decidim_term_customizer_translation_translation_set"
+  end
+
   create_table "decidim_user_blocks", force: :cascade do |t|
     t.bigint "decidim_user_id"
     t.integer "blocking_user_id"
@@ -1530,6 +1552,9 @@ ActiveRecord::Schema.define(version: 2021_11_21_050039) do
   add_foreign_key "decidim_scopes", "decidim_scope_types", column: "scope_type_id"
   add_foreign_key "decidim_scopes", "decidim_scopes", column: "parent_id"
   add_foreign_key "decidim_static_pages", "decidim_organizations"
+  add_foreign_key "decidim_term_customizer_constraints", "decidim_organizations"
+  add_foreign_key "decidim_term_customizer_constraints", "decidim_term_customizer_translation_sets", column: "translation_set_id"
+  add_foreign_key "decidim_term_customizer_translations", "decidim_term_customizer_translation_sets", column: "translation_set_id"
   add_foreign_key "decidim_user_blocks", "decidim_users"
   add_foreign_key "decidim_user_blocks", "decidim_users", column: "blocking_user_id"
   add_foreign_key "decidim_user_moderations", "decidim_users"


### PR DESCRIPTION
#### :tophat: What? Why?

#354 のためのブランチで、v0.24ブランチにDecidim::TermCustomerを追加してみます。

#### :pushpin: Related Issues
- Related to #354

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
<img width="1123" alt="admin-term-customizer" src="https://user-images.githubusercontent.com/10401/160052470-c1dead37-0ca1-4a2c-9a16-2a57d33af7d7.png">

↑これはブラウザで編集するための管理画面ですが、CSV等でエクスポート＆インポートもできます。

<img width="1120" alt="add-multiple" src="https://user-images.githubusercontent.com/10401/160052744-6884b672-faa7-46d0-9313-2dcbe0a87c59.png">

↑また、「まとめて追加」機能を使うと、文字列検索から候補を個別に追加できるので、かなり便利そうです（抽出はできるんですが一括置換はできないため、抽出した後はCSVにエクスポートしてエディタやExcelで編集するのが賢明そうです）。