### PR TITLE
Add task `delete:destroy_all`

### DIFF
--- a/app/commands/decidim/accountability/destroy_all_results.rb
+++ b/app/commands/decidim/accountability/destroy_all_results.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Accountability
+    # A command with all the business logic when destroys all proposals.
+    class DestroyAllResults < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy all results.
+      def initialize(organization)
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the results and statsues is deleted.
+      #
+      # Returns nothing.
+      def call
+        Decidim::Accountability::Result.find_each do |result|
+          if result&.organization == organization
+            puts "destroy result id: #{result.id}, for component id: #{result.decidim_component_id}"
+            result.destroy!
+          end
+        end
+
+        Decidim::Accountability::Status.find_each do |status|
+          if status.organization == organization
+            puts "destroy status id: #{status.id}, for component id: #{status.decidim_component_id}"
+            status.destroy!
+          end
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization
+    end
+  end
+end

--- a/app/commands/decidim/areas/destroy_all_areas.rb
+++ b/app/commands/decidim/areas/destroy_all_areas.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Areas
+    # A command with all the business logic when destroys all areas.
+    class DestroyAllAreas < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy all areas.
+      def initialize(organization)
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the area is deleted.
+      #
+      # Returns nothing.
+      def call
+        Decidim::Area.find_each do |area|
+          if area.organization == organization
+            puts "destroy area id: #{area.id}"
+            area.destroy!
+          end
+        end
+
+        Decidim::AreaType.find_each do |area_type|
+          if area_type.organization == organization
+            puts "destroy area_type id: #{area_type.id}"
+            area_type.destroy!
+          end
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization
+    end
+  end
+end

--- a/app/commands/decidim/assemblies/destroy_all_assemblies.rb
+++ b/app/commands/decidim/assemblies/destroy_all_assemblies.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Assemblies
+    # A command with all the business logic when destroys all assemblies.
+    class DestroyAllAssemblies < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy all assemblies.
+      def initialize(organization)
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the assembly is deleted.
+      #
+      # Returns nothing.
+      def call
+        Decidim::Assembly.where(organization: organization).find_each do |assembly|
+          puts "destroy assembly id: #{assembly.id}"
+          assembly.destroy!
+        end
+        Decidim::AssembliesType.where(organization: organization).destroy_all
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization
+    end
+  end
+end

--- a/app/commands/decidim/blogs/destroy_all_posts.rb
+++ b/app/commands/decidim/blogs/destroy_all_posts.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Blogs
+    # A command with all the business logic when destroys all posts.
+    class DestroyAllPosts < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy all posts.
+      def initialize(organization)
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the post is deleted.
+      #
+      # Returns nothing.
+      def call
+        Decidim::Blogs::Post.find_each do |post|
+          if post.organization == organization
+            puts "destroy post id: #{post.id}, for component id: #{post.decidim_component_id}"
+            post.destroy!
+          end
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization
+    end
+  end
+end

--- a/app/commands/decidim/budgets/destroy_all_budgets.rb
+++ b/app/commands/decidim/budgets/destroy_all_budgets.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Budgets
+    # A command with all the business logic when destroys all budgets.
+    class DestroyAllBudgets < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy all budgets.
+      def initialize(organization)
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the budget is deleted.
+      #
+      # Returns nothing.
+      def call
+        Decidim::Budgets::Budget.find_each do |budget|
+          if budget.organization == organization
+            puts "destroy budget id: #{budget.id}, for component id: #{budget.decidim_component_id}"
+            budget.destroy!
+          end
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization
+    end
+  end
+end

--- a/app/commands/decidim/comments/destroy_all_comments.rb
+++ b/app/commands/decidim/comments/destroy_all_comments.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Comments
+    # A command with all the business logic to destroy a comment
+    class DestroyAllComments < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy all comments.
+      def initialize(organization)
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      #
+      # Returns nothing.
+      def call
+        Decidim::Comments::Comment.find_each do |comment|
+          if comment.organization == organization
+            puts "destroy comment id: #{comment.id}, for #{comment.decidim_root_commentable_type}:#{comment.decidim_root_commentable_id}"
+            comment.destroy!
+          end
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization
+    end
+  end
+end

