### PR TITLE
fix: iframe: allow any domains

### DIFF
--- a/app/packs/src/decidim/cfj/editor/extensions/iframe/index.js
+++ b/app/packs/src/decidim/cfj/editor/extensions/iframe/index.js
@@ -1,14 +1,10 @@
 import { Node } from "@tiptap/core"
 
-const iframeAllowedDomains = ["www.youtube.com", "www.youtube-nocookie.com", "vimeo.com", "docs.google.com", "www.slideshare.net"];
-
 const isAllowedDomain = (src) => {
   if (!src) return false;
-  for (const domain of iframeAllowedDomains) {
-    const domainPattern = new RegExp(`^https://${domain}/`);
-    if (domainPattern.test(src)) {
-      return true;
-    }
+  const domainPattern = new RegExp(`^https://.*/`);
+  if (domainPattern.test(src)) {
+    return true;
   }
   return false;
 };


### PR DESCRIPTION
#### :tophat: What? Why?

iframeを許可するドメインのチェックをコード内で行っていたのですが、CSPがあるのでCSPにおまかせすることにします。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
