### PR TITLE
fix: remove `urlsafe_csrf_tokens`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,9 +18,6 @@ module DecidimApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
-    # TODO: remove these settings
-    config.action_controller.urlsafe_csrf_tokens = false
-
     config.generators do |g|
       # remove some specs
       g.test_framework :rspec,


### PR DESCRIPTION
#### :tophat: What? Why?

#609 でいったん無効化していた`urlsafe_csrf_tokens`を有効にします。これで #606 の対応は完了し、6.1のデフォルト設定になります。

この変更により、CSRF対策用のhidden文字列のエンコード方法が変わります。が、切替時にフォームを表示している以外はエラーにならないと思われます。

それ以外の挙動には変更はないはずです。

#### :pushpin: Related Issues
- Related to #606

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
