### PR TITLE
Fix amendable_fields in `Decidim::Amendable::AmendButtonCardCell`

### DIFF
--- a/app/cells/decidim/amendable/amend_button_card_cell.rb
+++ b/app/cells/decidim/amendable/amend_button_card_cell.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Amendable
+    # This cell renders the button to amend the given resource.
+    class AmendButtonCardCell < Decidim::ViewModel
+      delegate :current_user, to: :controller, prefix: false
+
+      def model_name
+        model.model_name.human
+      end
+
+      def current_component
+        model.component
+      end
+
+      def new_amend_path
+        decidim.new_amend_path(amendable_gid: model.to_sgid.to_s)
+      end
+
+      def new_amend_button_label
+        t("button", scope: "decidim.amendments.amendable", model_name: model_name)
+      end
+
+      def new_amend_help_text
+        content_tag :small do
+          t("help_text",
+            scope: "decidim.amendments.amendable",
+            model_name: model_name.downcase,
+            amendable_fields: model.amendable_fields.map { |field| model.class.human_attribute_name(field) }.to_sentence)
+        end
+      end
+
+      def button_classes
+        "amend_button_card_cell button hollow expanded button--icon button--sc"
+      end
+    end
+  end
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -34,6 +34,11 @@ ja:
         secondary_color: セカンダリ
       minutes:
         visible: 表示する
+  activerecord:
+    attributes:
+      decidim/proposals/proposal:
+        title: タイトル
+        body: 本文
   date:
     formats:
       decidim_short: "%Y/%m/%d"


### PR DESCRIPTION
#### :tophat: What? Why?

「提案を修正」のところの翻訳がされていないようだったので、翻訳されるよう修正します。

`Decidim::Amendable::AmendButtonCardCell#new_amend_help_text`をoverrideするだけではあるのですが、そこだけ修正するのはうまくいかなかったので、ファイルまるごと上書きして修正しています。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

#### Before

<img width="310" alt="before image" src="https://github.com/codeforjapan/decidim-cfj/assets/10401/e5cfc1f1-9455-489b-9bf4-29a4a1607d23">

#### After
<img width="320" alt="after image" src="https://github.com/codeforjapan/decidim-cfj/assets/10401/54fa49e6-d49f-408b-9cb4-c78f9c108bd1">


