### PR TITLE
fix: add `chromium-driver`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN  apt-get update && \
         curl \
         p7zip \
         wkhtmltopdf \
+        chromium-driver \
         wget && \
     apt-get clean && \
     apt-get autoremove


### PR DESCRIPTION
#### :tophat: What? Why?

https://github.com/TheDesignium/omniauth-cityos-dcp/issues/3#issuecomment-2720135934 の対応で、docker環境でもseleniumのテストできるよう、イメージに`chromium-driver`を追加しておきます。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
