### PR TITLE
docs: Replace CDK instead of Cloud Formation

### DIFF
--- a/docs/INFRA.md
+++ b/docs/INFRA.md
@@ -1,6 +1,6 @@
 # CDK の使い方
 
-AWS の code as a infrastructureサービスCloud Formationで、インフラストラクチャを構築しています。
+AWS の code as a infrastructureフレームワークCloud Development Kit(CDK)で、インフラストラクチャを構築しています。
 
 コードに落とすことで、レビューやバージョン管理が可能。またAWSコンソール上で、手動での変更検知などAWSに最適化されています。
 


### PR DESCRIPTION
#### :tophat: What? Why?

ドキュメントの文言修正です。

Cloud FormationになっていたところをCDKにします。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
