### PR TITLE
add editor extension: SimpleImage

### DIFF
--- a/app/packs/src/decidim/cfj/editor/extensions/simple_image/index.js
+++ b/app/packs/src/decidim/cfj/editor/extensions/simple_image/index.js
@@ -1,0 +1,62 @@
+import {
+  mergeAttributes,
+  Node,
+} from '@tiptap/core'
+
+/**
+ * This extension allows you to insert images, usually inline.
+ * @see https://www.tiptap.dev/api/nodes/image
+ */
+export const SimpleImage = Node.create({
+  name: 'simpleImage',
+
+  addOptions() {
+    return {
+      inline: true,
+      HTMLAttributes: {},
+    }
+  },
+
+  inline() {
+    return this.options.inline
+  },
+
+  group() {
+    return this.options.inline ? 'inline' : 'block'
+  },
+
+  draggable: true,
+
+  addAttributes() {
+    return {
+      src: {
+        default: null,
+      },
+      alt: {
+        default: null,
+      },
+      title: {
+        default: null,
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'img[src]:not([src^="data:"])' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['img', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)]
+  },
+
+  addCommands() {
+    return {
+      setImage: options => ({ commands }) => {
+        return commands.insertContent({
+          type: this.name,
+          attrs: options,
+        })
+      },
+    }
+  },
+})

--- a/app/packs/src/decidim/editor/extensions/decidim_kit/index.js
+++ b/app/packs/src/decidim/editor/extensions/decidim_kit/index.js
@@ -18,6 +18,7 @@ import VideoEmbed from "src/decidim/editor/extensions/video_embed";
 import Emoji from "src/decidim/editor/extensions/emoji";
 import TagEdit from "src/decidim/cfj/editor/extensions/tag_edit";
 import Iframe from "src/decidim/cfj/editor/extensions/iframe";
+import { SimpleImage } from "src/decidim/cfj/editor/extensions/simple_image";
 
 export default Extension.create({
   name: "decidimKit",
@@ -86,6 +87,8 @@ export default Extension.create({
     if (this.options.iframe !== false) {
       extensions.push(Iframe.configure(this.options.iframe));
     }
+
+    extensions.push(SimpleImage.configure(true));
 
     return extensions;
   }


### PR DESCRIPTION
#### :tophat: What? Why?

画像が欠落しないようにするため、標準のImageではない画像についてはインライン・編集不可・ダイアログ未対応といったシンプルな画像にするよう修正してみます。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
