### PR TITLE
Add a cookie param for comment order

### DIFF
--- a/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
+++ b/decidim-comments/app/controllers/decidim/comments/comments_controller.rb
@@ -102,7 +102,15 @@ module Decidim
       end
 
       def order
-        params.fetch(:order, "older")
+        params_order = params.fetch(:order, nil)
+        if params_order
+          cookies['comment_default_order'] = params_order
+          params_order
+        elsif cookies['comment_default_order']
+          cookies['comment_default_order']
+        else
+          'older'
+        end
       end
 
       def limit

--- a/decidim-comments/lib/decidim/comments/comments_helper.rb
+++ b/decidim-comments/lib/decidim/comments/comments_helper.rb
@@ -30,7 +30,7 @@ module Decidim
           machine_translations: machine_translations_toggled?,
           single_comment: params.fetch("commentId", nil),
           limit: limit,
-          order: options[:order]
+          order: options[:order] || cookies['comment_default_order']
         ).to_s
       end
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,6 +2,7 @@
 
 require "decidim/core/test/factories"
 require "decidim/cfj/test/factories"
+require "decidim/debates/test/factories"
 
 FactoryBot.define do
   sequence(:valid_jwt) do |_n|

--- a/spec/sytem/comment_sort_spec.rb
+++ b/spec/sytem/comment_sort_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Comments", type: :system, perform_enqueued: true do
+  let!(:component) { create(:debates_component, organization: organization) }
+  let!(:commentable) { create(:debate, :open_ama, component: component) }
+
+  let(:resource_path) { resource_locator(commentable).path }
+
+  let!(:organization) { create(:organization) }
+  let!(:user) { create(:user, :confirmed, organization: organization) }
+  let!(:comments) { create_list(:comment, 3, commentable: commentable) }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  it "allows user to store selected comment order in cookies", :slow do
+    comment = create(:comment, commentable: commentable, body: "Most Rated Comment")
+    create(:comment_vote, comment: comment, author: user, weight: 1)
+
+    visit resource_path
+
+    expect(page).to have_no_content("Comments are disabled at this time")
+
+    expect(page).to have_css(".comment", minimum: 1)
+    page.find(".order-by .dropdown.menu .is-dropdown-submenu-parent").hover
+
+    within ".comments" do
+      within ".order-by__dropdown" do
+        click_link "Older" # Opens the dropdown
+        click_link "Best rated"
+      end
+    end
+
+    expect(page).to have_css(".comments > div:nth-child(2)", text: "Most Rated Comment")
+
+    # show other page
+    visit "/"
+
+    # back to resource page
+    visit resource_path
+
+    expect(page).to have_css(".comment", minimum: 1)
+    page.find(".order-by .dropdown.menu .is-dropdown-submenu-parent").hover
+    expect(page).to have_css("#comments-order-menu-control", text: "Best rated")
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

#407 の対応のため、`comment_default_order`というクッキーを追加します。

----

### コメント機能について

Decidimのコメント機能は、提案コンポーネントやディベートコンポーネント、予算コンポーネントなどの各画面にコメントを追加するもので、以下のような特徴があります。

* 様々なコンポーネントにコメント機能を追加できる
* コメントはcommentIdを持っている
* コメントに対するコメントも書ける。これはスレッドとして表示される

### コメントの表示とそのURLについて

コメント表示は対象となるコンポーネントのアイテムを表示する際に合わせて表示されることもあれば、コメント単独で表示することもできます。

ある記事（例えば提案コンポーネントであれば「ある提案」）に対してのコメントは、その記事のURLにアクセスすると表示されます。

* https://meta.diycities.jp/assemblies/nazo/f/286/proposals/321#comments-for-Proposal-321
* https://meta.diycities.jp/assemblies/nazo/f/286/proposals/321

commentIdを指定すると、指定されたcommentIdのコメントと、それにぶら下がる一連のコメントが表示されます。ぶら下がるコメントがない場合は、単独のコメントのみ表示されます。

* https://meta.diycities.jp/assemblies/nazo/f/286/proposals/321?commentId=6893#comment_6893
* https://meta.diycities.jp/assemblies/nazo/f/286/proposals/321?commentId=6894#comment_6894
* https://meta.diycities.jp/assemblies/nazo/f/286/proposals/321?commentId=6896#comment_6896


コメントの右側にある「並び順」を変更すると、コメントのソート順が変更されます。これはJavaScriptで実現されているものです。

ソート順を「最近のもの」に変更すると、以下のようなURLにリクエストが発行されます（commentable_gidがやたら長いIDになっているのに注意）。

* `https://meta.diycities.jp/comments?commentable_gid=BAh7CEkiCGdpZAY6BkVUSSI3Z2lkOi8vZGVjaWRpbS1hcHAvRGVjaWRpbTo6UHJvcG9zYWxzOjpQcm9wb3NhbC8zMjEGOwBUSSIMcHVycG9zZQY7AFRJIgxkZWZhdWx0BjsAVEkiD2V4cGlyZXNfYXQGOwBUSSIdMjAyMi0wOS0yM1QwNzozNzo0OS45ODRaBjsAVA%3D%3D--c19d0c71392e07ca8e114b6016d5edfe7c3897ae&order=recent&reload=1`

（なお、上記URLはJavaScriptからアクセスされるときと、直接ブラウザのアドレスバーにURLを入れてアクセスした際では挙動が異なります。JavaScriptからアクセスされると、現在表示しているHTML内のコメント表示部分だけを更新するようなしくみになっています。ブラウザからの通常のアクセスの際は、適切なURL (この場合は `https://meta.diycities.jp/assemblies/nazo/f/286/proposals/321` ) にリダイレクトされます。）

### コメントの並び順の維持方法について

（ここからがこのPRの説明です）

修正するのは2点あり、「並び順をクッキーに保存する」「クッキーに保存された並び順を使ってコメントを表示する」です。

* 前者については、`https://meta.diycities.jp/comments?...`にアクセスした際に、並び順をクッキーに入れます
* 後者については、`https://meta.diycities.jp/assemblies/nazo/f/286/proposals/321`やその他もろもろにアクセスした際、その記憶させた並び順を使ってソートさせるようにします

このPRの仕様では、一度ソート順を変更すると、それ以降はどのコンポーネント用のコメントでも同じ並び順で表示されるようになるはずです。なお、クッキーが消されると「古い順」に戻ります。

----

#### :pushpin: Related Issues
- Related to #407

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask
