### PR TITLE
Hide links to conversations

### DIFF
--- a/app/packs/stylesheets/decidim/cfj/messagings.scss
+++ b/app/packs/stylesheets/decidim/cfj/messagings.scss
@@ -1,0 +1,9 @@
+/* fix decidim-core/app/packs/stylesheets/decidim/modules/_navbar.scss */
+a.topbar__conversations {
+    display: none !important;
+}
+
+/* fix decidim-core/app/packs/stylesheets/decidim/layouts/_user.scss */
+span.user-contact_link {
+    display: none !important;
+}

--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -12,3 +12,4 @@
 @import "./cfj/search";
 @import "./cfj/media_print";
 @import "./cfj/ql_html_editor";
+@import "./cfj/messagings";


### PR DESCRIPTION
#### :tophat: What? Why?

DMへのリンクを隠すものです。

素朴にCSSを上書きします。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

<img width="343" alt="ナビゲーション" src="https://github.com/codeforjapan/decidim-cfj/assets/10401/b3e82e41-8076-43cc-b803-84ac80075be2">


<img width="312" alt="プロフィール" src="https://github.com/codeforjapan/decidim-cfj/assets/10401/e7bb6e0a-533f-4430-9f85-500ccfa29ba1">

