### PR TITLE
GA: Use imagemagick7 in local binary

### DIFF
--- a/.github/workflows/rails-test.yml
+++ b/.github/workflows/rails-test.yml
@@ -50,7 +50,8 @@ jobs:
 
     - name: check imagemagick
       run: |
-        export PATH=${GITHUB_WORKSPACE}/vendor/imagemagick7/bin/magick:${PATH}
+        export PATH=${GITHUB_WORKSPACE}/vendor/imagemagick7/bin:${PATH}
+        which convert
         convert -version
 
     - name: Set up Ruby 2.7

--- a/.github/workflows/rails-test.yml
+++ b/.github/workflows/rails-test.yml
@@ -46,36 +46,12 @@ jobs:
     - name: apt-get
       run: |
         sudo apt-get update -y
-        sudo apt-get -yqq install libpq-dev postgresql-client
+        sudo apt-get -yqq install libpq-dev postgresql-client libfuse2
 
-    - name: remove imagemagick 6
-      run: sudo apt remove imagemagick
-    - name: setup imagemagick 7
-      run: |
-          sudo sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
-          sudo apt update
-          sudo apt install build-essential
-          sudo apt build-dep imagemagick
-          sudo apt install libwebp-dev libopenjp2-7-dev librsvg2-dev libde265-dev
-    - name: install libheif
-      run: |
-          git clone https://github.com/strukturag/libheif.git
-          cd libheif
-          ./autogen.sh
-          ./configure --disable-go --disable-examples
-          make
-          sudo make install
-    - name: install imagemagick 7
-      run: |
-          wget https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${IMAGEMAGICK_SRC}
-          tar xf ${IMAGEMAGICK_SRC}
-          cd ImageMagick-7*
-          ./configure
-          make
-          sudo make install
-          sudo ldconfig
     - name: check imagemagick
-      run: convert -version
+      run: |
+        export PATH=${GITHUB_WORKSPACE}/vendor/imagemagick7/bin/magick:${PATH}
+        convert -version
 
     - name: Set up Ruby 2.7
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
#### :tophat: What? Why?

GitHub Actionsでimagemagick7のビルドをするのはかなり時間がかかっているため、imagemagickの公式サイトからダウンロードしたバイナリを使うように修正し、実行時間短縮を図ります。

バイナリはポータブルに実行できるAppImageなので、 `vendor/imagemagick7/bin` にそのまま置いてあります（convertにrenameしてあります）。バージョンは `Version: ImageMagick 7.1.1-6 Q16-HDRI x86_64 1be141ef8:20230402` です。
また、aptでlibfuse2を追加しています。

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask
