### PR TITLE
fix: editor_image permissions for process admin

### DIFF
--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -193,6 +193,34 @@ Rails.application.config.to_prepare do
     end
   end
 
+  module DecidimAdminPermissionsPatch
+    def permissions
+      if user &&
+         permission_action.scope == :admin &&
+         permission_action.subject == :editor_image && (
+           user.admin? ||
+           user.roles.any? ||
+           Decidim::ParticipatoryProcessUserRole.exists?(user:) ||
+           Decidim::AssemblyUserRole.exists?(user:) ||
+           Decidim::ConferenceUserRole.exists?(user:)
+         )
+        allow!
+      end
+
+      super
+    end
+  end
+
+  Decidim::Admin::Permissions # rubocop:disable Lint/Void
+
+  module Decidim
+    module Admin
+      class Permissions < Decidim::DefaultPermissions
+        prepend DecidimAdminPermissionsPatch
+      end
+    end
+  end
+
   # Fix I18n.transliterate()
   I18n.config.backend.instance_eval do
     @transliterators[:ja] = I18n::Backend::Transliterator.get(->(string) { string })

--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -217,6 +217,10 @@ Rails.application.config.to_prepare do
     module Admin
       class Permissions < Decidim::DefaultPermissions
         prepend DecidimAdminPermissionsPatch
+      end
+    end
+  end
+
   # ----------------------------------------
 
   # fix editing the assembly content block


### PR DESCRIPTION
#### :tophat: What? Why?

`editor_image`の権限を修正します。

`Decidim::Admin::Permissions#permissions`で定義されている権限を修正するため`DecidimAdminPermissionsPatch`をprependしています。指定した条件を満たす場合は`allow!`、満たさない場合は`super`で元のメソッドを呼び出しています。

#### 注意点

元にしているのは https://github.com/decidim/decidim/pull/13772 ですが、こちらとは実行順序が違っているので注意が必要です。
ですが、以下の理由により先頭にチェックを突っ込む方法で問題ないと考えています。

なお、コードの通りここで権限を適用する(`allow!`を実行する)条件は以下になります。

- `user`が存在する
- `permission_action.scope == :admin`を満たす
- `permission_action.subject == :editor_image`を満たす
- （その他いろいろ）

よって、上記の条件を満たなさいものについては、実行順序が前後しても問題ないはずです。

元のコードの各行・ブロックごとに確認していきます：

- `return permission_action if managed_user_action?`
  - 挿入している条件は`permission_action.subject == :managed_user`ではないので無視して良さそうです
- `unless permission_action.scope == :admin ....`
  - `permission_action.scope == :admin` ではないので無視して良さそうです
- `unless user ....`
  - userは存在するので無視して良さそうです
- `if user_manager? ....`
  - これは最後に`allow!`するものなので、別の理由で`allow!`するのは問題ないはずです
- `allow! if user_can_enter_space_area?(require_admin_terms_accepted: true)`
  - これも最後に`allow!`するものなので、別の理由で`allow!`するのは問題ないはずです
- `read_admin_dashboard_action?`
  - `permission_action.subject == :admin_dashboard` ではないので無視して良さそうです
- `apply_newsletter_permissions_for_admin!`
  - `permission_action.subject == :newsletter` ではないので無視して良さそうです
- `apply_global_moderations_permission_for_admin!`
  - `permission_action.subject == :global_moderation` ではないので無視して良さそうです

以上で全部なので、実行順序を変えても問題ないと判断しました。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
