### PR TITLE
fix `warning: already initialized constant`

### DIFF
--- a/config/initializers/pg_search_override.rb
+++ b/config/initializers/pg_search_override.rb
@@ -64,7 +64,8 @@ Rails.application.config.to_prepare do
     end
   end
 
-  ## override `PgSearch::ScopeOptions::FEATURE_CLASSES`
+  ## XXX: override `PgSearch::ScopeOptions::FEATURE_CLASSES`
+  PgSearch::ScopeOptions.send(:remove_const, :FEATURE_CLASSES) if PgSearch::ScopeOptions.const_defined?(:FEATURE_CLASSES)
   PgSearch::ScopeOptions::FEATURE_CLASSES = {
     dmetaphone: PgSearch::Features::DMetaphone,
     tsearch: PgSearch::Features::TSearch,

--- a/spec/system/comment_sort_spec.rb
+++ b/spec/system/comment_sort_spec.rb
@@ -19,6 +19,8 @@ describe "Comments", :perform_enqueued do
     create(:comment_vote, comment:, author: user, weight: 1)
 
     visit decidim.root_path(locale: :ja)
+
+    Capybara.raise_server_errors = false
   end
 
   it "allows user to store selected comment order in cookies", :slow do


### PR DESCRIPTION
#### :tophat: What? Why?

警告避けのため、`PgSearch::ScopeOptions::FEATURE_CLASSES`を再定義する前にremove_constします。
（本当は一瞬定数が消えるためthread safeではない処理なので望ましくないですが、初期化時の実行だからまあ大丈夫かなというところです）

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
