### PR TITLE
feat: `OmniAuth::Logging` and subscribe hook

### DIFF
--- a/config/initializers/omniauth_logging.rb
+++ b/config/initializers/omniauth_logging.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module OmniAuth
+  module Logging
+    def call_app!(env = @env)
+      ActiveSupport::Notifications.instrument("omniauth.auth.succeed", auth: env["omniauth.auth"]) if env["omniauth.auth"]
+      super
+    end
+  end
+end
+
+# Add logging for all OmniAuth Strategies
+OmniAuth::Strategy.prepend(OmniAuth::Logging)
+
+ActiveSupport::Notifications.subscribe("omniauth.auth.succeed") do |_name, start, finish, _id, payload|
+  auth = payload[:auth]
+  provider = auth["provider"]
+  uid = auth["uid"]
+  email = auth.dig("info", "email") || "N/A"
+
+  Rails.logger.info "[OmniAuth] Duration: #{start} - #{finish}, Provider: #{provider}, UID: #{uid}, Email: #{email}, Auth Data: #{auth.inspect}"
+end


### PR DESCRIPTION
#### :tophat: What? Why?

OmniAuthでログインした際にRailsのログに以下のような情報を出力するようにします。

```
[OmniAuth] Duration: 2025-03-03 20:08:09 +0900 - 2025-03-03 20:08:09 +0900, Provider: line_login, UID: UXXXXXXXXXXXXX, Email: N/A, Auth Data: #<OmniAuth::AuthHash credentials=#<OmniAuth::AuthHash expires=true expires_at=1743592089 refresh_token="XXXXXXXXXXXXx" token="XXXXX.XXXXX-XXXXXX-XXXXXXXXXXX-XXXXXX.XXXXXX"> extra=#<OmniAuth::AuthHash> info=#<OmniAuth::AuthHash::InfoHash email=nil image=nil name="foobar" user_id="XXXXX"> provider="line_login" uid="XXXXX">
```

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
