### PR TITLE
feat: add replace to null decidim_organization command

### DIFF
--- a/lib/tasks/replace_to_null.rake
+++ b/lib/tasks/replace_to_null.rake
@@ -5,4 +5,15 @@ namespace :replace_to_null do
   task decidim_assemblies_announcement: :environment do
     Decidim::Assembly.update_all(announcement: nil) # rubocop:disable Rails/SkipsModelValidations
   end
+
+  desc "fix organization edit bug.Make all "" columns of decidim_assemblies table null"
+  task decidim_organization: :environment do
+    Decidim::Organization.all.each do |org|
+      if org.description === "" && org.highlighted_content_banner_short_description === ""
+        org.description = org.description.presence
+        org.highlighted_content_banner_short_description = org.highlighted_content_banner_short_description.presence
+        org.save()
+      end
+    end
+  end
 end

--- a/lib/tasks/replace_to_null.rake
+++ b/lib/tasks/replace_to_null.rake
@@ -9,10 +9,10 @@ namespace :replace_to_null do
   desc 'fix organization edit bug.Make all "" columns of decidim_assemblies table null'
   task decidim_organization: :environment do
     Decidim::Organization.all.each do |org|
-      next unless org.description === "" && org.highlighted_content_banner_short_description === "" # rubocop:disable Style/CaseEquality
+      next unless org.description == "" && org.highlighted_content_banner_short_description == ""
 
-      org.description = org.description.presence
-      org.highlighted_content_banner_short_description = org.highlighted_content_banner_short_description.presence
+      org.description = nil
+      org.highlighted_content_banner_short_description = nil
       org.save
     end
   end

--- a/lib/tasks/replace_to_null.rake
+++ b/lib/tasks/replace_to_null.rake
@@ -8,12 +8,12 @@ namespace :replace_to_null do
 
   desc 'fix organization edit bug.Make all "" columns of decidim_assemblies table null'
   task decidim_organization: :environment do
-    Decidim::Organization.all.each do |org|
-      next unless org.description == "" && org.highlighted_content_banner_short_description == ""
-
-      org.description = nil
-      org.highlighted_content_banner_short_description = nil
-      org.save
+    Decidim::Organization.transaction do
+      Decidim::Organization.all.each do |org|
+        org.description = nil if org.description == ""
+        org.highlighted_content_banner_short_description = nil if org.highlighted_content_banner_short_description == ""
+        org.save!
+      end
     end
   end
 end

--- a/lib/tasks/replace_to_null.rake
+++ b/lib/tasks/replace_to_null.rake
@@ -6,14 +6,14 @@ namespace :replace_to_null do
     Decidim::Assembly.update_all(announcement: nil) # rubocop:disable Rails/SkipsModelValidations
   end
 
-  desc "fix organization edit bug.Make all "" columns of decidim_assemblies table null"
+  desc 'fix organization edit bug.Make all "" columns of decidim_assemblies table null'
   task decidim_organization: :environment do
     Decidim::Organization.all.each do |org|
-      if org.description === "" && org.highlighted_content_banner_short_description === ""
-        org.description = org.description.presence
-        org.highlighted_content_banner_short_description = org.highlighted_content_banner_short_description.presence
-        org.save()
-      end
+      next unless org.description === "" && org.highlighted_content_banner_short_description === "" # rubocop:disable Style/CaseEquality
+
+      org.description = org.description.presence
+      org.highlighted_content_banner_short_description = org.highlighted_content_banner_short_description.presence
+      org.save
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
decidim_organizationsテーブルで""文字が入ってるカラムがエラーを起こしているのでnullに書き換えるコマンドの追加です

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
