### PR TITLE
refactor: Move SlackChatMessenger to use in Decidim apps

### DIFF
--- a/config/initializers/slack.rb
+++ b/config/initializers/slack.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "slack-ruby-client"
+require_relative "../../lib/slack_chat_messenger"
 
 Slack.configure do |config|
   config.token = ENV["SLACK_API_TOKEN"]

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../lib/slack_chat_messenger"
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
@@ -19,17 +21,6 @@ environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
-
-class SlackChatMessenger
-  def self.notify(channel:, message:)
-    unless channel && message
-      Rails.logger.error "Cannot send messages to slack!"
-      return
-    end
-    client = Slack::Web::Client.new
-    client.chat_postMessage(channel: channel, text: message, as_user: true)
-  end
-end
 
 before_fork do
   PumaWorkerKiller.config do |config|

--- a/lib/slack_chat_messenger.rb
+++ b/lib/slack_chat_messenger.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SlackChatMessenger
+  def self.notify(channel:, message:)
+    unless channel && message
+      Rails.logger.error "Cannot send messages to slack!"
+      return
+    end
+    client = Slack::Web::Client.new
+    client.chat_postMessage(channel: channel, text: message, as_user: true)
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

現状では`SlackChatMessenger`はconfig/puma.rb内でしか使えないので、Decidim本体の好きなところから使えるようにlibに置くようにします。

config/puma.rb内でもrequire_relativeで読み込んでいるので、今まで通り使えます。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
