### PR TITLE
menu_highlighted_participatory_process: remove `PromotedParticipatoryProcesses`

### DIFF
--- a/app/helpers/decidim/menu_helper.rb
+++ b/app/helpers/decidim/menu_helper.rb
@@ -59,8 +59,7 @@ module Decidim
 
       @menu_highlighted_participatory_process ||= (
         # The queries already include the order by weight
-        Decidim::ParticipatoryProcesses::OrganizationParticipatoryProcesses.new(current_organization).query.visible_for(current_user) |
-        Decidim::ParticipatoryProcesses::PromotedParticipatoryProcesses.new.query.visible_for(current_user)
+        Decidim::ParticipatoryProcesses::OrganizationParticipatoryProcesses.new(current_organization).query.visible_for(current_user)
       ).first
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

`OrganizationParticipatoryProcesses`は（名前の通り）そのorganizationのプロセスを抽出しているのですが、`PromotedParticipatoryProcesses`はorganizationにまたがるプロセスを抽出しているので、後者は削って前者のみにしてみます。

これで、

* そのorganizationに属していて、
* 現在のユーザーから見ることができる

プロセスから選択されるようになるはずです。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
