### PR TITLE
セッションストアとしてcache_storeを使えるよう`DecidimApp::Application`を修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,15 @@ module DecidimApp
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    # skip `session_store` initializer in Decidim::Core::Engine
+    config.before_initialize do
+      Rails.application.initializers.each do |initializer|
+        if initializer.name == "Expire sessions"
+          initializer.instance_eval { @options[:group] = :force_skip }
+          Rails.logger.info "XXX: Skip initializer '#{initializer.name}'"
+        end
+      end
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,8 +19,9 @@ Rails.application.configure do
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
-    if ENV["REDIS_CACHE_URL"] # rubocop:disable Style/ConditionalAssignment
+    if ENV["REDIS_CACHE_URL"]
       config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_CACHE_URL", nil) }
+      config.session_store(:cache_store, key: "decidim_session")
     else
       config.cache_store = :memory_store
     end

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -83,6 +83,13 @@ Decidim本体のバージョンを更新する際、特に注意が必要な内�
 
   https://github.com/codeforjapan/decidim-cfj/pull/455 で追加したもの。ピクセル数の大きい画像に対応するため、max_image_height_or_widthの値を変更している。
 
+* `config/application.rb`
+
+  https://github.com/codeforjapan/decidim-cfj/pull/638 で追加したものです。
+  `config.before_initialize`ブロックで、`Decidim::Core::Engine`内のinitializerのうち`"Expire sessions"`というinitializerをスキップするよう修正しています。
+  これは`session_store`を`cookie_store`に強制していたものを無効化するものです。
+  Decidim v0.28では本体に修正が入っており、アプリ側でsession_storeを指定している場合には自動で無効化されるため、このブロックは不要になります（削除するべきです）。
+
 * `lib/tasks/delete.rake`
 
   `delete:destroy_all`タスク。https://github.com/codeforjapan/decidim-cfj/pull/501 で追加されたものです。


### PR DESCRIPTION
#### :tophat: What? Why?

#630 はDecidimのバージョンをあげると動かなくなるので、（あまり）依存しない形に修正しました。

いずれにしても、v0.28になれば不要になるため、更新時には消す必要があります。

#### 修正方法

initializerは上書きできるという説もあったのですが、いろいろ試してみたところでは結局session_storeの差し替えには失敗してしまうようでした。
そのため、initializerのgroup(指定しない場合は`:default`)を変更することで`run_initializers`実行時に無視されるよう修正したところ、正しく修正されるようだったのでこれにしてみます。

#### :pushpin: Related Issues
- Related to #629 , #630

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
