### PR TITLE
`outro` in messaging should be empty

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -177,16 +177,22 @@ ja:
     messaging:
       conversation_mailer:
         comanagers_new_conversation:
+          greeting: "%{recipient}さん、こんにちは。"
           outro: ''
         comanagers_new_message:
+          greeting: "%{recipient}さん、こんにちは。"
           outro: ''
         new_conversation:
+          greeting: "%{recipient}さん、こんにちは。"
           outro: ''
         new_group_conversation:
+          greeting: "%{recipient}さん、こんにちは。"
           outro: ''
         new_group_message:
+          greeting: "%{recipient}さん、こんにちは。"
           outro: ''
         new_message:
+          greeting: "%{recipient}さん、こんにちは。"
           outro: ''
 
     moderations:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -174,6 +174,21 @@ ja:
           origin_values:
             citizens: 一般参加者
             official: 事務局
+    messaging:
+      conversation_mailer:
+        comanagers_new_conversation:
+          outro: ''
+        comanagers_new_message:
+          outro: ''
+        new_conversation:
+          outro: ''
+        new_group_conversation:
+          outro: ''
+        new_group_message:
+          outro: ''
+        new_message:
+          outro: ''
+
     moderations:
       actions:
         hidden: 非表示


### PR DESCRIPTION
#### :tophat: What? Why?

#36 の対応です。

`お楽しみください！`は`decidim.messaging.conversation_mailer.*.outro`というキーの値だったようなので、まとめて削除してみました。
合わせて「Hi, ○○○!」のところも「○○○さん、こんにちは。」に修正してみました。

#### :pushpin: Related Issues
- Fixes #36

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
<img width="615" alt="message" src="https://user-images.githubusercontent.com/10401/208298872-90e66666-21c8-4980-a6d2-50817049fee2.png">
