### PR TITLE
fix: remove hack to skip session_store

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,15 +33,5 @@ module DecidimApp
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
-
-    # skip `session_store` initializer in Decidim::Core::Engine
-    config.before_initialize do
-      Rails.application.initializers.each do |initializer|
-        if initializer.name == "Expire sessions"
-          initializer.instance_eval { @options[:group] = :force_skip }
-          Rails.logger.info "XXX: Skip initializer '#{initializer.name}'"
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

#638 ではv0.27.x用のcookie session storeを無効化するためのhackを導入しました。
decidim-cfjもv0.28.xになり、このhackは不要になったので消しておきます。

ローカルの開発環境ではこの変更後もRedisでセッション管理していることは確認済みです（が、安全のため他の環境でも丁寧に確認した方が良さそうではあります）。

#### :pushpin: Related Issues
- Related to #638

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
