### PR TITLE
Add decidim-polis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem "decidim-decidim_awesome", git: "https://github.com/codeforjapan/decidim-mod
 
 gem "decidim-term_customizer", git: "https://github.com/codeforjapan/decidim-module-term_customizer.git", branch: "026-ja"
 
+gem "decidim-polis", git: "https://github.com/takahashim/decidim-polis.git", branch: "update-0-26-5"
+
 gem "bootsnap"
 
 gem "puma", ">= 5.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/takahashim/decidim-polis.git
-  revision: 685a305b31ba7fb9fc0c60ba775e7ea006b69e8f
+  revision: c0eecae2eb409fbead6076b3521146e05f26105f
   branch: update-0-26-5
   specs:
     decidim-polis (0.26.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/takahashim/decidim-polis.git
-  revision: e77d1f6363f4e15f42e5e3c6f2b1c41477d3f2bb
+  revision: 685a305b31ba7fb9fc0c60ba775e7ea006b69e8f
   branch: update-0-26-5
   specs:
     decidim-polis (0.26.5)
@@ -109,7 +109,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     acts_as_list (0.9.19)
       activerecord (>= 3.0)
-    addressable (2.8.1)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
@@ -392,7 +392,7 @@ GEM
       rainbow (>= 2.1.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (4.9.0)
+    devise (4.9.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -409,7 +409,7 @@ GEM
       nokogiri (>= 1.13.2, < 1.14.0)
       rubyzip (~> 2.3.0)
     docile (1.4.0)
-    doorkeeper (5.6.5)
+    doorkeeper (5.6.6)
       railties (>= 5)
     doorkeeper-i18n (4.0.1)
     dotenv (2.7.6)
@@ -488,7 +488,7 @@ GEM
     highline (2.1.0)
     html_tokenizer (0.0.7)
     htmlentities (4.3.4)
-    i18n (1.12.0)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.37)
       activesupport (>= 4.0.2)
@@ -583,7 +583,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     newrelic_rpm (9.1.0)
-    nio4r (2.5.8)
+    nio4r (2.5.9)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -651,12 +651,12 @@ GEM
       get_process_mem (~> 0.2)
       puma (>= 2.7)
     racc (1.6.2)
-    rack (2.2.6.4)
+    rack (2.2.7)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
-    rack-protection (3.0.5)
+    rack-protection (3.0.6)
       rack
     rack-proxy (0.7.6)
       rack

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,14 @@ GIT
       decidim-admin (~> 0.26.0)
       decidim-core (~> 0.26.0)
 
+GIT
+  remote: https://github.com/takahashim/decidim-polis.git
+  revision: e77d1f6363f4e15f42e5e3c6f2b1c41477d3f2bb
+  branch: update-0-26-5
+  specs:
+    decidim-polis (0.26.5)
+      decidim-core (= 0.26.5)
+
 PATH
   remote: decidim-comments
   specs:
@@ -888,6 +896,7 @@ DEPENDENCIES
   decidim-comments!
   decidim-decidim_awesome!
   decidim-dev (= 0.26.5)
+  decidim-polis!
   decidim-term_customizer!
   decidim-user_extension!
   deface

--- a/babel.config.json
+++ b/babel.config.json
@@ -25,6 +25,18 @@
       {
         "async": false
       }
+    ],
+    [
+      "@babel/plugin-proposal-private-property-in-object",
+      {
+        loose: true
+      }
+    ],
+    [
+      "@babel/plugin-proposal-private-methods",
+      {
+        "loose": true
+      }
     ]
   ]
 }

--- a/babel.config.json
+++ b/babel.config.json
@@ -25,18 +25,6 @@
       {
         "async": false
       }
-    ],
-    [
-      "@babel/plugin-proposal-private-property-in-object",
-      {
-        loose: true
-      }
-    ],
-    [
-      "@babel/plugin-proposal-private-methods",
-      {
-        "loose": true
-      }
     ]
   ]
 }

--- a/config/locales/polis_ja.yml
+++ b/config/locales/polis_ja.yml
@@ -1,22 +1,19 @@
 ja:
+  activemodel:
+    attributes:
+      organization:
+        polis_site_id: Pol.isサイトID
+        polis_site_url: Pol.isサイトURL
   decidim:
     admin:
       menu:
-        appearance: 外見
-        area_types: エリアタイプ
-        areas: エリア
-        configuration: 設定
         decidim_polis: Pol.is
-        help_sections: ヘルプセクション
-        homepage: ホームページ
-        scope_types: スコープ種別
-        scopes: スコープ
       organization:
         update:
           error: エラー
           success: 成功
       polis_config:
