### PR TITLE
Make frequncy of puma-worker-killer 60(sec)

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,7 +23,7 @@ pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 before_fork do
   PumaWorkerKiller.config do |config|
     config.ram = 2048
-    config.frequency = 5
+    config.frequency = 60
     config.percent_usage = 0.9
     config.rolling_restart_frequency = 24 * 60 * 60
     config.reaper_status_logs = true


### PR DESCRIPTION
#### :tophat: What? Why?

puma-worker-killerのログが多いため、監視のタイミングを5秒から60秒に変更します。

#### :pushpin: Related Issues
- Related to #447

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
