### PR TITLE
Update decidim-comments v0.27.4

### DIFF
--- a/decidim-comments/decidim-comments.gemspec
+++ b/decidim-comments/decidim-comments.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
   s.license = "AGPL-3.0"
   s.homepage = "https://github.com/decidim/decidim"
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 3.0"
 
   s.name = "decidim-comments"
   s.summary = "Decidim comments module"

--- a/decidim-comments/spec/commands/create_comment_spec.rb
+++ b/decidim-comments/spec/commands/create_comment_spec.rb
@@ -10,7 +10,7 @@ module Decidim
 
         describe "when the form is not valid" do
           before do
-            expect(form).to receive(:invalid?).and_return(true)
+            allow(form).to receive(:invalid?).and_return(true)
           end
 
           it "broadcasts invalid" do
@@ -49,13 +49,13 @@ module Decidim
 
           it "creates a new comment" do
             expect(Comment).to receive(:create!).with(
-              author: author,
+              { author: author,
               commentable: commentable,
               root_commentable: commentable,
               body: { en: body },
               alignment: alignment,
               decidim_user_group_id: user_group_id,
-              participatory_space: form.current_component.try(:participatory_space)
+                participatory_space: form.current_component.try(:participatory_space) }
             ).and_call_original
 
             expect do
@@ -74,7 +74,7 @@ module Decidim
             user_group_parser = instance_double("kind of UserGroupParser", groups: [])
             parsed_metadata = { user: user_parser, user_group: user_group_parser }
             parser = instance_double("kind of parser", rewrite: "whatever", metadata: parsed_metadata)
