### PR TITLE
Fix amendable_fieds in English; Add locale text in English

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,11 @@ en:
         gender: Gender
         occupation: Occupation
         real_name: Real Name
+  activerecord:
+    attributes:
+      decidim/proposals/proposal:
+        title: Title
+        body: Body
   decidim:
     debates:
       debates:


### PR DESCRIPTION
#### :tophat: What? Why?

#541 の修正で、英語のlocaleデータを追加します。

ただ、これだと元々の英語版での表示とは若干異なってしまっていて、単語（titleとbody）がcapitalizeされるのでした。
（これはデータを修正すればいいのですが、他の単語はふつうCapitalizeしたデータになっているので、ここだけ変えるのもどうかという気がしています…）

#### :pushpin: Related Issues
- Fixes #541

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
<img width="297" alt="fiexed in english" src="https://github.com/codeforjapan/decidim-cfj/assets/10401/4db77a1e-5b01-47dc-9f47-400c2e585682">

