### PR TITLE
Use `docker compose` instead of `docker-compose`

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -84,24 +84,24 @@ git checkout -b master origin/master
 
 ### 3.3 docker build
 ```
-docker-compose build
+docker compose build
 ```
 
 ### 3.4 DB作成からシードまで
 ```
-docker-compose run --rm app ./bin/rails db:create db:migrate
-docker-compose run --rm app ./bin/rails db:seed
+docker compose run --rm app ./bin/rails db:create db:migrate
+docker compose run --rm app ./bin/rails db:seed
 ```
 
 `db:seed`でエラーが起きた場合、ダミーのデータ作成に失敗している可能性があります。以下を実行し、DBを再作成してみてください。
 
 ```
-docker-compose run --rm app ./bin/rails db:reset
+docker compose run --rm app ./bin/rails db:reset
 ```
 
 ### 3.5 サーバー起動
 ```
-docker-compose up -d
+docker compose up -d
 ```
 ### 3.6 お疲れさまでした
 http://localhost:3000 にアクセス


### PR DESCRIPTION
#### :tophat: What? Why?

Compose V2に合わせて、ドキュメントにあるCLIで使う`docker-compose`を`docker compose`に置き換えます。
ローカルの開発環境で使う分には問題なさそうでした。

https://docs.docker.com/compose/migrate/

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
