### PR TITLE
Fix markers in dynamic_map

### DIFF
--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -35,4 +35,29 @@ Rails.application.config.to_prepare do
       end
     end
   end
+
+  module Decidim
+    module Map
+      class DynamicMap < Map::Frontend
+        class Builder < Decidim::Map::Frontend::Builder
+          # Overwrite
+          def map_element(html_options = {})
+            opts = view_options
+            opts["markers"] = opts["markers"].reject { |item| item[:latitude].nil? || item[:latitude].nan? } if opts["markers"].present?
+            map_html_options = {
+              "data-decidim-map" => opts.to_json,
+              # The data-markers-data is kept for backwards compatibility
+              "data-markers-data" => opts.fetch(:markers, []).to_json
+            }.merge(html_options)
+
+            content = template.capture { yield }.html_safe if block_given?
+
+            template.content_tag(:div, map_html_options) do
+              (content || "")
+            end
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

DynamicMapの地図を表示する際、マーカーが表示されないことがあるのを修正します。

問題を起こす挙動というか最終的な原因自体はあまり把握できていないのですが、マーカーの情報として緯度・経度が空（nil or NaN）の値が渡ってくる場合があるようで、その場合に問題が生じるようでした。
そのため、`Decidim::Map::DynamicMap::Builder#map_element`でそういったデータが含まれていた場合、除去する処理を加えています。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

#### Before

<img width="1288" alt="map-before" src="https://user-images.githubusercontent.com/10401/224304294-75063fa2-6c5d-4229-b6a6-fbfcb2c5087e.png">

#### After

<img width="1201" alt="map-after" src="https://user-images.githubusercontent.com/10401/224304327-91f72bfb-226d-40dc-8a2b-eeead5346c2e.png">

