### PR TITLE
Fix #446; set `max_complexity` after initializers

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -242,4 +242,6 @@ Devise.allow_unconfirmed_access_for = Decidim.unconfirmed_access_for
 Decidim.register_assets_path File.expand_path("app/packs", Rails.application.root)
 
 # Set max_complexity of GraphQL::Schema
-Decidim::Api::Schema.max_complexity = 100_000
+Rails.application.config.to_prepare do
+  Decidim::Api::Schema.max_complexity = 100_000
+end


### PR DESCRIPTION
#### :tophat: What? Why?

#446 の修正で、`max_complexity`を変更するタイミングをinitializerの実行後に行うようにします。

#### :pushpin: Related Issues

- Fixes #446

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask
