### PR TITLE
履歴が大きすぎる場合に表示させないよう修正

### DIFF
--- a/app/controllers/decidim/debates/versions_controller.rb
+++ b/app/controllers/decidim/debates/versions_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Debates
+    # Exposes Debates versions so users can see how a Debate has been updated
+    # through time.
+    class VersionsController < Decidim::Proposals::ApplicationController
+      include Decidim::ApplicationHelper
+      include Decidim::ResourceVersionsConcern
+
+      def versioned_resource
+        @versioned_resource ||= present(Debate.where(component: current_component).find(params[:debate_id]))
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/debates/versions_controller.rb
+++ b/app/controllers/decidim/debates/versions_controller.rb
@@ -8,8 +8,18 @@ module Decidim
       include Decidim::ApplicationHelper
       include Decidim::ResourceVersionsConcern
 
+      OBJECT_CHANGE_SIZE_LIMIT = 1_000_000
+
       def versioned_resource
         @versioned_resource ||= present(Debate.where(component: current_component).find(params[:debate_id]))
+      end
+
+      def show
+        description = current_version.object_changes
+        if description.size > OBJECT_CHANGE_SIZE_LIMIT
+          flash[:alert] = I18n.t("debates.versions.too_large_changeset", scope: "decidim.debates")
+          redirect_to action: :index
+        end
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,10 @@ en:
         occupation: Occupation
         real_name: Real Name
   decidim:
+    debates:
+      debates:
+        versions:
+          too_large_changeset: This changeset is too large to show.
     following:
       non_public_followings: Some of the resources followed are not public.
   enums:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -79,6 +79,8 @@ ja:
           citizens: 一般参加者
           official: 事務局
           origin: 起案者
+        versions:
+          too_large_changeset: 履歴のサイズが大きすぎるため表示できません
     devise:
       registrations:
         new:

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -33,6 +33,10 @@ Decidim本体のバージョンを更新する際、特に注意が必要な内�
 
   https://github.com/decidim/decidim/pull/7781 で本家にフィードバックしたので、これが取り込まれたバージョン(v0.25.0以降)になればファイルごと削除できるはずです。
 
+* `app/controllers/decidim/debates/versions_controller.rb`
+
+  https://github.com/codeforjapan/decidim-cfj/pull/359 で追加したファイル。履歴の差分が巨大になるとサーバ負荷が大きいため、renderを実行させないよう表示前にredirectさせるものです。
+
 * `app/forms/decidim/proposals/proposal_wizard_create_step_form.rb`, `app/forms/decidim/proposals/admin/proposal_form.rb`
 
   https://github.com/codeforjapan/decidim-cfj/issues/23 の対応のために追加されたもの。対応するPRは https://github.com/codeforjapan/decidim-cfj/pull/60 https://github.com/codeforjapan/decidim-cfj/pull/163 です。

--- a/spec/sytem/needs_user_extension_spec.rb
+++ b/spec/sytem/needs_user_extension_spec.rb
@@ -19,7 +19,7 @@ describe "Need user extension", type: :system do
       context "without user extension" do
         it "redirect to account page" do
           visit decidim.notifications_path
-          expect(page).to have_current_path(decidim.account_path)
+          expect(page).to have_current_path(decidim.account_path, ignore_query: true)
         end
 
         it "not redirect in root page" do


### PR DESCRIPTION
#### :tophat: What? Why?

ディベートで履歴が大きすぎる場合にサーバに負荷がかかるようなので、差分の大きさについて適当な上限を設けて、それを超える場合は表示をあきらめるようにしてみました。

とりあえず現状は1MBに指定してみています(`OBJECT_CHANGE_SIZE_LIMIT`の定数の値です)。

#### 注意事項

* DBの操作を頑張ればクエリを発行してデータを受け取る前にチェックできそうですが、クエリ以上に画面描画にかかるコストが大きいようなので、DBクエリそのものは変更せずに通常通りデータを受け取った後、そのサイズを見て描画を行わないようにする修正になっています。これでもダメそうであれば、DBクエリの方を修正します。
* 現状はディベートが問題になっているのでそこだけ修正していますが、同様の履歴機能は、アカウンタビリティ・イニシアティブ・ミーティング・提案それぞれに存在しています。そちらは対応していません（それぞれ個別に同様のコードを追加する必要があります）。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [ ] Add tests
- [x] Another subtask

### :camera: Screenshots (optional)

↓こんな感じのエラーメッセージを出して履歴の一覧画面に戻します。

<img width="456" alt="changeset_limit" src="https://user-images.githubusercontent.com/10401/161110168-f2e8d78e-a86a-490c-8ccd-282d7319c3f4.png">