--- a/app/commands/decidim/debates/destroy_all_debates.rb
+++ b/app/commands/decidim/debates/destroy_all_debates.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Debates
+    # A command with all the business logic when destroys all debates.
+    class DestroyAllDebates < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy all debates.
+      def initialize(organization)
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the debate is deleted.
+      #
+      # Returns nothing.
+      def call
+        Decidim::Debates::Debate.find_each do |debate|
+          if debate.organization == organization
+            puts "destroy debate id: #{debate.id}, for component id: #{debate.decidim_component_id}"
+            debate.destroy!
+          end
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization
+    end
+  end
+end

--- a/app/commands/decidim/destroy_all_attachments.rb
+++ b/app/commands/decidim/destroy_all_attachments.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A command with all the business logic when destroys all proposals.
+  class DestroyAllAttachments < Rectify::Command
+    # Public: Initializes the command.
+    #
+    # organization - The organization to destroy all results.
+    def initialize(organization)
+      @organization = organization
+    end
+
+    # Executes the command. Broadcasts these events:
+    #
+    # - :ok when everything is valid and the results and statsues is deleted.
+    #
+    # Returns nothing.
+    def call
+      Decidim::Attachment.find_each do |attachment|
+        if attachment.organization == organization
+          puts "destroy attachment id: #{attachment.id}, for #{attachment.attached_to_type}:#{attachment.attached_to_id}"
+          attachment.file.purge
+          attachment.destroy!
+        end
+      end
+
+      broadcast(:ok)
+    end
+
+    private
+
+    attr_reader :organization
+  end
+end

--- a/app/commands/decidim/gamifications/destroy_all_badges.rb
+++ b/app/commands/decidim/gamifications/destroy_all_badges.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Gamifications
+    # A command with all the business logic when destroys all meetings.
+    class DestroyAllBadges < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy all meetings.
+      def initialize(organization, user)
+        @organization = organization
+        @user = user
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the meeting is deleted.
+      #
+      # Returns nothing.
+      def call
+        if user.organization == organization
+          Decidim::Gamification::BadgeScore.where(user: user).find_each do |badge_score|
+            puts "destroy badge_score id: #{badge_score.id}, badge_name: #{badge_score.badge_name}"
+            badge_score.destroy!
+          end
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization, :user
+    end
+  end
+end

--- a/app/commands/decidim/meetings/destroy_all_meetings.rb
+++ b/app/commands/decidim/meetings/destroy_all_meetings.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    # A command with all the business logic when destroys all meetings.
+    class DestroyAllMeetings < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy all meetings.
+      def initialize(organization)
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the meeting is deleted.
+      #
+      # Returns nothing.
+      def call
+        Decidim::Meetings::Meeting.find_each do |meeting|
+          if meeting.organization == organization
+            puts "destroy meeting id: #{meeting.id}, for component id: #{meeting.decidim_component_id}"
+            meeting.destroy!
+          end
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization
+    end
+  end
+end

--- a/app/commands/decidim/messaging/destroy_all_messages.rb
+++ b/app/commands/decidim/messaging/destroy_all_messages.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Messaging
+    # A command with all the business logic when destroys all meetings.
+    class DestroyAllMessages < Rectify::Command
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the message is deleted.
+      #
+      # Returns nothing.
+      def call
+        Decidim::Messaging::Receipt.find_each do |receipt|
+          if receipt.recipient.nil?
+            puts "destroy receipt id: #{receipt.id}"
+            receipt.destroy!
+          end
+        end
+
+        Decidim::Messaging::Message.find_each do |message|
+          if message.sender.nil? && message.receipts.empty?
+            puts "destroy message id: #{message.id}"
+            message.destroy!
+          end
+        end
+
+        Decidim::Messaging::Participation.find_each do |participation|
+          if participation.participant.nil?
+            puts "destroy participation id: #{participation.id}"
+            participation.destroy!
+          end
+        end
+
+        Decidim::Messaging::Conversation.find_each do |conversation|
+          if conversation.participations.empty? && conversation.messages.empty?
+            puts "destroy conversation id: #{conversation.id}"
+            conversation.destroy!
+          end
+        end
+
+        broadcast(:ok)
+      end
+    end
+  end
+end

