### PR TITLE
fix: max_results options in highlighted settings

### DIFF
--- a/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
+++ b/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
@@ -1,0 +1,3 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <%= settings_fields.select :max_results, [6, 9, 12], prompt: "", label: %>
+<% end %>

--- a/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
+++ b/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_settings_form/show.erb
@@ -1,3 +1,3 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, [6, 9, 12], prompt: "", label: %>
+  <%= settings_fields.select :max_results, Decidim.max_results_options, prompt: "", label: %>
 <% end %>

--- a/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
+++ b/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
@@ -1,0 +1,3 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <%= settings_fields.select :max_results, [6, 9, 12], prompt: "", label: %>
+<% end %>

--- a/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
+++ b/app/cells/decidim/conferences/content_blocks/highlighted_conferences_settings_form/show.erb
@@ -1,3 +1,3 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, [6, 9, 12], prompt: "", label: %>
+  <%= settings_fields.select :max_results, Decidim.max_results_options, prompt: "", label: %>
 <% end %>

--- a/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
+++ b/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
@@ -1,0 +1,3 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <%= settings_fields.select :max_results, [6, 9, 12], prompt: "", label: %>
+<% end %>

--- a/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
+++ b/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_settings_form/show.erb
@@ -1,3 +1,3 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, [6, 9, 12], prompt: "", label: %>
+  <%= settings_fields.select :max_results, Decidim.max_results_options, prompt: "", label: %>
 <% end %>

--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -251,4 +251,10 @@ Rails.application.config.to_prepare do
     @transliterators[:ja] = I18n::Backend::Transliterator.get(->(string) { string })
     @transliterators[:en] = I18n::Backend::Transliterator.get(->(string) { string })
   end
+
+  module Decidim
+    config_accessor :max_results_options
+  end
+
+  Decidim.max_results_options = [6, 9, 12, 15]
 end


### PR DESCRIPTION
#### :tophat: What? Why?

`Decidim.max_results_options`という設定を追加して、表示する要素の最大量のdropdown listの内容を指定できるようにします。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

<img width="975" alt="dropdown" src="https://github.com/user-attachments/assets/93c103f1-cd03-4db2-9db7-4f960436ce02" />

