### PR TITLE
use redis for cache and session store

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,7 +19,11 @@ Rails.application.configure do
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
-    config.cache_store = :memory_store
+    if ENV["REDIS_CACHE_URL"] # rubocop:disable Style/ConditionalAssignment
+      config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_CACHE_URL", nil) }
+    else
+      config.cache_store = :memory_store
+    end
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,6 +51,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_CACHE_URL", nil) }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  Rails.application.config.session_store :cache_store if ENV["REDIS_CACHE_URL"]
+end


### PR DESCRIPTION
#### :tophat: What? Why?

これはセッションストアをRedisにする修正ですが、以下の2点を変更しています。

* キャッシュストアとしてRedisを使うように変更
   * ただし、sidekiqで使ってるはずの`REDIS_URL`をそのまま使うのではなく、`REDIS_CACHE_URL`で設定されるRedisを使用します
* セッションストアとしてキャッシュを使うように変更
  * 別解として「Sidekiqで使うRedis」「キャッシュで使うRedis」「セッションに使うRedis」を全部分けるという選択肢もありますが、そこまでこだわる必要があるかどうか不明だったので2番目と3番目を同一にしています

キャッシュ用のRedisは`REDIS_CACHE_URL`という環境変数で設定しています。`REDIS_URL`と同じ値に設定してもよいですし、`redis://${ props.cache }:6379/1`などと別データベースを指定してもよいかもしれません。
注意点として、セッションに使う場合はEvictionで勝手に既存のセッションを消されたりしないよう十分なサイズを確保する必要があります。

また、開発環境でも`REDIS_CACHE_URL`が設定されていて、かつ`tmp/caching-dev.txt`が存在する場合にはRedisを使うようになります。
`tmp/caching-dev.txt`は`rails dev:cache`でON/OFFがトグルできるようになっています。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
