### PR TITLE
提案とコメントの並び順の項目名を変更

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -72,6 +72,12 @@ ja:
             does_not_belong: 違法行為、個人情報、または %{organization_name} に属していないと思われる内容が含まれています。
             offensive: 差別的な内容、誹謗中傷などの不適切な内容が含まれています。
             spam: 本来の内容に関係が無い広告、詐欺や悪意のある処理などが含まれています。
+      comment_order_selector:
+        order:
+          best_rated: 評価の高い順
+          most_discussed: 議論数の多い順
+          older: 古い順
+          recent: 新しい順
       down_vote_button:
         text: このコメントに同意しません
     debates:
@@ -295,6 +301,15 @@ ja:
           origin: 起案者
         index:
           collaborative_drafts_list: 共同草案にアクセスする
+        orders:
+          label: '提案の並び順：'
+          most_commented: コメントの多い順
+          most_endorsed: オススメの多い順
+          most_followed: フォローの多い順
+          most_voted: サポートの多い順
+          random: ランダム
+          recent: 新しい順
+          with_more_authors: 起案者の多い順
         show:
           link_to_collaborative_draft_help_text: この提案は共同草案の結果です。履歴を確認してください
           link_to_collaborative_draft_text: 共同草案を見る


### PR DESCRIPTION
#### :tophat: What? Why?

コメントのソート順と提案のソート順について、並び順の名前に統一感がなかったため変えてみます。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

#### 提案

<img width="341" alt="提案の並び順" src="https://user-images.githubusercontent.com/10401/217859904-ade22494-396a-4a22-9c9c-265a0ae7b3a0.png">

#### コメント

<img width="302" alt="コメントの並び順" src="https://user-images.githubusercontent.com/10401/217860181-998ba469-a3c7-4ab0-a074-e7c0b02cda12.png">


