### PR TITLE
Fix locale order to generate seeds in JA

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -12,7 +12,7 @@ Decidim.configure do |config|
   # When an organization is created through the System area, system admins will
   # be able to choose the available languages for that organization. That list
   # of languages will be equal or a subset of the list in this file.
-  config.available_locales = [:en, :ja]
+  config.available_locales = [:ja, :en]
 
   # Enable machine translations
   config.enable_machine_translations = false


### PR DESCRIPTION
#### :tophat: What? Why?

#378 の件ですが、どうもavailable_localesの順番に依存してseedのデータを作るようで、一番うしろになっているのが問題なようです。

というわけで、日本語と英語の順番を入れ替えて、日本語を先頭に移動させます。

#### :pushpin: Related Issues
- Fixes #378 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask

### :camera: Screenshots (optional)
<img width="800" alt="seed-ja" src="https://user-images.githubusercontent.com/10401/170833503-322ed068-2835-4ec5-b0aa-6c4c10b680de.png">

