### PR TITLE
Fix translation of `last_activity`

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -72,6 +72,10 @@ ja:
           most_discussed: 議論数の多い順
           older: 古い順
           recent: 新しい順
+    content_blocks:
+      last_activity:
+        name: 最近のアクティビティ
+        title: 最近のアクティビティ
     debates:
       debates:
         filters:
@@ -128,6 +132,9 @@ ja:
       file_help:
         image:
           message_1: "テキストを含まない風景画像が適しています（推奨サイズ: 縦横どちらも3800ピクセル以下程度）"
+    last_activities:
+      index:
+        last_activity: 最近のアクティビティ
     meetings:
       meetings:
         filters:


### PR DESCRIPTION
#### :tophat: What? Why?

`Last activity`の訳語を「最近のアクティビティ」に変更します。

変更する箇所は以下の3か所になります：

* トップページのlast_activityコンテンツブロックのタイトル (content_blocks.last_activity.title)
* 上記のコンテンツブロック内の「すべて表示」ボタンを押した先のページのタイトル (last_activities.index.last_activity)
* 管理画面で表示されるlast_activityコンテンツブロックの名前 (content_blocks.last_activity.name)

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

トップページ（PR適用後）：

<img width="1300" alt="更新" src="https://github.com/codeforjapan/decidim-cfj/assets/10401/fd37c255-c563-451f-9dbf-70a2931565fc">

/last_activities ：

<img width="1274" alt="スクリーンショット 2023-12-12 0 45 17" src="https://github.com/codeforjapan/decidim-cfj/assets/10401/49824026-c397-43e3-a4ac-2c58b4d0cc2a">

管理画面（設定→ホームページ）：

<img width="400" alt="スクリーンショット 2023-12-12 0 47 33" src="https://github.com/codeforjapan/decidim-cfj/assets/10401/3ceabd66-48bc-412c-90be-a28b0fed62ce">
