### PR TITLE
GitHub Actions: use postgres12 with pg_bigm

### DIFF
--- a/.github/docker/Dockerfile.postgres
+++ b/.github/docker/Dockerfile.postgres
@@ -1,0 +1,18 @@
+FROM postgres:12
+
+RUN apt update
+RUN apt install -y postgresql-server-dev-12 make gcc curl libicu-dev
+
+RUN cd /tmp && \
+    curl -L -O https://github.com/pgbigm/pg_bigm/archive/refs/tags/v1.2-20240606.tar.gz && \
+    tar zxf v1.2-20240606.tar.gz && \
+    cd pg_bigm-1.2-20240606 && \
+    make USE_PGXS=1 && \
+    make USE_PGXS=1 install && \
+    rm -rf /tmp/pg_bigm-1.2-20240606 /tmp/v1.2-20240606.tar.gz
+
+RUN echo shared_preload_libraries='pg_bigm' >> /var/lib/postgresql/data/postgresql.conf
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+EXPOSE 5432
+CMD ["postgres"]

--- a/.github/workflows/_check.yaml
+++ b/.github/workflows/_check.yaml
@@ -43,7 +43,7 @@ jobs:
       SLACK_MESSAGE_CHANNEL: '#test'
     services:
       db:
-        image: postgres:12.14
+        image: ghcr.io/${{ github.repository_owner }}/postgres_bigm:12-latest
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/_check.yaml
+++ b/.github/workflows/_check.yaml
@@ -43,7 +43,7 @@ jobs:
       SLACK_MESSAGE_CHANNEL: '#test'
     services:
       db:
-        image: ghcr.io/${{ github.repository_owner }}/postgres_bigm:12-latest
+        image: postgres:12.14
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/pg_build.yml
+++ b/.github/workflows/pg_build.yml
@@ -1,0 +1,32 @@
+name: Build and Push Docker Image of PostgreSQL with pg_bigm
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: postgres_bigm
+      IMAGE_TAG: 12-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        file: .github/docker/Dockerfile.postgres
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}


### PR DESCRIPTION
#### :tophat: What? Why?

GitHub Actionsで使用するPostgreSQLをpg_bigm対応のものに変更します。

pg_bigm対応PostgreSQLのビルドもGitHub Actionsのpg_build.ymlでbuild + ghcr.ioにpushするようにしています。
このActionは普段実行する必要はないので、`workflow_dispatch`で手動実行するようにしています。

#### :pushpin: Related Issues
- Related to #615 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
