### PR TITLE
feat: add rake task `i18n_yaml:dump_all`

### DIFF
--- a/lib/tasks/i18n_yaml.rake
+++ b/lib/tasks/i18n_yaml.rake
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+def deep_keys(hash, prefix = "")
+  hash.flat_map do |key, value|
+    full_key = prefix.empty? ? key.to_s : "#{prefix}.#{key}"
+    value.is_a?(Hash) ? deep_keys(value, full_key) : full_key
+  end
+end
+
+namespace :i18n_yaml do
+  desc "dump all locale data for some locale"
+  task dump_all: :environment do
+    locale = :ja
+    all_translations = I18n.t(".", locale:, default: {}).deep_merge({})
+    keys = deep_keys(all_translations)
+    buf = []
+    I18n.with_locale(locale) do
+      keys.each do |key|
+        # skip faker.*
+        next if key.start_with?("faker.")
+
+        buf << "#{key}: #{I18n.t(key)}"
+      rescue StandardError => e
+        warn "ERROR: #{key}, #{e.message}"
+      end
+    end
+
+    puts buf
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

デバッグ用に使うためのrake taskを追加します。

Railsで読み込んでいるlocale/config以下のデータを全部読み込んで出力します。
出力はキーが`.`区切りで並ぶように出力されます。

なおfakerはダミーのデータが多すぎるのでskipするようにしています。

#### Usage:

```console
$ bin/rails i18n_yaml:dump_all > tmp/dump_ja.yml
```

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