--- a/app/commands/decidim/organizations/destroy_organization.rb
+++ b/app/commands/decidim/organizations/destroy_organization.rb
@@ -24,6 +24,8 @@ module Decidim
           end
         end
 
+        Decidim::ActionLog.where(organization: organization).delete_all
+
         organization.destroy!
 
         broadcast(:ok)

--- a/app/commands/decidim/organizations/destroy_organization.rb
+++ b/app/commands/decidim/organizations/destroy_organization.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Organizations
+    # A command with all the business logic when destroys organization.
+    class DestroyOrganization < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy.
+      def initialize(organization)
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the organization is deleted.
+      #
+      # Returns nothing.
+      def call
+        Decidim::DecidimAwesome::AwesomeConfig.find_each do |awesome_config|
+          if awesome_config.organization == organization
+            puts "destroy awesome_config id: #{awesome_config.id}"
+            awesome_config.destroy!
+          end
+        end
+
+        organization.destroy!
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization
+    end
+  end
+end

--- a/app/commands/decidim/pages/destroy_all_pages.rb
+++ b/app/commands/decidim/pages/destroy_all_pages.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Pages
+    # A command with all the business logic when destroys all pages.
+    class DestroyAllPages < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy all pages.
+      def initialize(organization)
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the page is deleted.
+      #
+      # Returns nothing.
+      def call
+        Decidim::Pages::Page.find_each do |page|
+          if page.organization == organization
+            puts "destroy page id: #{page.id}, for component id: #{page.decidim_component_id}"
+            page.destroy!
+          end
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization
+    end
+  end
+end

--- a/app/commands/decidim/participatory_processes/destroy_all_participatory_processes.rb
+++ b/app/commands/decidim/participatory_processes/destroy_all_participatory_processes.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    # A command with all the business logic when destroys all participatory_processes.
+    class DestroyAllParticipatoryProcesses < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy all participatory_processes.
+      def initialize(organization)
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the participatory_process is deleted.
+      #
+      # Returns nothing.
+      def call
+        Decidim::ParticipatoryProcess.where(organization: organization).find_each do |participatory_process|
+          puts "destroy participatory_process id: #{participatory_process.id}"
+          participatory_process.destroy!
+        end
+        Decidim::ParticipatoryProcessGroup.where(organization: organization).find_each do |participatory_process_group|
+          puts "destroy participatory_process_group id: #{participatory_process_group.id}"
+          participatory_process_group.destroy!
+        end
+        Decidim::ContentBlock.where(organization: organization).destroy_all
+        Decidim::Scope.where(organization: organization).destroy_all
+        Decidim::ScopeType.where(organization: organization).destroy_all
+        Decidim::StaticPage.where(organization: organization).destroy_all
+        Decidim::StaticPageTopic.where(organization: organization).destroy_all
+        Decidim::SearchableResource.where(organization: organization).destroy_all
+        Decidim::ContextualHelpSection.where(organization: organization).destroy_all
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization
+    end
+  end
+end

--- a/app/commands/decidim/participatory_processes/destroy_all_participatory_processes.rb
+++ b/app/commands/decidim/participatory_processes/destroy_all_participatory_processes.rb
@@ -28,7 +28,7 @@ module Decidim
         Decidim::ContentBlock.where(organization: organization).destroy_all
         Decidim::Scope.where(organization: organization).destroy_all
         Decidim::ScopeType.where(organization: organization).destroy_all
