### PR TITLE
Update decidim-polis to fix avatar_url

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/takahashim/decidim-polis.git
-  revision: c0eecae2eb409fbead6076b3521146e05f26105f
+  revision: 528c830677e3554e61808e98ba26a816a3f6ee78
   branch: update-0-26-5
   specs:
     decidim-polis (0.26.5)


### PR DESCRIPTION
#### :tophat: What? Why?

`Decidim::Polis::PolisHelper.avatar_url`がエラーになることがあるようなので修正します。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
