### PR TITLE
Add a spec for `Decidim::Proposals::ProposalWizardCreateStepForm`

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,6 +3,7 @@
 require "decidim/core/test/factories"
 require "decidim/cfj/test/factories"
 require "decidim/debates/test/factories"
+require "decidim/proposals/test/factories"
 
 FactoryBot.define do
   sequence(:valid_jwt) do |_n|

--- a/spec/forms/decidim/proposals/proposal_wizard_create_step_form_spec.rb
+++ b/spec/forms/decidim/proposals/proposal_wizard_create_step_form_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Decidim
+  module Proposals
+    describe ProposalWizardCreateStepForm do
+      subject { form }
+
+      let(:params) do
+        {
+          title: title,
+          body: body,
+          body_template: body_template,
+          user_group_id: user_group.id
+        }
+      end
+
+      let(:organization) { create(:organization) }
+      let(:participatory_space) { create(:participatory_process, :with_steps, organization: organization) }
+      let(:component) { create(:proposal_component, participatory_space: participatory_space) }
+      let(:title) { "More sidewalks and less roads" }
+      let(:body) { "Cities need more people, not more cars" }
+      let(:body_template) { nil }
+      let(:author) { create(:user, organization: organization) }
+      let(:user_group) { create(:user_group, :verified, users: [author], organization: organization) }
+
+      let(:form) do
+        described_class.from_params(params).with_context(
+          current_component: component,
+          current_organization: component.organization,
+          current_participatory_space: participatory_space
+        )
+      end
+
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when there's no title" do
+        let(:title) { nil }
+
+        it { is_expected.to be_invalid }
+
+        it "only adds errors to this field" do
+          subject.valid?
+          expect(subject.errors.keys).to eq [:title]
+        end
+      end
+
+      context "when the title is not long enough" do
+        let(:component) { create(:proposal_component, participatory_space: participatory_space) }
+        let(:title) { "A short title" }
+
+        context "with short title settings" do
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context "when there's no body" do
+        let(:body) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when the body exceeds the permited length" do
+        let(:component) { create(:proposal_component, :with_proposal_length, participatory_space: participatory_space, proposal_length: allowed_length) }
+        let(:allowed_length) { 15 }
+        let(:body) { "A body longer than the permitted" }
+
+        it { is_expected.to be_invalid }
+
+        context "with carriage return characters that cause it to exceed" do
+          let(:allowed_length) { 80 }
+          let(:body) { "This text is just the correct length\r\nwith the carriage return characters removed" }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
+      context "when there's a body template set" do
+        let(:body_template) { "This is the template" }
+
+        it { is_expected.to be_valid }
+
+        context "when the template and the body are the same" do
+          let(:body) { body_template }
+
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

#61 の対応に先立って、テストを追加します。

#### :pushpin: Related Issues
- Related to #61

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