-        Decidim::StaticPage.where(organization: organization).destroy_all
+        Decidim::StaticPage.where(organization: organization).delete_all ## some static_pages are not removed by `destroy_all`
         Decidim::StaticPageTopic.where(organization: organization).destroy_all
         Decidim::SearchableResource.where(organization: organization).destroy_all
         Decidim::ContextualHelpSection.where(organization: organization).destroy_all

--- a/app/commands/decidim/proposals/destroy_all_proposals.rb
+++ b/app/commands/decidim/proposals/destroy_all_proposals.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    # A command with all the business logic when destroys all proposals.
+    class DestroyAllProposals < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy all proposals.
+      def initialize(organization)
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the proposal is deleted.
+      #
+      # Returns nothing.
+      def call
+        Decidim::Proposals::Proposal.find_each do |proposal|
+          if proposal.organization == organization
+            puts "destroy proposal id: #{proposal.id}, for component id: #{proposal.decidim_component_id}"
+            proposal.destroy!
+          end
+        end
+
+        Decidim::Proposals::CollaborativeDraft.find_each do |draft|
+          if draft.organization == organization
+            puts "destroy collaborative draft id: #{draft.id}, for component id: #{draft.decidim_component_id}"
+            draft.destroy!
+          end
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization
+    end
+  end
+end

--- a/app/commands/decidim/proposals/destroy_all_proposals.rb
+++ b/app/commands/decidim/proposals/destroy_all_proposals.rb
@@ -19,6 +19,10 @@ module Decidim
       def call
         Decidim::Proposals::Proposal.find_each do |proposal|
           if proposal.organization == organization
+            proposal.amendments.each do |amendment|
+              puts "destroy amendment id: #{amendment.id}"
+              amendment.destroy!
+            end
             puts "destroy proposal id: #{proposal.id}, for component id: #{proposal.decidim_component_id}"
             proposal.destroy!
           end

--- a/app/commands/decidim/surveys/destroy_all_surveys.rb
+++ b/app/commands/decidim/surveys/destroy_all_surveys.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Surveys
+    # A command with all the business logic when destroys all surveys.
+    class DestroyAllSurveys < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # organization - The organization to destroy all surveys.
+      def initialize(organization)
+        @organization = organization
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid and the survey is deleted.
+      #
+      # Returns nothing.
+      def call
+        Decidim::Surveys::Survey.find_each do |survey|
+          if survey.organization == organization
+            puts "destroy survey id: #{survey.id}, for component id: #{survey.decidim_component_id}"
+            survey.destroy!
+          end
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :organization
+    end
+  end
+end

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -15,7 +15,10 @@ namespace :delete do
     :destroy_all_surveys,
     :destroy_all_assemblies,
     :destroy_all_participatory_processes,
-    :destroy_all_users
+    :destroy_all_areas,
+    :destroy_all_users,
+    :destroy_organization,
+    :destroy_all_messages
   ]
 
   desc "Destroy all comments for a given organization"
@@ -186,6 +189,20 @@ namespace :delete do
     puts "Finish destroy_all_participatory_processes of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
   end
 
+  desc "Destroy all areas for a given organization"
+  task destroy_all_areas: :environment do
+    puts "Start destroy_all_areas of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = decidim_find_organization
+    return unless organization
+
+    Decidim::Area.transaction do
+      Decidim::Areas::DestroyAllAreas.call(organization)
+    end
+
+    puts "Finish destroy_all_areas of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
   desc "Destroy all users for a given organization"
   task destroy_all_users: :environment do
     puts "Start destroy_all_users of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
@@ -204,6 +221,31 @@ namespace :delete do
     end
 
     puts "Finish destroy_all_users of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
