### PR TITLE
fix: make use_cookies_with_metadata true (same as default)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,9 +18,6 @@ module DecidimApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
-    # TODO: make this setting true
-    config.action_dispatch.use_cookies_with_metadata = false
-
     config.generators do |g|
       # remove some specs
       g.test_framework :rspec,


### PR DESCRIPTION
#### :tophat: What? Why?

#605 でいったん無効化していた`use_cookies_with_metadata`を有効にします。

この変更により、クッキーへの格納方法が変わるため、それ以前のバージョンに戻すとクッキーがおかしくなるため注意してください。

それ以外の挙動には変更はないはずです。

#### :pushpin: Related Issues
- Related to #606

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
