### PR TITLE
Disallow sitemap.xml

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow: /*/versions
+Disallow: /sitemap.xml


### PR DESCRIPTION
#### :tophat: What? Why?

sitemap.xmlがエラーになる件ですが、とりいそぎクローラから辿れなくするものです。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
