### PR TITLE
docs: db:reset when db:seed failed

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -93,6 +93,12 @@ docker-compose run --rm app ./bin/rails db:create db:migrate
 docker-compose run --rm app ./bin/rails db:seed
 ```
 
+`db:seed`でエラーが起きた場合、ダミーのデータ作成に失敗している可能性があります。以下を実行し、DBを再作成してみてください。
+
+```
+docker-compose run --rm app ./bin/rails db:reset
+```
+
 ### 3.5 サーバー起動
 ```
 docker-compose up -d


### PR DESCRIPTION
#### :tophat: What? Why?

DEVELOPMENT.mdにあるdocker-composeを試してみたところ、db:seedを実行するところで下記のようなエラーが出たのでdb:resetする流れを追記してみます。

```
rails aborted!
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_decidim_users_on_nickame_and_decidim_organization_id"
DETAIL:  Key (nickname, decidim_organization_id)=(foster, 1) already exists.
```

（本家のseedの書き方が問題ありそう…）

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
