### PR TITLE
decidim-user_extension: Remove Rails version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ PATH
     decidim-user_extension (0.1.0)
       decidim-admin
       decidim-core
-      rails (~> 5.2.4, >= 5.2.4.4)
+      rails
 
 GEM
   remote: https://rubygems.org/

--- a/decidim-user_extension/decidim-user_extension.gemspec
+++ b/decidim-user_extension/decidim-user_extension.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "decidim-admin"
   spec.add_dependency "decidim-core"
-  spec.add_dependency "rails", "~> 5.2.4", ">= 5.2.4.4"
+  spec.add_dependency "rails"
 
   spec.add_development_dependency "decidim-dev"
 end


### PR DESCRIPTION
#### :tophat: What? Why?

`Decidim::UserExtension`の依存にRailsのバージョンを含めないようにします。
テスト等の特殊な環境以外では（Decidimで使っているRailsをそのまま使うはずなので）特に問題ないかと思います。

#### :pushpin: Related Issues
- Related to #373

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask
