### PR TITLE
refactor: move CSS from editor.js

### DIFF
--- a/app/packs/src/decidim/decidim_awesome/editors/editor.js
+++ b/app/packs/src/decidim/decidim_awesome/editors/editor.js
@@ -40,66 +40,6 @@ export function destroyQuillEditor(container) {
 
 export function createQuillEditor(container) {
   // decidim-cfj custom start
-  function __createCSS() {
-    var css = document.createElement("style")
-    css.type = "text/css"
-    css.innerText = `
-.ql-html-overlayContainer {
-  background: #0000007d;
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 9999;
-}
-
-.ql-html-popupContainer {
-  background: #ddd;
-  position: absolute;
-  top: 5%;
-  left: 5%;
-  right: 5%;
-  bottom: 5%;
-  border-radius: 10px;
-}
-
-.ql-html-textContainer {
-  position: relative;
-  width: calc(100% - 40px);
-  height: calc(100% - 40px);
-  padding: 20px;
-}
-
-.ql-html-textArea {
-  background: #fff;
-  position: absolute;
-  left: 15px;
-  width: calc(100% - 45px);
-  height: calc(100% - 116px);
-}
-
-.ql-html-buttonCancel {
-  margin-right: 20px;
-}
-
-.ql-html-popupTitle {
-  margin: 0;
-  display: block;
-}
-
-.ql-html-buttonGroup {
-  position: absolute;
-  bottom: 20px;
-  transform: scale(1.5);
-  left: calc(50% - 60px);
-}
-        `;
-    document.head.appendChild(css);
-  }
-  __createCSS();
-
-
   function $create(elName) {
     return document.createElement(elName);
   }

--- a/app/packs/stylesheets/decidim/admin/application.scss
+++ b/app/packs/stylesheets/decidim/admin/application.scss
@@ -1,0 +1,22 @@
+@import "stylesheets/decidim/admin/decidim";
+@import "stylesheets/decidim/admin/extra/action-icon";
+@import "stylesheets/decidim/admin/extra/block_user";
+@import "stylesheets/decidim/admin/extra/cards";
+@import "stylesheets/decidim/admin/extra/categories";
+@import "stylesheets/decidim/admin/extra/dropdown_inverted";
+@import "stylesheets/decidim/admin/extra/editor";
+@import "stylesheets/decidim/admin/extra/email_preview";
+@import "stylesheets/decidim/admin/extra/label-required";
+@import "stylesheets/decidim/admin/extra/login";
+@import "stylesheets/decidim/admin/extra/logs";
+@import "stylesheets/decidim/admin/extra/newsletter-templates-gallery";
+@import "stylesheets/decidim/admin/extra/organization-appearance";
+@import "stylesheets/decidim/admin/extra/quill";
+@import "stylesheets/decidim/admin/extra/select_multiple";
+@import "stylesheets/decidim/admin/extra/show_email";
+@import "stylesheets/decidim/admin/extra/sort";
+@import "stylesheets/decidim/admin/extra/title_bar";
+
+// This imports all the Decidim module stylesheet imports registered at
+// `config/assets.rb` of the module for the "admin" group.
+@import "!decidim-style-imports[admin]";

--- a/app/packs/stylesheets/decidim/admin/application.scss
+++ b/app/packs/stylesheets/decidim/admin/application.scss
@@ -17,6 +17,8 @@
 @import "stylesheets/decidim/admin/extra/sort";
 @import "stylesheets/decidim/admin/extra/title_bar";
 
+@import "stylesheets/decidim/cfj/ql_html_editor";
+
 // This imports all the Decidim module stylesheet imports registered at
 // `config/assets.rb` of the module for the "admin" group.
 @import "!decidim-style-imports[admin]";

--- a/app/packs/stylesheets/decidim/cfj/ql_html_editor.scss
+++ b/app/packs/stylesheets/decidim/cfj/ql_html_editor.scss
@@ -1,0 +1,53 @@
+/*
+ * for Quill HTML Editor
+ */
+.ql-html-overlayContainer {
+  background: #0000007d;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9999;
+}
+
+.ql-html-popupContainer {
+  background: #ddd;
+  position: absolute;
+  top: 5%;
+  left: 5%;
+  right: 5%;
+  bottom: 5%;
+  border-radius: 10px;
+}
+
+.ql-html-textContainer {
+  position: relative;
+  width: calc(100% - 40px);
+  height: calc(100% - 40px);
+  padding: 20px;
+}
+
+.ql-html-textArea {
+  background: #fff;
+  position: absolute;
+  left: 15px;
+  width: calc(100% - 45px);
+  height: calc(100% - 116px);
+}
+
+.ql-html-buttonCancel {
+  margin-right: 20px;
+}
+
+.ql-html-popupTitle {
+  margin: 0;
+  display: block;
+}
+
+.ql-html-buttonGroup {
+  position: absolute;
+  bottom: 20px;
+  transform: scale(1.5);
+  left: calc(50% - 60px);
+}

--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -11,3 +11,4 @@
 @import "./cfj/forms";
 @import "./cfj/search";
 @import "./cfj/media_print";
+@import "./cfj/ql_html_editor";


### PR DESCRIPTION
#### :tophat: What? Why?

Quill EditorのHTMLボタン拡張について、JSファイル内でCSSを設定していた部分について、普通のCSSファイルに切り出してみます。見た目は変更ないはずです。

この拡張のJS部分についても後でもう少し整理したいと思っています（現状はdecidim_awesomeのファイルと混ざってしまっていて良くないので…）。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