+  desc "Destroy a given organization"
+  task destroy_organization: :environment do
+    puts "Start destroy_organization of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = decidim_find_organization
+    return unless organization
+
+    Decidim::Organization.transaction do
+      Decidim::Organizations::DestroyOrganization.call(organization)
+    end
+
+    puts "Finish destroy_organization of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
+  desc "Destroy all messages for a given organization"
+  task destroy_all_messages: :environment do
+    puts "Start destroy_all_messages"
+
+    Decidim::Messaging::Message.transaction do
+      Decidim::Messaging::DestroyAllMessages.call
+    end
+
+    puts "Finish destroy_all_messages"
   end
 end
 

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 namespace :delete do
+  desc "Destroy all components for a given organization"
+  task destroy_all: [:destroy_all_comments, :destroy_all_budgets, :destroy_all_proposals, :destroy_all_blogs, :destroy_all_debates, :destroy_all_meetings, :destroy_all_pages]
+
   desc "Destroy all comments for a given organization"
   task destroy_all_comments: :environment do
     puts "Start destroy_all_comments of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
@@ -18,5 +21,119 @@ namespace :delete do
     end
 
     puts "Finish destroy_all_comments of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
+  desc "Destroy all budgets for a given organization"
+  task destroy_all_budgets: :environment do
+    puts "Start destroy_all_budgets of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
+
+    unless organization
+      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
+      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_budgets"
+      return
+    end
+
+    Decidim::Budgets::Budget.transaction do
+      Decidim::Budgets::DestroyAllBudgets.call(organization)
+    end
+
+    puts "Finish destroy_all_budgets of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
+  desc "Destroy all proposals for a given organization"
+  task destroy_all_proposals: :environment do
+    puts "Start destroy_all_proposals of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
+
+    unless organization
+      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
+      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_proposals"
+      return
+    end
+
+    Decidim::Proposals::Proposal.transaction do
+      Decidim::Proposals::DestroyAllProposals.call(organization)
+    end
+
+    puts "Finish destroy_all_proposals of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
+  desc "Destroy all blogs for a given organization"
+  task destroy_all_blogs: :environment do
+    puts "Start destroy_all_blogs of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
+
+    unless organization
+      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
+      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_blogs"
+      return
+    end
+
+    Decidim::Blogs::Post.transaction do
+      Decidim::Blogs::DestroyAllPosts.call(organization)
+    end
+
+    puts "Finish destroy_all_blogs of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
+  desc "Destroy all debates for a given organization"
+  task destroy_all_debates: :environment do
+    puts "Start destroy_all_debates of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
+
+    unless organization
+      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
+      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_debates"
+      return
+    end
+
+    Decidim::Debates::Debate.transaction do
+      Decidim::Debates::DestroyAllDebates.call(organization)
+    end
+
+    puts "Finish destroy_all_debates of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
+  desc "Destroy all meetings for a given organization"
+  task destroy_all_meetings: :environment do
+    puts "Start destroy_all_meetings of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
+
+    unless organization
+      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
+      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_meetings"
+      return
+    end
+
+    Decidim::Meetings::Meeting.transaction do
+      Decidim::Meetings::DestroyAllMeetings.call(organization)
+    end
+
+    puts "Finish destroy_all_meetings of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
+  desc "Destroy all pages for a given organization"
+  task destroy_all_pages: :environment do
+    puts "Start destroy_all_pages of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
+
+    unless organization
+      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
+      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_pages"
+      return
+    end
+
+    Decidim::Pages::Page.transaction do
+      Decidim::Pages::DestroyAllPages.call(organization)
+    end
+
+    puts "Finish destroy_all_pages of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
   end
 end

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -11,14 +11,18 @@ namespace :delete do
     :destroy_all_blogs,
     :destroy_all_debates,
     :destroy_all_meetings,
-    :destroy_all_pages
+    :destroy_all_pages,
+    :destroy_all_surveys,
+    :destroy_all_assemblies,
+    :destroy_all_participatory_processes,
+    :destroy_all_users
   ]
 
   desc "Destroy all comments for a given organization"
   task destroy_all_comments: :environment do
     puts "Start destroy_all_comments of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = decidim_find_organization()
