### PR TITLE
Fix `I18n.transliterate`

### DIFF
--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -121,7 +121,7 @@ Rails.application.config.to_prepare do
 
   # Fix I18n.transliterate()
   I18n.config.backend.instance_eval do
-    @transliterators[:ja] = I18n::Backend::Transliterator.get( ->(string) { string } )
-    @transliterators[:en] = I18n::Backend::Transliterator.get( ->(string) { string } )
+    @transliterators[:ja] = I18n::Backend::Transliterator.get(->(string) { string })
+    @transliterators[:en] = I18n::Backend::Transliterator.get(->(string) { string })
   end
 end

--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -118,4 +118,10 @@ Rails.application.config.to_prepare do
       end
     end
   end
+
+  # Fix I18n.transliterate()
+  I18n.config.backend.instance_eval do
+    @transliterators[:ja] = I18n::Backend::Transliterator.get( ->(string) { string } )
+    @transliterators[:en] = I18n::Backend::Transliterator.get( ->(string) { string } )
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

#612 を修正するため、`@transliterators`の`:ja`に何も変換しないProcを渡すように修正します。
本来は`:en`は修正しなくてもいいはずですが、ダミーのデータで試す際にはlocaleの判別がうまくいってない場合があったため、念の為こちらも修正してみます。

#### :pushpin: Related Issues
- Fixes #612 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
