### PR TITLE
Fix comment_vote dependency

### DIFF
--- a/lib/tasks/comment.rake
+++ b/lib/tasks/comment.rake
@@ -2,6 +2,7 @@
 
 class CommentForMigration < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
   self.table_name = :decidim_comments_comments
+  has_many :votes, foreign_key: "decidim_comment_id", class_name: "CommentVote", dependent: :destroy
 end
 
 namespace :comment do

--- a/lib/tasks/comment.rake
+++ b/lib/tasks/comment.rake
@@ -17,8 +17,7 @@ namespace :comment do
 
         begin
           commentable_class = commentable_type.constantize
-          comment_obj = commentable_class.find(commentable_id)
-          puts "OK: #{comment.id}, #{comment_obj.class}(id: #{comment_obj.id})"
+          _comment_obj = commentable_class.find(commentable_id)
         rescue ActiveRecord::RecordNotFound, NameError
           puts "XXX Remove comment #{comment.id}"
           comment.destroy!

--- a/lib/tasks/comment.rake
+++ b/lib/tasks/comment.rake
@@ -2,7 +2,7 @@
 
 class CommentForMigration < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
   self.table_name = :decidim_comments_comments
-  has_many :votes, foreign_key: "decidim_comment_id", class_name: "CommentVote", dependent: :destroy
+  has_many :votes, foreign_key: "decidim_comment_id", class_name: "Decidim::Comments::CommentVote", dependent: :destroy
 end
 
 namespace :comment do


### PR DESCRIPTION
#### :tophat: What? Why?

#454 で追加したタスクですが、CommentVoteも合わせて消せるよう修正してみました。これでどうでしょうか？

合わせて正常にアクセスできたときにはログを残さないようにしてみました。

#### :pushpin: Related Issues
- Related to #454 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
