### PR TITLE
Fix AuthorizeUser; "Fix verification report with multitenants"

### DIFF
--- a/app/commands/decidim/verifications/authorize_user.rb
+++ b/app/commands/decidim/verifications/authorize_user.rb
@@ -7,8 +7,9 @@ module Decidim
       # Public: Initializes the command.
       #
       # handler - An AuthorizationHandler object.
-      def initialize(handler)
+      def initialize(handler, organization)
         @handler = handler
+        @organization = organization
       end
 
       # Executes the command. Broadcasts these events:
@@ -39,7 +40,7 @@ module Decidim
           event: "decidim.events.verifications.managed_user_error_event",
           event_class: Decidim::Verifications::ManagedUserErrorEvent,
           resource: conflict,
-          affected_users: Decidim::User.where(admin: true)
+          affected_users: Decidim::User.where(admin: true, organization: @organization)
         )
       end
 

--- a/app/commands/decidim/verifications/authorize_user.rb
+++ b/app/commands/decidim/verifications/authorize_user.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    # A command to authorize a user with an authorization handler.
+    class AuthorizeUser < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # handler - An AuthorizationHandler object.
+      def initialize(handler)
+        @handler = handler
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the handler wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        if handler.invalid?
+          conflict = create_verification_conflict
+          notify_admins(conflict) if conflict.present?
+
+          return broadcast(:invalid)
+        end
+
+        Authorization.create_or_update_from(handler)
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :handler
+
+      def notify_admins(conflict)
+        Decidim::EventsManager.publish(
+          event: "decidim.events.verifications.managed_user_error_event",
+          event_class: Decidim::Verifications::ManagedUserErrorEvent,
+          resource: conflict,
+          affected_users: Decidim::User.where(admin: true)
+        )
+      end
+
+      def create_verification_conflict
+        authorization = Decidim::Authorization.find_by(unique_id: handler.unique_id)
+        return if authorization.blank?
+
+        conflict = Decidim::Verifications::Conflict.find_or_initialize_by(
+          current_user: handler.user,
+          managed_user: authorization.user,
+          unique_id: handler.unique_id
+        )
+
+        conflict.update(times: conflict.times + 1)
+
+        conflict
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Verifications
+    # This controller allows users to create and destroy their authorizations. It
+    # shouldn't be necessary to expand it to add new authorization schemes.
+    class AuthorizationsController < Verifications::ApplicationController
+      helper_method :handler, :unauthorized_methods, :authorization_method, :authorization
+      before_action :valid_handler, only: [:new, :create]
+
+      include Decidim::UserProfile
+      include Decidim::Verifications::Renewable
+      helper Decidim::DecidimFormHelper
+      helper Decidim::CtaButtonHelper
+      helper Decidim::AuthorizationFormHelper
+      helper Decidim::TranslationsHelper
+
+      layout "layouts/decidim/user_profile", only: [:index]
+
+      def new; end
+
+      def index
+        @granted_authorizations = granted_authorizations
+        @pending_authorizations = pending_authorizations
+      end
+
+      def first_login
+        if unauthorized_methods.length == 1
+          redirect_to(
+            action: :new,
+            handler: unauthorized_methods.first.name,
+            redirect_url: decidim.account_path
+          )
+        end
+      end
+
+      def create
+        AuthorizeUser.call(handler) do
+          on(:ok) do
+            flash[:notice] = t("authorizations.create.success", scope: "decidim.verifications")
+            redirect_to redirect_url || authorizations_path
+          end
+
+          on(:invalid) do
+            flash[:alert] = t("authorizations.create.error", scope: "decidim.verifications")
+            render action: :new
+          end
+        end
+      end
+
+      protected
+
+      def authorization_method(authorization)
+        return unless authorization
+
+        Decidim::Verifications::Adapter.from_element(authorization.name)
+      end
+
+      def handler
+        @handler ||= Decidim::AuthorizationHandler.handler_for(handler_name, handler_params)
+      end
+
+      def handler_params
+        (params[:authorization_handler] || {}).merge(user: current_user)
+      end
+
+      def handler_name
+        params[:handler] || params.dig(:authorization_handler, :handler_name)
+      end
+
+      def valid_handler
+        return true if handler
+
+        logger.warn "Invalid authorization handler given: #{handler_name} doesn't"\
+          "exist or you haven't added it to `Decidim.authorization_handlers`"
+
+        redirect_to(authorizations_path) && (return false)
+      end
+
+      def unauthorized_methods
+        @unauthorized_methods ||= available_verification_workflows.reject do |handler|
+          active_authorization_methods.include?(handler.key)
+        end
+      end
+
+      def active_authorization_methods
+        Authorizations.new(organization: current_organization, user: current_user).pluck(:name)
+      end
+
+      def granted_authorizations
+        Authorizations.new(organization: current_organization, user: current_user, granted: true)
+      end
+
+      def pending_authorizations
+        Authorizations.new(organization: current_organization, user: current_user, granted: false)
+      end
+
+      def store_current_location
+        return if redirect_url.blank? || !request.format.html?
+
+        store_location_for(:user, redirect_url)
+      end
+
+      private
+
+      def authorization
+        @authorization ||= Decidim::Authorization.find_by(
+          user: current_user,
+          name: handler_name
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -35,7 +35,7 @@ module Decidim
       end
 
       def create
-        AuthorizeUser.call(handler) do
+        AuthorizeUser.call(handler, current_organization) do
           on(:ok) do
             flash[:notice] = t("authorizations.create.success", scope: "decidim.verifications")
             redirect_to redirect_url || authorizations_path

--- a/spec/commands/decidim/verifications/authorize_user_spec.rb
+++ b/spec/commands/decidim/verifications/authorize_user_spec.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class DummyAuthorizationHandler < Decidim::AuthorizationHandler
+  # Define the attributes you need for this authorization handler. Attributes
+  # are defined using Decidim::AttributeObject.
+  #
+  attribute :name_and_surname, String
+  attribute :document_number, String
+  attribute :postal_code, String
+  attribute :birthday, Decidim::Attributes::LocalizedDate
+  attribute :scope_id, Integer
+
+  # You can (and should) also define validations on each attribute:
+  #
+  validates :document_number, presence: true
+
+  # You can also define custom validations:
+  #
+  validate :valid_document_number
+  validate :valid_scope_id
+
+  # The only method that needs to be implemented for an authorization handler.
+  # Here you can add your business logic to check if the authorization should
+  # be created or not, you should return a Boolean value.
+  #
+  # Note that if you set some validations and overwrite this method, then the
+  # validations will not run, so it's easier to remove this method and rewrite
+  # your logic using ActiveModel validations.
+  #
+  # def valid?
+  #   raise NotImplementedError
+  # end
+
+  # If set, enforces the handler to validate the uniqueness of the field
+  #
+  def unique_id
+    document_number
+  end
+
+  # The user scope
+  #
+  def scope
+    user.organization.scopes.find_by(id: scope_id) if scope_id
+  end
+
+  # If you need to store any of the defined attributes in the authorization you
+  # can do it here.
+  #
+  # You must return a Hash that will be serialized to the authorization when
+  # it's created, and available though authorization.metadata
+  #
+  def metadata
+    super.merge(document_number: document_number, postal_code: postal_code, scope_id: scope_id)
+  end
+
+  private
+
+  def valid_document_number
+    errors.add(:document_number, :invalid) unless document_number.to_s.end_with?("X")
+  end
+
+  def valid_scope_id
+    errors.add(:scope_id, :invalid) if scope_id && !scope
+  end
+
+  # If you need custom authorization logic, you can implement your own action
+  # authorizer. In this case, it allows to set a list of valid postal codes for
+  # an authorization.
+  class DummyActionAuthorizer < Decidim::Verifications::DefaultActionAuthorizer
+    attr_reader :allowed_postal_codes, :allowed_scope_id
+
+    # Overrides the parent class method, but it still uses it to keep the base behavior
+    def authorize
+      # Remove the additional setting from the options hash to avoid to be considered missing.
+      @allowed_postal_codes ||= options.delete("allowed_postal_codes")&.split(/[\W,;]+/)
+      @allowed_scope_id ||= options.delete("allowed_scope_id")&.to_i
+
+      status_code, data = *super
+
+      extra_explanations = []
+      if allowed_postal_codes.present?
+        # Does not authorize users with different postal codes
+        status_code = :unauthorized if status_code == :ok && disallowed_user_postal_code
+
+        # Adds an extra message for inform the user the additional restriction for this authorization
+        if disallowed_user_postal_code
+          if user_postal_code
+            i18n_postal_codes_key = "extra_explanation.user_postal_codes"
+            user_postal_code_params = { user_postal_code: user_postal_code }
+          else
+            i18n_postal_codes_key = "extra_explanation.postal_codes"
+            user_postal_code_params = {}
+          end
+
+          extra_explanations << { key: i18n_postal_codes_key,
+                                  params: { scope: "decidim.verifications.dummy_authorization",
+                                            count: allowed_postal_codes.count,
+                                            postal_codes: allowed_postal_codes.join(", ") }.merge(user_postal_code_params) }
+        end
+      end
+
+      if allowed_scope.present?
+        # Does not authorize users with different scope
+        status_code = :unauthorized if status_code == :ok && disallowed_user_user_scope
+
+        # Adds an extra message to inform the user about additional restrictions for this authorization
+        if disallowed_user_user_scope
+          if user_scope_id
+            i18n_scope_key = "extra_explanation.user_scope"
+            user_scope_params = { user_scope_name: user_scope_name }
+          else
+            i18n_scope_key = "extra_explanation.scope"
+            user_scope_params = {}
+          end
+
+          extra_explanations << { key: i18n_scope_key,
+                                  params: { scope: "decidim.verifications.dummy_authorization",
+                                            scope_name: allowed_scope.name[I18n.locale.to_s] }.merge(user_scope_params) }
+        end
+      end
+
+      data[:extra_explanation] = extra_explanations if extra_explanations.any?
+
+      [status_code, data]
+    end
+
+    # Adds the list of allowed postal codes and scope to the redirect URL, to allow forms to inform about it
+    def redirect_params
+      { postal_codes: allowed_postal_codes&.join(","), scope: allowed_scope_id }.merge(user_metadata_params)
+    end
+
+    private
+
+    def allowed_scope
+      @allowed_scope ||= Decidim::Scope.find(allowed_scope_id) if allowed_scope_id
+    end
+
+    def user_scope
+      @user_scope ||= Decidim::Scope.find(user_scope_id) if user_scope_id
+    end
+
+    def user_scope_id
+      return unless authorization
+
+      @user_scope_id ||= authorization.metadata["scope_id"]&.to_i
+    end
+
+    def user_scope_name
+      @user_scope_name ||= user_scope.name[I18n.locale.to_s] if authorization && user_scope
+    end
+
+    def disallowed_user_user_scope
+      return unless user_scope || allowed_scope.present?
+
+      allowed_scope_id != user_scope_id
+    end
+
+    def user_postal_code
+      @user_postal_code ||= authorization.metadata["postal_code"] if authorization && authorization.metadata
+    end
+
+    def disallowed_user_postal_code
+      return unless user_postal_code || allowed_postal_codes.present?
+
+      !allowed_postal_codes.member?(user_postal_code)
+    end
+
+    def user_metadata_params
+      return {} unless authorization
+
+      @user_metadata_params ||= begin
+        user_metadata_params = {}
+        user_metadata_params[:user_scope_name] = user_scope.name[I18n.locale.to_s] if user_scope
+
+        user_metadata_params[:user_postal_code] = authorization.metadata["postal_code"] if authorization.metadata["postal_code"].present?
+
+        user_metadata_params
+      end
+    end
+  end
+end
+
+module Decidim::Verifications
+  describe AuthorizeUser do
+    subject { described_class.new(handler) }
+
+    let(:user) { create(:user, :confirmed) }
+    let(:document_number) { "12345678X" }
+    let(:handler) do
+      DummyAuthorizationHandler.new(
+        document_number: document_number,
+        user: user
+      )
+    end
+
+    let(:authorizations) { Authorizations.new(organization: user.organization, user: user, granted: true) }
+
+    context "when the form is not authorized" do
+      before do
+        expect(handler).to receive(:valid?).and_return(false)
+      end
+
+      it "is not valid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+    end
+
+    context "when everything is ok" do
+      it "creates an authorization for the user" do
+        expect { subject.call }.to change(authorizations, :count).by(1)
+      end
+
+      it "stores the metadata" do
+        subject.call
+
+        expect(authorizations.first.metadata["document_number"]).to eq("12345678X")
+      end
+
+      it "sets the authorization as granted" do
+        subject.call
+
+        expect(authorizations.first).to be_granted
+      end
+    end
+
+    describe "uniqueness" do
+      let(:unique_id) { "foo" }
+
+      context "when there's no other authorizations" do
+        it "is valid if there's no authorization with the same id" do
+          expect { subject.call }.to change(authorizations, :count).by(1)
+        end
+      end
+
+      context "when there's other authorizations" do
+        let!(:other_user) { create(:user, organization: user.organization) }
+
+        before do
+          create(:authorization,
+                 user: other_user,
+                 unique_id: document_number,
+                 name: handler.handler_name)
+        end
+
+        it "is invalid if there's another authorization with the same id" do
+          expect { subject.call }.to change(authorizations, :count).by(0)
+        end
+      end
+    end
+
+    describe "managed user" do
+      context "when document_id was used by a managed user" do
+        let!(:other_user) { create(:user, managed: true, organization: user.organization) }
+
+        before do
+          create(:authorization,
+                 user: other_user,
+                 unique_id: document_number,
+                 name: handler.handler_name)
+        end
+
+        it "saves conflicts" do
+          expect { subject.call }.to change(Decidim::Verifications::Conflict, :count).by(1)
+        end
+
+        it "increases conflicts times" do
+          subject.call
+
+          conflict = Decidim::Verifications::Conflict.last
+
+          expect(conflict.times).to eq(1)
+
+          subject.call
+
+          expect(conflict.reload.times).to eq(2)
+        end
+
+        it "sends notification to admins" do
+          allow(Decidim::EventsManager).to receive(:publish).and_call_original
+          subject.call
+
+          conflict = Decidim::Verifications::Conflict.last
+
+          expect(Decidim::EventsManager).to have_received(:publish).with(
+            event: "decidim.events.verifications.managed_user_error_event",
+            event_class: Decidim::Verifications::ManagedUserErrorEvent,
+            resource: conflict,
+            affected_users: Decidim::User.where(admin: true)
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/decidim/verifications/authorize_user_spec.rb
+++ b/spec/commands/decidim/verifications/authorize_user_spec.rb
@@ -71,6 +71,7 @@ class DummyAuthorizationHandler < Decidim::AuthorizationHandler
   class DummyActionAuthorizer < Decidim::Verifications::DefaultActionAuthorizer
     attr_reader :allowed_postal_codes, :allowed_scope_id
 
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     # Overrides the parent class method, but it still uses it to keep the base behavior
     def authorize
       # Remove the additional setting from the options hash to avoid to be considered missing.
@@ -125,6 +126,8 @@ class DummyAuthorizationHandler < Decidim::AuthorizationHandler
 
       [status_code, data]
     end
+
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     # Adds the list of allowed postal codes and scope to the redirect URL, to allow forms to inform about it
     def redirect_params
@@ -200,7 +203,7 @@ module Decidim::Verifications
 
     context "when the form is not authorized" do
       before do
-        expect(handler).to receive(:valid?).and_return(false)
+        expect(handler).to receive(:valid?).and_return(false) # rubocop:disable RSpec/StubbedMock
       end
 
       it "is not valid" do

--- a/spec/commands/decidim/verifications/authorize_user_spec.rb
+++ b/spec/commands/decidim/verifications/authorize_user_spec.rb
@@ -184,8 +184,9 @@ end
 
 module Decidim::Verifications
   describe AuthorizeUser do
-    subject { described_class.new(handler) }
+    subject { described_class.new(handler, organization) }
 
+    let(:organization) { create(:organization) }
     let(:user) { create(:user, :confirmed) }
     let(:document_number) { "12345678X" }
     let(:handler) do
@@ -287,7 +288,7 @@ module Decidim::Verifications
             event: "decidim.events.verifications.managed_user_error_event",
             event_class: Decidim::Verifications::ManagedUserErrorEvent,
             resource: conflict,
-            affected_users: Decidim::User.where(admin: true)
+            affected_users: Decidim::User.where(admin: true, organization: organization)
           )
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport https://github.com/decidim/decidim/pull/8940

上記の本家PR(v0.26用)での修正をこちらに適用してみます。

（なおテスト用のspec/commands/decidim/verifications/authorize_user_spec.rbには、`class DummyAuthorizationHandler` のコードをまるごと同梱させています。）

#### :pushpin: Related Issues
- Related to https://cfj.slack.com/archives/C01CT4GTEBU/p1649825981863759

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