+    organization = decidim_find_organization
     return unless organization
 
     Decidim::Comments::Comment.transaction do
@@ -32,7 +36,7 @@ namespace :delete do
   task destroy_all_accountability: :environment do
     puts "Start destroy_all_accountability of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = decidim_find_organization()
+    organization = decidim_find_organization
     return unless organization
 
     Decidim::Accountability::Result.transaction do
@@ -46,7 +50,7 @@ namespace :delete do
   task destroy_all_attachments: :environment do
     puts "Start destroy_all_attachments of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = decidim_find_organization()
+    organization = decidim_find_organization
     return unless organization
 
     Decidim::Attachment.transaction do
@@ -60,7 +64,7 @@ namespace :delete do
   task destroy_all_budgets: :environment do
     puts "Start destroy_all_budgets of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = decidim_find_organization()
+    organization = decidim_find_organization
     return unless organization
 
     Decidim::Budgets::Budget.transaction do
@@ -74,7 +78,7 @@ namespace :delete do
   task destroy_all_proposals: :environment do
     puts "Start destroy_all_proposals of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = decidim_find_organization()
+    organization = decidim_find_organization
     return unless organization
 
     Decidim::Proposals::Proposal.transaction do
@@ -88,7 +92,7 @@ namespace :delete do
   task destroy_all_blogs: :environment do
     puts "Start destroy_all_blogs of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = decidim_find_organization()
+    organization = decidim_find_organization
     return unless organization
 
     Decidim::Blogs::Post.transaction do
@@ -102,7 +106,7 @@ namespace :delete do
   task destroy_all_debates: :environment do
     puts "Start destroy_all_debates of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = decidim_find_organization()
+    organization = decidim_find_organization
     return unless organization
 
     Decidim::Debates::Debate.transaction do
@@ -116,7 +120,7 @@ namespace :delete do
   task destroy_all_meetings: :environment do
     puts "Start destroy_all_meetings of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = decidim_find_organization()
+    organization = decidim_find_organization
     return unless organization
 
     Decidim::Meetings::Meeting.transaction do
@@ -130,7 +134,7 @@ namespace :delete do
   task destroy_all_pages: :environment do
     puts "Start destroy_all_pages of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = decidim_find_organization()
+    organization = decidim_find_organization
     return unless organization
 
     Decidim::Pages::Page.transaction do
@@ -139,11 +143,73 @@ namespace :delete do
 
     puts "Finish destroy_all_pages of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
   end
+
+  desc "Destroy all surveys for a given organization"
+  task destroy_all_surveys: :environment do
+    puts "Start destroy_all_surveys of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = decidim_find_organization
+    return unless organization
+
+    Decidim::Surveys::Survey.transaction do
+      Decidim::Surveys::DestroyAllSurveys.call(organization)
+    end
+
+    puts "Finish destroy_all_surveys of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
+  desc "Destroy all assemblies for a given organization"
+  task destroy_all_assemblies: :environment do
+    puts "Start destroy_all_assemblies of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = decidim_find_organization
+    return unless organization
+
+    Decidim::Assembly.transaction do
+      Decidim::Assemblies::DestroyAllAssemblies.call(organization)
+    end
+
+    puts "Finish destroy_all_assemblies of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
+  desc "Destroy all participatory_processes for a given organization"
+  task destroy_all_participatory_processes: :environment do
+    puts "Start destroy_all_participatory_processes of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = decidim_find_organization
+    return unless organization
+
+    Decidim::ParticipatoryProcess.transaction do
+      Decidim::ParticipatoryProcesses::DestroyAllParticipatoryProcesses.call(organization)
+    end
+
+    puts "Finish destroy_all_participatory_processes of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
+  desc "Destroy all users for a given organization"
+  task destroy_all_users: :environment do
+    puts "Start destroy_all_users of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = decidim_find_organization
+    return unless organization
+
+    Decidim::User.transaction do
+      form = OpenStruct.new(valid?: true, delete_reason: "Testing")
+      Decidim::User.where(organization: organization).find_each do |user|
+        Decidim::Gamifications::DestroyAllBadges.call(organization, user)
+        Decidim::Authorization.where(user: user).destroy_all
+        puts "destroy user id: #{user.id}"
+        Decidim::DestroyAccount.call(user, form)
+      end
+    end
+
+    puts "Finish destroy_all_users of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
 end
 
 private
 
