### PR TITLE
fix: Hide filter if only a single checkbox is present

### DIFF
--- a/app/views/decidim/shared/_filters.html.erb
+++ b/app/views/decidim/shared/_filters.html.erb
@@ -1,0 +1,42 @@
+<% filter_sections = [] unless local_assigns.has_key?(:filter_sections) %>
+<% search_label = t("decidim.searches.filters.search") unless local_assigns.has_key?(:search_label) %>
+
+<% if filter_sections.present? || local_assigns.has_key?(:search_variable) %>
+  <%= filter_form_for filter, url_for, class: "new_filter self-stretch", data: { filters: "", component: "accordion" } do |form| %>
+
+    <button id="dropdown-trigger-filters" data-component="dropdown" data-target="dropdown-menu-filters">
+      <%= icon "arrow-down-s-line" %>
+      <%= icon "arrow-up-s-line" %>
+      <span>
+        <%= local_assigns.has_key?(:search_variable) ? t("filter_and_search", scope: "decidim.searches.filters_small_view") : t("filter", scope: "decidim.searches.filters_small_view") %>
+      </span>
+    </button>
+
+    <div id="dropdown-menu-filters" aria-hidden="true">
+      <% if local_assigns.has_key?(:skip_to_id) %>
+        <%= link_to t("skip", scope: "decidim.shared.filter_form_help"), "##{skip_to_id}", class: "filter-skip" %>
+      <% end %>
+      <p class="filter-help"><%= t("help", scope: "decidim.shared.filter_form_help") %></p>
+
+      <% if local_assigns.has_key?(:search_variable) %>
+        <div class="filter-search filter-container">
+          <%= form.search_field search_variable,
+                                label: false,
+                                placeholder: search_label,
+                                title: search_label,
+                                "aria-label": search_label %>
+          <button type="submit" aria-label="<%= search_label %>">
+            <%= icon "search-line" %>
+          </button>
+        </div>
+      <% end %>
+
+      <% filter_sections.each do |f| %>
+        <%= form.collection_filter(**f) %>
+      <% end %>
+
+      <%= yield %>
+    </div>
+
+  <% end %>
+<% end %>

--- a/app/views/decidim/shared/_filters.html.erb
+++ b/app/views/decidim/shared/_filters.html.erb
@@ -32,7 +32,9 @@
       <% end %>
 
       <% filter_sections.each do |f| %>
-        <%= form.collection_filter(**f) %>
+        <% unless f[:collection].is_a?(Decidim::CheckBoxesTreeHelper::TreeNode) && f[:collection].node.count == 1 && f[:collection].node[0].is_a?(Decidim::CheckBoxesTreeHelper::TreePoint) %>
+          <%= form.collection_filter(**f) %>
+        <% end %>
       <% end %>
 
       <%= yield %>


### PR DESCRIPTION
#### :tophat: What? Why?

Decidimのフィルターのうち、候補が1つしかないチェックボックスのフィルターは表示させないようにします。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

### before

<img width="333" alt="スクリーンショット 2025-02-27 1 02 34" src="https://github.com/user-attachments/assets/3b7d1b11-eec7-416d-85ab-d5fd4a68dc19" />

### after

<img width="356" alt="スクリーンショット 2025-02-27 1 02 08" src="https://github.com/user-attachments/assets/032624bd-f28d-484f-bc1d-17178b1c3d3f" />

