### PR TITLE
Do not allow admin_accountability in DecidimAwesome

### DIFF
--- a/config/initializers/decidim_awesome.rb
+++ b/config/initializers/decidim_awesome.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Decidim::DecidimAwesome.configure do |config|
+  config.admin_accountability = []
+end


### PR DESCRIPTION
#### :tophat: What? Why?

DecidimAwesomeの`admin_accountability`がいまいちなのでいったん使えないようにしておきます。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

「管理者のアカウンタビリティ」をクリックすると以下のようなメッセージが出てエラーになります。

<img width="574" alt="admin_accountabilitiy_disabled" src="https://user-images.githubusercontent.com/10401/232442479-d8ef808f-c967-4e54-9588-6c41ff51aad7.png">