-        reminder: Pol.is の管理画面への直接リンクが機能するように、Pol.is にログインすることを忘れないでください。
+        reminder: Pol.isの管理画面への直接リンクが機能するように、Pol.isにログインすることを忘れないでください。
         title: Pol.isの設定
         warning: これはあなたの固有のIDです。共有したり変更したりしないでください。
     components:
@@ -53,11 +50,11 @@ ja:
           moderation:
             comments: コメント
             participants: 参加者
-            stats: スター
+            stats: 統計
             exports: エクスポート
             reports: 報告する
           or: または
-          question_circle_alt: 質問サークル
+          question_circle_alt: 質問
   layouts:
     decidim:
       admin:

--- a/config/locales/polis_ja.yml
+++ b/config/locales/polis_ja.yml
@@ -1,0 +1,68 @@
+ja:
+  decidim:
+    admin:
+      menu:
+        appearance: 外見
+        area_types: エリアタイプ
+        areas: エリア
+        configuration: 設定
+        decidim_polis: Pol.is
+        help_sections: ヘルプセクション
+        homepage: ホームページ
+        scope_types: スコープ種別
+        scopes: スコープ
+      organization:
+        update:
+          error: エラー
+          success: 成功
+      polis_config:
+        reminder: Pol.is の管理画面への直接リンクが機能するように、Pol.is にログインすることを忘れないでください。
+        title: Pol.isの設定
+        warning: これはあなたの固有のIDです。共有したり変更したりしないでください。
+    components:
+      polis:
+        settings:
+          step:
+            write_enabled: 書き込みを有効する
+            vote_enabled: 投票を有効にする
+          global:
+            title: タイトル
+            description: 説明
+            social_sign_in_enabled: ソーシャルログインを有効にする
+            visualization_enabled: ビジュアライゼーションを有効にする
+        name: Pol.is ディベート
+        views:
+          moder: 'Moderation:'
+    polis:
+      admin:
+        configuration:
+          edit:
+            update: 更新
+      polis:
+        show:
+          data: データ
+          help:
+            bottom: 新しいタイプのディスカッションへようこそ
+            description_1: 他人の意見に投票する
+            description_2: 自分の意見を表明する
+            description_3: 7人以上の投票者がいる場合、意見グループが形成されます
+            description_4: 新しい視点を提供して合意形成しましょう（意見グループはリアルタイムで変化します）
+            top: Pol.isの使い方
+          login_instructions: あなたのアカウントでログイン
+          login_title: ディベートに参加する
+          moderation:
+            comments: コメント
+            participants: 参加者
+            stats: スター
+            exports: エクスポート
+            reports: 報告する
+          or: または
+          question_circle_alt: 質問サークル
+  layouts:
+    decidim:
+      admin:
+        settings:
+          title: タイトル
+      header:
+        sign_in: ログイン
+        sign_up: 新規登録

--- a/db/migrate/20230426065808_add_polis_site_id_to_organizations.decidim_polis.rb
+++ b/db/migrate/20230426065808_add_polis_site_id_to_organizations.decidim_polis.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_polis (originally 20180301065746)
+
+class AddPolisSiteIdToOrganizations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_organizations, :polis_site_id, :string
+  end
+end

--- a/db/migrate/20230426065809_add_polis_site_url_to_organizations.decidim_polis.rb
+++ b/db/migrate/20230426065809_add_polis_site_url_to_organizations.decidim_polis.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_polis (originally 20220920152159)
+
+class AddPolisSiteUrlToOrganizations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_organizations, :polis_site_url, :string
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Decidim上でPol.isが使えるようになるdecidim-polisを追加してみました。

オリジナルではいろいろ動かなかったので、forkしてhttps://github.com/takahashim/decidim-polis.git を使っています。

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask

### :camera: Screenshots (optional)

管理者画面の組織の設定画面でpol.isの設定ページが追加されます。

<img width="1030" alt="admin-settings" src="https://user-images.githubusercontent.com/10401/234555243-e590a084-167d-440e-959a-b523a7ced9de.png">

コンポーネントとしてPol.isが追加できるようになります。

<img width="1289" alt="polis-setting" src="https://user-images.githubusercontent.com/10401/234556552-d0d33c4b-ea30-45ad-b0fa-c8575c5f1ed8.png">

設定すると、ユーザー画面で表示できるようになります。

<img width="976" alt="polis-show" src="https://user-images.githubusercontent.com/10401/234556661-ace8508a-7439-41db-ba92-c7c8947b7d2a.png">

ログインしていない場合は、回答はできずに図の表示だけされます。

<img width="973" alt="polis-no-login" src="https://user-images.githubusercontent.com/10401/234620769-291c35e5-61a7-46fa-b441-bd01544a79b4.png">

