### PR TITLE
fix to allow system specs to be run for each file

### DIFF
--- a/spec/system/user_profile_spec.rb
+++ b/spec/system/user_profile_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 describe "Profile", type: :system do
   let(:user) { create(:user, :confirmed) }


### PR DESCRIPTION
#### :tophat: What? Why?

直接spec_helper.rbを呼ばずにrails_helper.rbを呼ぶよう修正します（そうしないと個別にテストを実行できないため）。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
