### PR TITLE
Update `actions/checkout` and `actions/setup-node`

### DIFF
--- a/.github/workflows/rails-test.yml
+++ b/.github/workflows/rails-test.yml
@@ -37,7 +37,7 @@ jobs:
         - 6379/tcp
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
     - name: apt-get
@@ -51,7 +51,7 @@ jobs:
         bundler-cache: true
 
     - name: setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 16.9.1
         cache: 'yarn'


### PR DESCRIPTION
#### :tophat: What? Why?

GitHub Actionsで使っている `actions/checkout` と `actions/setup-node` は新しいバージョンがリリースされていたので更新しておきます。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