-def decidim_find_organization()
+def decidim_find_organization
   organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
 
   unless organization
@@ -154,4 +220,3 @@ def decidim_find_organization()
 
   organization
 end
-

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -2,7 +2,16 @@
 
 namespace :delete do
   desc "Destroy all components for a given organization"
-  task destroy_all: [:destroy_all_comments, :destroy_all_budgets, :destroy_all_proposals, :destroy_all_blogs, :destroy_all_debates, :destroy_all_meetings, :destroy_all_pages]
+  task destroy_all: [
+    :destroy_all_comments,
+    :destroy_all_accountability,
+    :destroy_all_budgets,
+    :destroy_all_proposals,
+    :destroy_all_blogs,
+    :destroy_all_debates,
+    :destroy_all_meetings,
+    :destroy_all_pages
+  ]
 
   desc "Destroy all comments for a given organization"
   task destroy_all_comments: :environment do
@@ -21,6 +30,25 @@ namespace :delete do
     end
 
     puts "Finish destroy_all_comments of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
+  desc "Destroy all accountability for a given organization"
+  task destroy_all_accountability: :environment do
+    puts "Start destroy_all_accountability of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
+
+    unless organization
+      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
+      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_accountability"
+      return
+    end
+
+    Decidim::Accountability::Result.transaction do
+      Decidim::Accountability::DestroyAllResults.call(organization)
+    end
+
+    puts "Finish destroy_all_accountability of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
   end
 
   desc "Destroy all budgets for a given organization"

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -18,13 +18,8 @@ namespace :delete do
   task destroy_all_comments: :environment do
     puts "Start destroy_all_comments of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
-
-    unless organization
-      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
-      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_comments"
-      return
-    end
+    organization = decidim_find_organization()
+    return unless organization
 
     Decidim::Comments::Comment.transaction do
       Decidim::Comments::DestroyAllComments.call(organization)
@@ -37,13 +32,8 @@ namespace :delete do
   task destroy_all_accountability: :environment do
     puts "Start destroy_all_accountability of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
-
-    unless organization
-      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
-      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_accountability"
-      return
-    end
+    organization = decidim_find_organization()
+    return unless organization
 
     Decidim::Accountability::Result.transaction do
       Decidim::Accountability::DestroyAllResults.call(organization)
@@ -56,13 +46,8 @@ namespace :delete do
   task destroy_all_attachments: :environment do
     puts "Start destroy_all_attachments of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
-
-    unless organization
-      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
-      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_attachments"
-      return
-    end
+    organization = decidim_find_organization()
+    return unless organization
 
     Decidim::Attachment.transaction do
       Decidim::DestroyAllAttachments.call(organization)
@@ -75,13 +60,8 @@ namespace :delete do
   task destroy_all_budgets: :environment do
     puts "Start destroy_all_budgets of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
-
-    unless organization
-      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
-      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_budgets"
-      return
-    end
+    organization = decidim_find_organization()
+    return unless organization
 
     Decidim::Budgets::Budget.transaction do
       Decidim::Budgets::DestroyAllBudgets.call(organization)
@@ -94,13 +74,8 @@ namespace :delete do
   task destroy_all_proposals: :environment do
     puts "Start destroy_all_proposals of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
-
-    unless organization
-      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
-      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_proposals"
-      return
-    end
+    organization = decidim_find_organization()
+    return unless organization
 
     Decidim::Proposals::Proposal.transaction do
       Decidim::Proposals::DestroyAllProposals.call(organization)
