### PR TITLE
fix: update load_defaults to `6.1`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,11 @@ Bundler.require(*Rails.groups)
 module DecidimApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 6.1
+
+    # TODO: remove these settings
+    config.action_dispatch.cookies_same_site_protection = nil
+    config.action_controller.urlsafe_csrf_tokens = false
 
     config.generators do |g|
       # remove some specs

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,6 @@ module DecidimApp
     config.load_defaults 6.1
 
     # TODO: remove these settings
-    config.action_dispatch.cookies_same_site_protection = nil
     config.action_controller.urlsafe_csrf_tokens = false
 
     config.generators do |g|


### PR DESCRIPTION
#### :tophat: What? Why?

( #608 が先にmainにマージされる前提で作ったPRのため、target branchがそちらになっています。）

#606 の一環で、 #605 に引き続き、config.load_defaultsを6.1まで上げます。

`config.action_dispatch.cookies_same_site_protection`と`config.action_controller.urlsafe_csrf_tokens`は変更しないようにしています。
この2つの中では、`urlsafe_csrf_tokens`を先に有効化した方がよいかもしれません。
→確認したところ `cookies_same_site_protection` はDecidim本体のdecidim-coreで設定されていたため、`config.action_controller.urlsafe_csrf_tokens`のみ設定を残しています。

#### :pushpin: Related Issues

- Related to #606 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