-            expect(Decidim::ContentProcessor).to receive(:parse).with(
+            allow(Decidim::ContentProcessor).to receive(:parse).with(
               form.body,
               current_organization: form.current_organization
             ).and_return(parser)
@@ -86,7 +86,7 @@ module Decidim
           it "sends the notifications" do
             creator_double = instance_double(NewCommentNotificationCreator, create: true)
 
-            expect(NewCommentNotificationCreator)
+            allow(NewCommentNotificationCreator)
               .to receive(:new)
               .with(kind_of(Comment), [], [])
               .and_return(creator_double)
@@ -121,13 +121,13 @@ module Decidim
 
             it "creates a new comment with user mention replaced" do
               expect(Comment).to receive(:create!).with(
-                author: author,
+                { author: author,
                 commentable: commentable,
                 root_commentable: commentable,
                 body: { en: Decidim::ContentProcessor.parse(body, parser_context).rewrite },
                 alignment: alignment,
                 decidim_user_group_id: user_group_id,
-                participatory_space: form.current_component.try(:participatory_space)
+                  participatory_space: form.current_component.try(:participatory_space) }
               ).and_call_original
 
               expect do
@@ -138,7 +138,7 @@ module Decidim
             it "sends the notifications" do
               creator_double = instance_double(NewCommentNotificationCreator, create: true)
 
-              expect(NewCommentNotificationCreator)
+              allow(NewCommentNotificationCreator)
                 .to receive(:new)
                 .with(kind_of(Comment), [mentioned_user], [])
                 .and_return(creator_double)
@@ -157,13 +157,13 @@ module Decidim
 
             it "creates a new comment with user_group mention replaced" do
               expect(Comment).to receive(:create!).with(
-                author: author,
+                { author: author,
                 commentable: commentable,
                 root_commentable: commentable,
                 body: { en: Decidim::ContentProcessor.parse(body, parser_context).rewrite },
                 alignment: alignment,
                 decidim_user_group_id: user_group_id,
-                participatory_space: form.current_component.try(:participatory_space)
+                  participatory_space: form.current_component.try(:participatory_space) }
               ).and_call_original
 
               expect do
@@ -174,7 +174,7 @@ module Decidim
             it "sends the notifications" do
               creator_double = instance_double(NewCommentNotificationCreator, create: true)
 
-              expect(NewCommentNotificationCreator)
+              allow(NewCommentNotificationCreator)
                 .to receive(:new)
                 .with(kind_of(Comment), [], [mentioned_group])
                 .and_return(creator_double)

--- a/decidim-comments/spec/controllers/decidim/comments/comments_controller_spec.rb
+++ b/decidim-comments/spec/controllers/decidim/comments/comments_controller_spec.rb
@@ -23,9 +23,9 @@ module Decidim
         end
 
         it "tells devise not to reset timeout counter" do
-          expect(request.env["devise.skip_timeoutable"]).to eq(nil)
+          expect(request.env["devise.skip_timeoutable"]).to be_nil
           get :index, xhr: true, params: { commentable_gid: commentable.to_signed_global_id.to_s }
-          expect(request.env["devise.skip_timeoutable"]).to eq(true)
+          expect(request.env["devise.skip_timeoutable"]).to be(true)
         end
 
         context "when requested without an XHR request" do
@@ -81,7 +81,7 @@ module Decidim
           it "creates the comment" do
             expect do
               post :create, xhr: true, params: { comment: comment_params }
-            end.to change { Decidim::Comments::Comment.count }.by(1)
+            end.to change(Decidim::Comments::Comment, :count).by(1)
 
             expect(comment.body.values.first).to eq("This is a new comment")
             expect(comment.alignment).to eq(comment_alignment)
@@ -122,7 +122,7 @@ module Decidim
             it "creates the comment with the alignment defined as 1" do
               expect do
                 post :create, xhr: true, params: { comment: comment_params }
-              end.to change { Decidim::Comments::Comment.count }.by(1)
+              end.to change(Decidim::Comments::Comment, :count).by(1)
 
               expect(comment.alignment).to eq(comment_alignment)
               expect(subject).to render_template(:create)
@@ -135,7 +135,7 @@ module Decidim
             it "creates the comment with the alignment defined as -1" do
               expect do
                 post :create, xhr: true, params: { comment: comment_params }
-              end.to change { Decidim::Comments::Comment.count }.by(1)
+              end.to change(Decidim::Comments::Comment, :count).by(1)
 
               expect(comment.alignment).to eq(comment_alignment)
               expect(subject).to render_template(:create)

--- a/decidim-comments/spec/events/decidim/comments/comment_by_followed_user_group_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_by_followed_user_group_event_spec.rb
@@ -19,28 +19,28 @@ module Decidim
 
       describe "email_subject" do
         it "is correct" do
-          expect(subject.email_subject).to eq("There is a new comment by #{CGI.escapeHTML(user_group.name)} in #{resource_title}")
+          expect(subject.email_subject).to eq("There is a new comment by #{escaped_html(user_group.name)} in #{resource_title}")
         end
       end
 
       describe "email_intro" do
         it "is correct" do
           expect(subject.email_intro)
-            .to eq("The group #{CGI.escapeHTML(user_group.name)} has left a comment in #{resource_title}. You can read it in this page:")
+            .to eq("The group #{escaped_html(user_group.name)} has left a comment in #{resource_title}. You can read it in this page:")
         end
       end
 
       describe "email_outro" do
         it "is correct" do
           expect(subject.email_outro)
-            .to include("You have received this notification because you are following #{CGI.escapeHTML(user_group.name)}")
+            .to include("You have received this notification because you are following #{escaped_html(user_group.name)}")
         end
       end
 
       describe "notification_title" do
         it "is correct" do
           expect(subject.notification_title)
-            .to start_with("There is a new comment by <a href=\"#{user_group_path}\">#{CGI.escapeHTML(user_group.name)} @#{user_group.nickname}</a> in")
+            .to start_with("There is a new comment by <a href=\"#{user_group_path}\">#{escaped_html(user_group.name)} @#{user_group.nickname}</a> in")
           expect(subject.notification_title)
             .to end_with("<a href=\"#{resource_path}?commentId=#{comment.id}#comment_#{comment.id}\">#{resource_title}</a>.")
         end

--- a/decidim-comments/spec/events/decidim/comments/user_group_mentioned_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/user_group_mentioned_event_spec.rb
@@ -8,7 +8,7 @@ describe Decidim::Comments::UserGroupMentionedEvent do
   let(:event_name) { "decidim.events.comments.user_group_mentioned" }
   let(:ca_comment_content) { "<div><p>Un commentaire pour #{author_link}</p></div>" }
   let(:en_comment_content) { "<div><p>Comment mentioning some user group, #{author_link}</p></div>" }
-  let(:author_link) { "<a class=\"user-mention\" href=\"http://#{organization.host}/profiles/#{group.nickname}\">@#{group.nickname}</a>" }
+  let(:author_link) { "<a class=\"user-mention\" href=\"http://#{organization.host}:#{Capybara.server_port}/profiles/#{group.nickname}\">@#{group.nickname}</a>" }
 
   let(:extra) do
     {
@@ -23,7 +23,7 @@ describe Decidim::Comments::UserGroupMentionedEvent do
 
   let(:parsed_body) { Decidim::ContentProcessor.parse("Comment mentioning some user group, @#{group.nickname}", current_organization: organization) }
   let(:parsed_ca_body) { Decidim::ContentProcessor.parse("Un commentaire pour @#{group.nickname}", current_organization: organization) }
-  let(:body) { { en: parsed_body.rewrite, "machine_translations": { "ca": parsed_ca_body.rewrite } } }
+  let(:body) { { en: parsed_body.rewrite, machine_translations: { ca: parsed_ca_body.rewrite } } }
 
   it_behaves_like "a comment event"
 
@@ -74,7 +74,7 @@ describe Decidim::Comments::UserGroupMentionedEvent do
   describe "translated notifications" do
     let(:en_body) { parsed_body.rewrite }
 
-    let(:body) { { en: en_body, "machine_translations": { "ca": parsed_ca_body.rewrite } } }
+    let(:body) { { en: en_body, machine_translations: { ca: parsed_ca_body.rewrite } } }
     let(:participatory_process) { create :participatory_process, organization: organization }
     let(:component) { create(:component, participatory_space: participatory_process) }
     let(:commentable) { create(:dummy_resource, component: component) }

--- a/decidim-comments/spec/events/decidim/comments/user_mentioned_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/user_mentioned_event_spec.rb
@@ -10,10 +10,10 @@ describe Decidim::Comments::UserMentionedEvent do
   let(:event_name) { "decidim.events.comments.user_mentioned" }
   let(:ca_comment_content) { "<div><p>Un commentaire pour #{author_link}</p></div>" }
   let(:en_comment_content) { "<div><p>Comment mentioning some user, #{author_link}</p></div>" }
-  let(:author_link) { "<a class=\"user-mention\" href=\"http://#{organization.host}/profiles/#{author.nickname}\">@#{author.nickname}</a>" }
+  let(:author_link) { "<a class=\"user-mention\" href=\"http://#{organization.host}:#{Capybara.server_port}/profiles/#{author.nickname}\">@#{author.nickname}</a>" }
   let(:parsed_body) { Decidim::ContentProcessor.parse("Comment mentioning some user, @#{author.nickname}", current_organization: organization) }
   let(:parsed_ca_body) { Decidim::ContentProcessor.parse("Un commentaire pour @#{author.nickname}", current_organization: organization) }
-  let(:body) { { en: parsed_body.rewrite, "machine_translations": { "ca": parsed_ca_body.rewrite } } }
+  let(:body) { { en: parsed_body.rewrite, machine_translations: { ca: parsed_ca_body.rewrite } } }
 
   let(:participatory_process) { create :participatory_process, organization: organization }
   let(:component) { create(:component, participatory_space: participatory_process) }
@@ -64,7 +64,7 @@ describe Decidim::Comments::UserMentionedEvent do
   describe "translated notifications" do
     let(:en_body) { parsed_body.rewrite }
 
-    let(:body) { { en: en_body, "machine_translations": { "ca": parsed_ca_body.rewrite } } }
+    let(:body) { { en: en_body, machine_translations: { ca: parsed_ca_body.rewrite } } }
 
     let(:participatory_process) { create :participatory_process, organization: organization }
     let(:component) { create(:component, participatory_space: participatory_process) }

--- a/decidim-comments/spec/forms/comment_form_spec.rb
+++ b/decidim-comments/spec/forms/comment_form_spec.rb
@@ -50,7 +50,7 @@ module Decidim
         it { is_expected.not_to be_valid }
 
         context "with carriage return characters that cause it to exceed" do
-          let(:body) { "#{("c" * 500)}\r\n#{("c" * 499)}" }
+          let(:body) { "#{"c" * 500}\r\n#{"c" * 499}" }
 
           it { is_expected.to be_valid }
         end
@@ -98,7 +98,7 @@ module Decidim
           let(:settings) { double }
 
           it "returns the organization comments_max_length" do
-            expect(component).to receive(:settings).and_return(settings)
+            allow(component).to receive(:settings).and_return(settings)
             expect(subject.max_length).to eq(organization.comments_max_length)
           end
         end

--- a/decidim-comments/spec/helpers/comments_helper_spec.rb
+++ b/decidim-comments/spec/helpers/comments_helper_spec.rb
@@ -24,7 +24,7 @@ module Decidim
 
           expect(cell).to receive(:to_s)
 
-          expect(helper)
+          allow(helper)
             .to receive(:cell)
             .with(
               "decidim/comments/comments",

--- a/decidim-comments/spec/lib/decidim/comments/comment_serializer_spec.rb
+++ b/decidim-comments/spec/lib/decidim/comments/comment_serializer_spec.rb
@@ -6,7 +6,8 @@ module Decidim
   module Comments
     describe CommentSerializer do
       let(:comment) { create(:comment) }
-      let(:subject) { described_class.new(comment) }
+
+      subject { described_class.new(comment) }
 
       describe "#serialize" do
         it "includes the id" do

--- a/decidim-comments/spec/lib/decidim/comments/comment_vote_serializer_spec.rb
+++ b/decidim-comments/spec/lib/decidim/comments/comment_vote_serializer_spec.rb
@@ -6,10 +6,10 @@ module Decidim
   module Comments
     describe CommentVoteSerializer do
       let(:comment) { create(:comment) }
+      let(:serialized) { subject.serialize }
       let(:resource) { create(:comment_vote, comment: comment) }
 
-      let(:subject) { described_class.new(resource) }
-      let(:serialized) { subject.serialize }
+      subject { described_class.new(resource) }
 
       describe "#serialize" do
         it "includes the id" do

--- a/decidim-comments/spec/lib/decidim/comments/export_spec.rb
+++ b/decidim-comments/spec/lib/decidim/comments/export_spec.rb
@@ -5,11 +5,14 @@ require "spec_helper"
 module Decidim
   module Comments
     describe Export do
-      let(:subject) { described_class }
+      subject { described_class }
       let!(:component) { create(:component, manifest_name: "dummy") }
       let!(:dummy_resources) { create_list(:dummy_resource, 2, component: component) }
       let!(:comments) { create_list(:comment, 5, commentable: dummy_resources[1], root_commentable: dummy_resources[1]) }
       let!(:other_comments) { create_list(:comment, 5) }
+      let!(:deleted_comment) { create(:comment, :deleted, commentable: dummy_resources[1], root_commentable: dummy_resources[1]) }
+      let!(:hidden_comment) { create(:comment, :deleted, commentable: dummy_resources[1], root_commentable: dummy_resources[1]) }
+      let!(:moderation) { create(:moderation, hidden_at: 6.hours.ago, reportable: hidden_comment) }
 
       describe "#comments_for_resource" do
         let(:collection) { subject.comments_for_resource(Decidim::DummyResources::DummyResource, component) }
@@ -20,6 +23,14 @@ module Decidim
 
         it "excludes other comments" do
           expect(collection).not_to include(*other_comments)
+        end
+
+        it "excludes deleted comments" do
+          expect(collection).not_to include(deleted_comment)
+        end
+
+        it "excludes hidden comments" do
+          expect(collection).not_to include(hidden_comment)
         end
       end
     end

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -58,7 +58,7 @@ module Decidim
       end
 
       it "is not valid if its parent is a comment and cannot accept new comments" do
-        expect(comment.root_commentable).to receive(:accepts_new_comments?).and_return false
+        allow(comment.root_commentable).to receive(:accepts_new_comments?).and_return false
         expect(replies[0]).not_to be_valid
       end
 
@@ -135,13 +135,14 @@ module Decidim
       describe "#reported_content_url" do
         subject { comment.reported_content_url }
 
-        let(:url_format) { "http://%{host}/processes/%{slug}/f/%{component_id}/dummy_resources/%{resource_id}#comment_%{comment_id}" }
+        let(:url_format) { "http://%{host}:%{port}/processes/%{slug}/f/%{component_id}/dummy_resources/%{resource_id}#comment_%{comment_id}" }
 
         it "returns the resource URL" do
           expect(subject).to eq(
             format(
               url_format,
               host: commentable.organization.host,
+              port: Capybara.server_port,
               slug: commentable.participatory_space.slug,
               component_id: commentable.component.id,
               resource_id: commentable.id,

--- a/decidim-comments/spec/models/seed_spec.rb
+++ b/decidim-comments/spec/models/seed_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 module Decidim
   module Comments
     describe Seed do
-      let(:subject) { Decidim::Comments::Seed }
+      subject { described_class }
 
       describe "#comments_for(resource)" do
         it "creates comments for a page if one is given" do

--- a/decidim-comments/spec/permissions/decidim/comments/permissions_spec.rb
+++ b/decidim-comments/spec/permissions/decidim/comments/permissions_spec.rb
@@ -8,7 +8,7 @@ module Decidim::Comments
 
     let(:user) { nil }
     let(:context) { {} }
-    let(:permission_action) { Decidim::PermissionAction.new(action) }
+    let(:permission_action) { Decidim::PermissionAction.new(**action) }
     let(:action_name) { :foo }
     let(:action_subject) { :bar }
     let(:action) do
@@ -39,17 +39,17 @@ module Decidim::Comments
       let(:context) { { commentable: commentable } }
 
       # Without any user
-      it { is_expected.to eq false }
+      it { is_expected.to be false }
 
       context "with a user who is allowed to comment" do
         let(:user) { create(:user, :confirmed, locale: "en", organization: organization) }
 
-        it { is_expected.to eq true }
+        it { is_expected.to be true }
 
         context "with comments disabled for the component" do
           let(:component) { create(:component, :with_comments_disabled, participatory_space: participatory_process) }
 
-          it { is_expected.to eq false }
+          it { is_expected.to be false }
         end
       end
 
@@ -57,7 +57,7 @@ module Decidim::Comments
         let(:participatory_process) { create :participatory_process, :private, organization: organization }
         let(:user) { create(:user, :confirmed, locale: "en", organization: organization) }
 
-        it { is_expected.to eq false }
+        it { is_expected.to be false }
       end
     end
 
@@ -67,12 +67,12 @@ module Decidim::Comments
       let(:context) { { comment: comment } }
 
       # Without any user
-      it { is_expected.to eq false }
+      it { is_expected.to be false }
 
       context "with a user who is allowed to comment" do
         let(:user) { create(:user, :confirmed, locale: "en", organization: organization) }
 
-        it { is_expected.to eq true }
+        it { is_expected.to be true }
 
         context "with comments disabled for the component" do
           before do
@@ -83,7 +83,7 @@ module Decidim::Comments
             component.save!
           end
 
-          it { is_expected.to eq true }
+          it { is_expected.to be true }
         end
       end
 
@@ -91,7 +91,7 @@ module Decidim::Comments
         let(:participatory_process) { create :participatory_process, :private, organization: organization }
         let(:user) { create(:user, :confirmed, locale: "en", organization: organization) }
 
-        it { is_expected.to eq false }
+        it { is_expected.to be false }
       end
     end
   end

--- a/decidim-comments/spec/queries/sorted_comments_spec.rb
+++ b/decidim-comments/spec/queries/sorted_comments_spec.rb
@@ -21,7 +21,7 @@ module Decidim::Comments
     let!(:author) { create(:user, organization: organization) }
     let!(:commentable) { create(:dummy_resource, component: component) }
     let!(:comment) { create(:comment, commentable: commentable, author: author) }
-    let!(:order_by) {}
+    let!(:order_by) { nil }
 
     it "returns the commentable's comments" do
       expect(subject.query).to eq [comment]

--- a/decidim-comments/spec/services/decidim/comments/comment_creation_spec.rb
+++ b/decidim-comments/spec/services/decidim/comments/comment_creation_spec.rb
@@ -26,7 +26,7 @@ module Decidim
         let(:block) { proc { |_data| "The block that is expected to be subscribed" } }
 
         it "subscribes to comment created" do
-          expect(ActiveSupport::Notifications)
+          allow(ActiveSupport::Notifications)
             .to receive(:subscribe)
             .with(described_class::EVENT_NAME, &block)
 

--- a/decidim-comments/spec/system/admin_manages_comments_spec.rb
+++ b/decidim-comments/spec/system/admin_manages_comments_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Admin manages comments", type: :system do
   let(:manifest_name) { "dummy" }
   let!(:dummy) { create :dummy_resource, component: current_component }
-  let!(:resources) { create_list(:dummy_resource, 3, component: current_component) }
+  let!(:resources) { create_list(:dummy_resource, 2, component: current_component) }
   let!(:reportables) do
     resources.map do |resource|
       create(:comment, commentable: resource)
@@ -18,4 +18,8 @@ describe "Admin manages comments", type: :system do
   include_context "when managing a component as an admin"
 
   it_behaves_like "manage moderations"
+
+  it_behaves_like "sorted moderations" do
+    let!(:reportables) { create_list(:dummy_resource, 17, component: current_component) }
+  end
 end

--- a/decidim-comments/spec/system/search_comments_spec.rb
+++ b/decidim-comments/spec/system/search_comments_spec.rb
@@ -7,7 +7,7 @@ describe "Search comments", type: :system do
   let(:manifest_name) { "dummy" }
   let!(:commentable) { create(:dummy_resource, component: component) }
   let!(:searchables) { create_list(:comment, 3, commentable: commentable) }
-  let!(:term) { translated(searchables.first.body).split(" ").last }
+  let!(:term) { translated(searchables.first.body).split.last }
   let(:hashtag) { "#decidim" }
 
   before do

--- a/decidim-comments/spec/types/comment_mutation_type_spec.rb
+++ b/decidim-comments/spec/types/comment_mutation_type_spec.rb
@@ -17,7 +17,7 @@ module Decidim
         end
 
         it "calls UpVoteComment command" do
-          expect(model).to receive(:up_voted_by?).with(current_user).and_return(true)
+          allow(model).to receive(:up_voted_by?).with(current_user).and_return(true)
           expect(response["upVote"]).to include("upVoted" => true)
         end
       end
@@ -30,7 +30,7 @@ module Decidim
         end
 
         it "calls UpVoteComment command" do
-          expect(model).to receive(:down_voted_by?).with(current_user).and_return(true)
+          allow(model).to receive(:down_voted_by?).with(current_user).and_return(true)
           expect(response["downVote"]).to include("downVoted" => true)
         end
       end

--- a/decidim-comments/spec/types/comment_type_spec.rb
+++ b/decidim-comments/spec/types/comment_type_spec.rb
@@ -133,7 +133,7 @@ module Decidim
         let(:query) { "{ upVoted }" }
 
         it "returns the up_voted_by? method evaluation with the current user" do
-          expect(model).to receive(:up_voted_by?).with(current_user).and_return(true)
+          allow(model).to receive(:up_voted_by?).with(current_user).and_return(true)
           expect(response).to include("upVoted" => true)
         end
       end
@@ -142,7 +142,7 @@ module Decidim
         let(:query) { "{ downVoted }" }
 
         it "returns the down_voted_by? method evaluation with the current user" do
-          expect(model).to receive(:down_voted_by?).with(current_user).and_return(true)
+          allow(model).to receive(:down_voted_by?).with(current_user).and_return(true)
           expect(response).to include("downVoted" => true)
         end
       end
@@ -151,7 +151,7 @@ module Decidim
         let(:query) { "{ alreadyReported }" }
 
         it "returns the reported_by? method evaluation with the current user" do
-          expect(model).to receive(:reported_by?).with(current_user).and_return(true)
+          allow(model).to receive(:reported_by?).with(current_user).and_return(true)
           expect(response).to include("alreadyReported" => true)
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

decidim-commentsについて、v0.27.4との差分を反映させます。
ざっと見たところ、変更がありそうなのはgemspec（Rubyのバージョン）とテストだけのようでした。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