@@ -113,13 +88,8 @@ namespace :delete do
   task destroy_all_blogs: :environment do
     puts "Start destroy_all_blogs of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
-
-    unless organization
-      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
-      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_blogs"
-      return
-    end
+    organization = decidim_find_organization()
+    return unless organization
 
     Decidim::Blogs::Post.transaction do
       Decidim::Blogs::DestroyAllPosts.call(organization)
@@ -132,13 +102,8 @@ namespace :delete do
   task destroy_all_debates: :environment do
     puts "Start destroy_all_debates of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
-
-    unless organization
-      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
-      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_debates"
-      return
-    end
+    organization = decidim_find_organization()
+    return unless organization
 
     Decidim::Debates::Debate.transaction do
       Decidim::Debates::DestroyAllDebates.call(organization)
@@ -151,13 +116,8 @@ namespace :delete do
   task destroy_all_meetings: :environment do
     puts "Start destroy_all_meetings of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
-
-    unless organization
-      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
-      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_meetings"
-      return
-    end
+    organization = decidim_find_organization()
+    return unless organization
 
     Decidim::Meetings::Meeting.transaction do
       Decidim::Meetings::DestroyAllMeetings.call(organization)
@@ -170,13 +130,8 @@ namespace :delete do
   task destroy_all_pages: :environment do
     puts "Start destroy_all_pages of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
 
-    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
-
-    unless organization
-      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
-      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_pages"
-      return
-    end
+    organization = decidim_find_organization()
+    return unless organization
 
     Decidim::Pages::Page.transaction do
       Decidim::Pages::DestroyAllPages.call(organization)
@@ -185,3 +140,18 @@ namespace :delete do
     puts "Finish destroy_all_pages of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
   end
 end
+
+private
+
+def decidim_find_organization()
+  organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
+
+  unless organization
+    puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
+    puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_pages"
+    return
+  end
+
+  organization
+end
+

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -4,6 +4,7 @@ namespace :delete do
   desc "Destroy all components for a given organization"
   task destroy_all: [
     :destroy_all_comments,
+    :destroy_all_attachments,
     :destroy_all_accountability,
     :destroy_all_budgets,
     :destroy_all_proposals,
@@ -49,6 +50,25 @@ namespace :delete do
     end
 
     puts "Finish destroy_all_accountability of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+
+  desc "Destroy all attachments for a given organization"
+  task destroy_all_attachments: :environment do
+    puts "Start destroy_all_attachments of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
+
+    unless organization
+      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
+      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_attachments"
+      return
+    end
+
+    Decidim::Attachment.transaction do
+      Decidim::DestroyAllAttachments.call(organization)
+    end
+
+    puts "Finish destroy_all_attachments of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
   end
 
   desc "Destroy all budgets for a given organization"

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+namespace :delete do
+  desc "Destroy all comments for a given organization"
+  task destroy_all_comments: :environment do
+    puts "Start destroy_all_comments of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+
+    organization = Decidim::Organization.find_by(name: ENV["DECIDIM_ORGANIZATION_NAME"])
+
+    unless organization
+      puts "Organization not found: '#{ENV["DECIDIM_ORGANIZATION_NAME"]}'"
+      puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all_comments"
+      return
+    end
+
+    Decidim::Comments::Comment.transaction do
+      Decidim::Comments::DestroyAllComments.call(organization)
+    end
+
+    puts "Finish destroy_all_comments of #{ENV["DECIDIM_ORGANIZATION_NAME"]}"
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

指定したorganizationのコメントその他をまとめて削除するタスクを追加します。
安全側に倒して個別に削除しているためそれなりの時間がかかるかもです。

#### 使い方

rakeタスクとして`delete:destroy_all`を指定します。
その際、削除対象のorganizationの名前を`DECIDIM_ORGANIZATION_NAME`で指定します。何も指定しない場合、組織が存在しない場合はエラーが出て終了します。

```console
DECIDIM_ORGANIZATION_NAME="組織名" bin/rails delete:destroy_all
```

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
