### PR TITLE
fix: use `decidim_sanitize_admin` instead of `decidim_escape_translated`

### DIFF
--- a/app/views/decidim/accountability/results/_timeline.html.erb
+++ b/app/views/decidim/accountability/results/_timeline.html.erb
@@ -1,0 +1,30 @@
+<div class="small-12 columns">
+  <div class="section">
+    <h4 class="section-heading"><%= t(".title") %></h4>
+    <ol class="timeline">
+      <% result.timeline_entries.each_with_index do |timeline_entry, i| %>
+        <li class="timeline__item ">
+          <div class="timeline__phase">
+            <span class="timeline__phase__number"><%= i + 1 %></span>
+          </div>
+          <div class="timeline__info">
+            <div class="timeline__description">
+              <span class="timeline__date text-small">
+                <%= l timeline_entry.entry_date, format: :decidim_short %>
+              </span>
+              <h4 class="timeline__title">
+                <%= translated_attribute timeline_entry.title %>
+              </h4>
+
+              <% if translated_attribute(timeline_entry.description).present? %>
+                <div class="timeline__description__description">
+                  <%= decidim_sanitize_admin translated_attribute(timeline_entry.description) %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </li>
+      <% end %>
+    </ol>
+  </div>
+</div>


### PR DESCRIPTION
#### :tophat: What? Why?

Fix invalid escaping(?) in timeline in accountability module.

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/12547

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask

### :camera: Screenshots (optional)

### Before

<img width="1234" alt="before" src="https://github.com/user-attachments/assets/8619da0b-3ef4-4f07-974b-c39f496817af">

### After

<img width="289" alt="after" src="https://github.com/user-attachments/assets/1dfce7f8-24ae-4fe8-b2a5-7d949f5566aa">

