### PR TITLE
Fix spec: use japanese texts

### DIFF
--- a/spec/system/comment_sort_spec.rb
+++ b/spec/system/comment_sort_spec.rb
@@ -21,7 +21,7 @@ describe "Comments", type: :system, perform_enqueued: true do
     comment = create(:comment, commentable: commentable, body: "Most Rated Comment")
     create(:comment_vote, comment: comment, author: user, weight: 1)
 
-    click_button "I agree"
+    click_button "同意します"
     visit resource_path
 
     expect(page).to have_no_content("Comments are disabled at this time")
@@ -31,8 +31,8 @@ describe "Comments", type: :system, perform_enqueued: true do
 
     within ".comments" do
       within ".order-by__dropdown" do
-        click_link "Older" # Opens the dropdown
-        click_link "Best rated"
+        click_link "古い順" # Opens the dropdown
+        click_link "評価の高い順"
       end
     end
 
@@ -46,6 +46,6 @@ describe "Comments", type: :system, perform_enqueued: true do
 
     expect(page).to have_css(".comment", minimum: 1)
     page.find(".order-by .dropdown.menu .is-dropdown-submenu-parent").hover
-    expect(page).to have_css("#comments-order-menu-control", text: "Best rated")
+    expect(page).to have_css("#comments-order-menu-control", text: "評価の高い順")
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

テストが失敗するようになっていたので、修正します。

メッセージのテキストが日本語になっていたようなので、それに合わせてテストも修正します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
