### PR TITLE
Fix old message for endorsement button

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -100,8 +100,6 @@ ja:
       authorizations:
         new:
           connect_your_account_html: "<strong>%{organization}</strong> にログインしてアカウントに接続します"
-    endorsement_buttons_cell:
-      already_endorsed: 支持済み
     errors:
       not_found:
         content_doesnt_exist: このアドレスは正しくないか削除されています。


### PR DESCRIPTION
#### :tophat: What? Why?

古い文言が残っていたので削除します。
これで「支持済み」が「オススメ済み」になります。

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask

### :camera: Screenshots (optional)

#### before

<img width="306" alt="before-button" src="https://user-images.githubusercontent.com/10401/204257575-332fc6c7-e7f9-4a36-961a-457b9566e441.png">

#### after

<img width="337" alt="after-button" src="https://user-images.githubusercontent.com/10401/204257632-a877ed29-f0f5-43f2-8f46-e8ac7c016d1d.png">
