### PR TITLE
GitHub Actions: RuboCop should be another action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+on:
+  push:
+    branches:
+    - master
+    - develop
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: apt-get
+      run: |
+        sudo apt-get update -y
+        sudo apt-get -yqq install libpq-dev postgresql-client
+    - name: Set up Ruby 2.7
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+    - name: Lint by RuboCop
+      run: |
+        bundle exec rubocop --parallel

--- a/.github/workflows/rails-test.yml
+++ b/.github/workflows/rails-test.yml
@@ -55,6 +55,3 @@ jobs:
     - name: Test with RSpec
       run: |
         bundle exec rails spec
-    - name: Lint by RuboCop
-      run: |
-        bundle exec rubocop --parallel


### PR DESCRIPTION
#### :tophat: What? Why?

RuboCopを同じAction内で動かす必要はないので、分割しておきます。

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
