### PR TITLE
Update a form in v0.27.4

### DIFF
--- a/app/forms/decidim/debates/close_debate_form.rb
+++ b/app/forms/decidim/debates/close_debate_form.rb
@@ -7,7 +7,6 @@ module Decidim
       mimic :debate
 
       attribute :conclusions, Decidim::Attributes::CleanString
-      attribute :debate, Debate
 
       validates :debate, presence: true
       validates :conclusions, presence: true, length: { minimum: 10, maximum: 10_000 }
@@ -19,7 +18,6 @@ module Decidim
 
       def map_model(debate)
         super
-        self.debate = debate
 
         # Debates can be translated in different languages from the admin but
         # the public form doesn't allow it. When a user closes a debate the
@@ -29,6 +27,10 @@ module Decidim
                            else
                              debate.conclusions&.values&.first
                            end
+      end
+
+      def debate
+        @debate ||= Debate.find_by(id: id)
       end
 
       private


### PR DESCRIPTION
#### :tophat: What? Why?

Decidim::Debates::CloseDebateForm がv0.27.4で更新されていたので、差分を反映させます。

#### :pushpin: Related Issues
- Related to #415

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
