### PR TITLE
ブログのmeta・OGPを修正

### DIFF
--- a/app/views/decidim/blogs/posts/show.html.erb
+++ b/app/views/decidim/blogs/posts/show.html.erb
@@ -2,7 +2,7 @@
 
 <% add_decidim_meta_tags({
   title: translated_attribute(post.title),
-  description: translated_attribute(post.body),
+  description: translated_attribute(post.body).truncate(Rails.application.config.default_blog_ogp_description_limit),
   url: post_url(post.id)
 }) %>
 

--- a/app/views/decidim/blogs/posts/show.html.erb
+++ b/app/views/decidim/blogs/posts/show.html.erb
@@ -5,7 +5,11 @@
   description: translated_attribute(post.body).truncate(Rails.application.config.default_blog_ogp_description_limit),
   url: post_url(post.id)
 }) %>
-
+<%
+  doc = Nokogiri::HTML(translated_attribute(post.body))
+  img = doc.css('img')&.first
+  add_decidim_meta_image_url(img['src']) if img
+  %>
 <%
   edit_link(
     resource_locator(post).edit,

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -254,6 +254,9 @@ Rails.application.config.i18n.default_locale = Decidim.default_locale
 ## Set default comments limit. It's used in Decidim::Comments component. Default value is 100.
 Rails.application.config.default_comments_limit = ENV.fetch("DECIDIM_COMMENTS_LIMIT", 100).to_i
 
+## Set default OGP description length limit. It's used in Decidim::Blogs components
+Rails.application.config.default_blog_ogp_description_limit = ENV.fetch("DECIDIM_BLOG_OGP_DESCRIPTION_LIMIT", 150).to_i
+
 # Overwrite Devise.allow_unconfirmed_access_for
 Devise.allow_unconfirmed_access_for = Decidim.unconfirmed_access_for
 


### PR DESCRIPTION
#### :tophat: What? Why?

<del>注意) これは #549 がマージされた前提のPRで、 #549 との差分になっています。</del>
→ #549 がマージされたので develop との差分になりました

- ブログエントリの本文が長い場合、metaとOGPのdescriptionはtruncateします
- ブログエントリに画像が含まれる場合、その画像をmetaとOGP画像に使用します

前者のtrucateする長さは環境変数 `DECIDIM_BLOG_OGP_DESCRIPTION_LIMIT`で指定できます。指定されていない場合のデフォルトは150文字にしています。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
