### PR TITLE
refactor: change image upload size limit

### DIFF
--- a/app/uploaders/decidim/image_uploader.rb
+++ b/app/uploaders/decidim/image_uploader.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This class deals with uploading hero images to ParticipatoryProcesses.
+  class ImageUploader < ApplicationUploader
+    def validable_dimensions
+      true
+    end
+
+    def content_type_allowlist
+      extension_allowlist.map { |ext| "image/#{ext}" }
+    end
+
+    # Fetches info about different variants, their processors and dimensions
+    def dimensions_info
+      return if variants.blank?
+
+      variants.transform_values do |variant|
+        {
+          processor: variant.keys.first,
+          dimensions: variant.values.first
+        }
+      end
+    end
+
+    # Add a white list of extensions which are allowed to be uploaded.
+    # For images you might use something like this:
+    def extension_allowlist
+      Decidim.organization_settings(model).upload_allowed_file_extensions_image
+    end
+
+    def max_image_height_or_width
+      8000
+    end
+
+    private
+
+    def maximum_upload_size
+      Decidim.organization_settings(model).upload_maximum_file_size
+    end
+  end
+end
+

--- a/app/uploaders/decidim/image_uploader.rb
+++ b/app/uploaders/decidim/image_uploader.rb
@@ -40,4 +40,3 @@ module Decidim
     end
   end
 end
-


### PR DESCRIPTION
#### :tophat: What? Why?
画像のuploadの制限を緩くします
とりあえずはヒーロー画像と同じサイズまでは許容するように変更しました

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
