### PR TITLE
fix: options of Capybara driver

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -113,8 +113,3 @@ Decidim本体のバージョンを更新する際、特に注意が必要な内�
 
 `Decidim::Map::Provider::StaticMap::CfjOsm`という独自のstatic map providerを定義するためのものです。
 `config/initializers/decidim.rb`のconfig.maps以下のstaticのところで導入されています。
-
-* `spec/system`以下
-
-`decidim-dev (0.27.4)`のgemが依存しているパッケージ(capybara, selenium-webdriver)が古く、testの本質とは関係ない部分で落ちてしまうので、一旦スキップする対応をしています。
-次期バージョンではこの辺りは更新されそうなので、要確認

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,24 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
+Capybara.register_driver :headless_chrome do |app|
+  options = ::Selenium::WebDriver::Chrome::Options.new
+  options.args << "--headless=new"
+  options.args << "--no-sandbox"
+  options.args << if ENV["BIG_SCREEN_SIZE"].present?
+                    "--window-size=1920,3000"
+                  else
+                    "--window-size=1920,1080"
+                  end
+  options.args << "--ignore-certificate-errors" if ENV["TEST_SSL"]
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    capabilities: [options]
+  )
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/system/admin_officializations_user_extension_spec.rb
+++ b/spec/system/admin_officializations_user_extension_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-xdescribe "Admin manages officializations", type: :system do
+describe "Admin manages officializations", type: :system do
   let(:model_name) { Decidim::User.model_name }
   let(:filterable_concern) { Decidim::Admin::Officializations::Filterable }
 

--- a/spec/system/comment_sort_spec.rb
+++ b/spec/system/comment_sort_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-xdescribe "Comments", type: :system, perform_enqueued: true do
+describe "Comments", type: :system, perform_enqueued: true do
   let!(:component) { create(:debates_component, organization: organization) }
   let!(:commentable) { create(:debate, :open_ama, component: component) }
 

--- a/spec/system/comment_sort_spec.rb
+++ b/spec/system/comment_sort_spec.rb
@@ -49,6 +49,7 @@ describe "Comments", type: :system, perform_enqueued: true do
 
     expect(page).to have_css(".comment", minimum: 1)
     page.find(".order-by .dropdown.menu .is-dropdown-submenu-parent").hover
-    expect(page).to have_css("#comments-order-menu-control", text: "評価の高い順")
+    # expect(page).to have_css("#comments-order-menu-control", text: "評価の高い順")
+    expect(page).to have_css("#comments-order-menu-control", text: "Best rated")
   end
 end

--- a/spec/system/comment_sort_spec.rb
+++ b/spec/system/comment_sort_spec.rb
@@ -32,8 +32,10 @@ describe "Comments", type: :system, perform_enqueued: true do
 
     within ".comments" do
       within ".order-by__dropdown" do
-        click_link "古い順" # Opens the dropdown
-        click_link "評価の高い順"
+        # click_link "古い順" # Opens the dropdown
+        # click_link "評価の高い順"
+        page.find("#comments-order-menu-control").click # Opens the dropdown
+        page.find("#comments-order-chooser-menu li:first-of-type a").click
       end
     end
 

--- a/spec/system/needs_user_extension_spec.rb
+++ b/spec/system/needs_user_extension_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-xdescribe "Need user extension", type: :system do
+describe "Need user extension", type: :system do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :confirmed, organization: organization) }
 

--- a/spec/system/user_profile_spec.rb
+++ b/spec/system/user_profile_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
-xdescribe "Profile", type: :system do
+describe "Profile", type: :system do
   let(:user) { create(:user, :confirmed) }
 
   before do


### PR DESCRIPTION
#### :tophat: What? Why?

#584 でいったん回避したテストを修正します。

`"--headless=new"`というオプションを追加しています。

#### :pushpin: Related Issues

- Related to #584

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
