### PR TITLE
Add `:comments_count` for stats of Accountability, Blogs, Debates, and Sortitions components

### DIFF
--- a/app/queries/decidim/accountability/filtered_results.rb
+++ b/app/queries/decidim/accountability/filtered_results.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Accountability
+    # A class used to find results filtered by components and a date range
+    class FilteredResults < Decidim::Query
+      # Syntactic sugar to initialize the class and return the queried objects.
+      #
+      # components - An array of Decidim::Component
+      # start_at - A date to filter resources created after it
+      # end_at - A date to filter resources created before it.
+      def self.for(components, start_at = nil, end_at = nil)
+        new(components, start_at, end_at).query
+      end
+
+      # Initializes the class.
+      #
+      # components - An array of Decidim::Component
+      # start_at - A date to filter resources created after it
+      # end_at - A date to filter resources created before it.
+      def initialize(components, start_at = nil, end_at = nil)
+        @components = components
+        @start_at = start_at
+        @end_at = end_at
+      end
+
+      # Finds the Results scoped to an array of components and filtered
+      # by a range of dates.
+      def query
+        results = Decidim::Accountability::Result.where(component: @components)
+        results = results.where(created_at: @start_at..) if @start_at.present?
+        results = results.where(created_at: ..@end_at) if @end_at.present?
+        results
+      end
+    end
+  end
+end

--- a/app/queries/decidim/blogs/filtered_posts.rb
+++ b/app/queries/decidim/blogs/filtered_posts.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Blogs
+    # A class used to find posts filtered by components and a date range
+    class FilteredPosts < Decidim::Query
+      # Syntactic sugar to initialize the class and return the queried objects.
+      #
+      # components - An array of Decidim::Component
+      # start_at - A date to filter resources created after it
+      # end_at - A date to filter resources created before it.
+      def self.for(components, start_at = nil, end_at = nil)
+        new(components, start_at, end_at).query
+      end
+
+      # Initializes the class.
+      #
+      # components - An array of Decidim::Component
+      # start_at - A date to filter resources created after it
+      # end_at - A date to filter resources created before it.
+      def initialize(components, start_at = nil, end_at = nil)
+        @components = components
+        @start_at = start_at
+        @end_at = end_at
+      end
+
+      # Finds the Posts scoped to an array of components and filtered
+      # by a range of dates.
+      def query
+        posts = Decidim::Blogs::Post.where(component: @components)
+        posts = posts.where(created_at: @start_at..) if @start_at.present?
+        posts = posts.where(created_at: ..@end_at) if @end_at.present?
+        posts
+      end
+    end
+  end
+end

--- a/app/queries/decidim/debates/filtered_debates.rb
+++ b/app/queries/decidim/debates/filtered_debates.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Debates
+    # A class used to find debates filtered by components and a date range
+    class FilteredDebates < Decidim::Query
+      # Syntactic sugar to initialize the class and return the queried objects.
+      #
+      # components - An array of Decidim::Component
+      # start_at - A date to filter resources created after it
+      # end_at - A date to filter resources created before it.
+      def self.for(components, start_at = nil, end_at = nil)
+        new(components, start_at, end_at).query
+      end
+
+      # Initializes the class.
+      #
+      # components - An array of Decidim::Component
+      # start_at - A date to filter resources created after it
+      # end_at - A date to filter resources created before it.
+      def initialize(components, start_at = nil, end_at = nil)
+        @components = components
+        @start_at = start_at
+        @end_at = end_at
+      end
+
+      # Finds the Debates scoped to an array of components and filtered
+      # by a range of dates.
+      def query
+        debates = Decidim::Debates::Debate.where(component: @components)
+        debates = debates.where(created_at: @start_at..) if @start_at.present?
+        debates = debates.where(created_at: ..@end_at) if @end_at.present?
+        debates
+      end
+    end
+  end
+end

--- a/config/initializers/comments_count.rb
+++ b/config/initializers/comments_count.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  # Add :comment_count to accountability_component's stat
+  accountability_component = Decidim.find_component_manifest(:accountability)
+  accountability_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
+    results = Decidim::Accountability::FilteredResults.for(components, start_at, end_at)
+    results.sum(:comments_count)
+  end
+
+  # Add :comment_count to blogs_component's stat
+  blogs_component = Decidim.find_component_manifest(:blogs)
+  blogs_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
+    posts = Decidim::Blogs::FilteredPosts.for(components, start_at, end_at)
+    posts.sum(:comments_count)
+  end
+
+  # Add :comment_count to debates_component's stat
+  debates_component = Decidim.find_component_manifest(:debates)
+  debates_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
+    debates = Decidim::Debates::FilteredDebates.for(components, start_at, end_at)
+    debates.sum(:comments_count)
+  end
+
+  # Add :comment_count to sortitions_component's stat
+  sortitions_component = Decidim.find_component_manifest(:sortitions)
+  sortitions_component.register_stat :comments_count, tag: :comments do |components, start_at, end_at|
+    sortitions = Decidim::Sortitions::FilteredSortitions.for(components, start_at, end_at)
+    sortitions.sum(:comments_count)
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

統計のコメント数について、集計対象を増やします。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
