### PR TITLE
Decidim::NotificationToMailerPresenter: support organization's locale

### DIFF
--- a/app/presenters/decidim/notification_to_mailer_presenter.rb
+++ b/app/presenters/decidim/notification_to_mailer_presenter.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Decidim
+  #
+  # Decorator for notifications in mail digest
+  #
+  class NotificationToMailerPresenter < SimpleDelegator
+    include Decidim::TranslatableAttributes
+
+    delegate :url_helpers, to: "Decidim::Core::Engine.routes"
+    delegate :resource_title, to: :event
+    delegate :resource_url, to: :event
+    delegate :email_intro, to: :event
+    delegate :resource_path, to: :event
+
+    def date_time
+      created_at_in_time_zone = created_at.in_time_zone(resource.organization.time_zone)
+      if frequency == :daily
+        I18n.l(created_at_in_time_zone, format: :time_of_day)
+      else
+        I18n.l(created_at_in_time_zone, format: :decidim_short)
+      end
+    end
+
+    private
+
+    def event
+      @event ||= event_class.constantize.new(
+        resource: resource,
+        user: user,
+        user_role: user_role,
+        event_name: event_name,
+        extra: extra
+      )
+    end
+
+    def frequency
+      @frequency ||= user.notifications_sending_frequency
+    end
+  end
+end

--- a/spec/presenters/decidim/notification_to_mailer_presenter_spec.rb
+++ b/spec/presenters/decidim/notification_to_mailer_presenter_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Decidim
+  describe NotificationToMailerPresenter, type: :presenter do
+    subject { described_class.new(notification) }
+
+    context "with a daily frequency" do
+      let(:creating_date) { Time.parse("Wed, 1 Sep 2021 21:00:00 UTC +00:00").in_time_zone }
+      let(:notification) { create(:notification, created_at: creating_date) }
+
+      describe "#date_time" do
+        it "returns the hour formated" do
+          allow(subject).to receive(:frequency).and_return(:daily)
+          expect(subject.date_time).to eq("21:00")
+        end
+      end
+    end
+
+    context "with a daily frequency in timezone of Japan" do
+      let(:creating_date) { Time.zone.parse("Wed, 1 Sep 2021 21:00:00 +00:00").in_time_zone("Asia/Tokyo") }
+      let(:notification) do
+        create(:notification, created_at: creating_date) do |notification|
+          org = notification.resource.organization
+          org.time_zone = "Asia/Tokyo"
+          org.save!
+        end
+      end
+
+      describe "#date_time" do
+        it "returns the hour formated" do
+          allow(subject).to receive(:frequency).and_return(:daily)
+          expect(subject.date_time).to eq("06:00")
+        end
+      end
+    end
+
+    context "with a weekly frequency" do
+      let(:creating_date) { Time.parse("Wed, 1 Sep 2021 21:00:00 UTC +00:00").in_time_zone }
+      let(:notification) { create(:notification, created_at: creating_date) }
+
+      describe "#date_time" do
+        it "returns the date formated" do
+          allow(subject).to receive(:frequency).and_return(:weekly)
+          expect(subject.date_time).to eq("01/09/2021 21:00")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

ダイジェストメールの日時をorganizationのタイムゾーンに合わせるようにします。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
