### PR TITLE
Dockerfile: fix warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.0-bullseye-slim as node
+FROM node:16.13.0-bullseye-slim AS node
 
 FROM ruby:3.0.6-slim-bullseye
 


### PR DESCRIPTION
#### :tophat: What? Why?

`docker compose build`を行った際、`WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)`というwarningが出るのを修正します。

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` upgrade notes, if required
- [x] If there's a new public field, add it to GraphQL API
- [x] Add documentation regarding the feature 
- [x] Add/modify seeds
- [x] Add tests
- [x] Another subtask
