### PR TITLE
fix: greeting in mobile account dropdown

### DIFF
--- a/app/views/layouts/decidim/header/_main_links_mobile_account.html.erb
+++ b/app/views/layouts/decidim/header/_main_links_mobile_account.html.erb
@@ -23,7 +23,7 @@
       <%= icon "user-smile-line", class: "main-bar__avatar" %>
     <% end %>
 
-    <p class="h3 mt-2"><%= t("decidim.block_user_mailer.notify.hello") %>&nbsp;<%= current_user.name %></p>
+    <p class="h3 mt-2"><%= t("layouts.decidim.header.hello", name: current_user.name) %></p>
 
     <ul>
       <%= render partial: "layouts/decidim/header/main_links_dropdown" %>

--- a/app/views/layouts/decidim/header/_main_links_mobile_account.html.erb
+++ b/app/views/layouts/decidim/header/_main_links_mobile_account.html.erb
@@ -1,0 +1,32 @@
+<div id="dropdown-menu-account-mobile" class="main-bar__links-mobile__account" aria-hidden="true">
+  <div class="main-bar">
+    <div class="main-bar__logo">
+      <%= render partial: "layouts/decidim/logo", locals: { organization: current_organization } %>
+    </div>
+
+    <div>
+      <div class="main-bar__links-mobile__trigger" onclick="document.querySelector('#dropdown-trigger-links-mobile').click();">
+        <%= icon "close-line" %>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-4 container">
+    <% if current_user.avatar.attached? %>
+      <div class="main-bar__avatar">
+        <%= image_tag(
+                current_user.attached_uploader(:avatar).variant_url(:thumb),
+                alt: t("decidim.author.avatar", name: decidim_sanitize(current_user.avatar.name))
+              ) %>
+      </div>
+    <% else %>
+      <%= icon "user-smile-line", class: "main-bar__avatar" %>
+    <% end %>
+
+    <p class="h3 mt-2"><%= t("decidim.block_user_mailer.notify.hello") %>&nbsp;<%= current_user.name %></p>
+
+    <ul>
+      <%= render partial: "layouts/decidim/header/main_links_dropdown" %>
+    </ul>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,3 +32,7 @@ en:
         male: Male
         not_applicable: Not Applicable
         not_known: Not Known
+  layouts:
+    decidim:
+      header:
+        hello: Hello, %{name}!

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -786,6 +786,8 @@ ja:
       assemblies:
         index:
           promoted_assemblies: 注目の参加スペース
+      header:
+        hello: こんにちは、 %{name} さん
       participatory_processes:
         index:
           promoted_processes: 注目の参加型プロセス


### PR DESCRIPTION
#### :tophat: What? Why?

モバイルで下の「アカウント」ボタンを押した時に出てくるドロップダウンのあいさつメッセージを正しく`I18n.t()`で置き換えられるように修正します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

### before

<img width="507" src="https://github.com/user-attachments/assets/2be61d06-1057-42e9-bf12-718e75becba8" />

### after

<img width="508" alt="スクリーンショット 2025-02-10 22 16 16" src="https://github.com/user-attachments/assets/59d717d7-cda0-4c41-9f7a-864f5bbadf75" />
