### PR TITLE
1組織内で複数のpol.isをサポートするよう修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/takahashim/decidim-polis.git
-  revision: 8a9b7e48ca0696d60b2cb038756388be08c000ff
+  revision: af644a8004555134370fc56bb510d78ab76c8c12
   branch: update-0-26-5
   specs:
     decidim-polis (0.26.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/takahashim/decidim-polis.git
-  revision: 528c830677e3554e61808e98ba26a816a3f6ee78
+  revision: 8a9b7e48ca0696d60b2cb038756388be08c000ff
   branch: update-0-26-5
   specs:
     decidim-polis (0.26.5)

--- a/config/locales/polis_ja.yml
+++ b/config/locales/polis_ja.yml
@@ -27,6 +27,8 @@ ja:
             description: 説明
             social_sign_in_enabled: ソーシャルログインを有効にする
             visualization_enabled: ビジュアライゼーションを有効にする
+            site_id: サイトID
+            site_url: サイトURL
         name: Pol.is ディベート
         views:
           moder: 'Moderation:'

--- a/db/migrate/20230522090010_remove_polis_site_id_and_url.decidim_polis.rb
+++ b/db/migrate/20230522090010_remove_polis_site_id_and_url.decidim_polis.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# This migration comes from decidim_polis (originally 20230508082639)
+
+class RemovePolisSiteIdAndUrl < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :decidim_organizations, :polis_site_id, :string
+    remove_column :decidim_organizations, :polis_site_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_17_104040) do
+ActiveRecord::Schema.define(version: 2023_05_22_090010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"


### PR DESCRIPTION
#### :tophat: What? Why?

元々のdecidim-polisではorganizationにpol.isのsite_idを持たせていたため、組織内では複数のpol.isコンポーネントを作っても同じ画面しか表示できませんでした。

そのため、コンポーネントのsettingsにsite_id（とsite_url）を保持するように変更します。
（decidim-polis自体は変更済みで、変更したリビジョンを使用するように変更するものです）

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
