### PR TITLE
fix: update load_defaults to `6.0`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,10 @@ Bundler.require(*Rails.groups)
 module DecidimApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
+
+    # TODO: make this setting true
+    config.action_dispatch.use_cookies_with_metadata = false
 
     config.generators do |g|
       # remove some specs

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,3 +8,5 @@
   - metrics
   - exports
   - translations
+  - active_storage_analysis
+  - active_storage_purge


### PR DESCRIPTION
#### :tophat: What? Why?

config.load_defaultsを6.0まで上げます。
最終的には6.1まで上げた方が良さそうですが、もろもろ設定が変更されるので小さく修正するようにしていまｓ．

また、`config.action_dispatch.use_cookies_with_metadata`の変更は不可逆なため、いったん変更しないようにしておきます。
この修正が問題ないようであれば、別途`config.action_dispatch.use_cookies_with_metadata`を変更する予定です。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
