### PR TITLE
fix: disable external link to attached documents

### DIFF
--- a/app/views/decidim/application/_document.html.erb
+++ b/app/views/decidim/application/_document.html.erb
@@ -1,0 +1,23 @@
+<div id="<%= dom_id(document) %>">
+  <div class="card__list-content">
+    <%= link_to document.url, target: "_blank", rel: "noopener noreferrer", class: "card__list-title", title: t("decidim.application.document.download") do %>
+      <%= h attachment_title(document) %>
+    <% end %>
+    <% if document.description.present? %>
+      <div class="card__list-text"><%= decidim_escape_translated(document.description) %></div>
+    <% end %>
+    <div class="card__list-metadata">
+      <div><%= icon "file-text-line" %><%= document.file_type %></div>
+      <div><%= icon "scales-2-line" %><%= number_to_human_size(document.file_size) %></div>
+    </div>
+  </div>
+  <%= link_to document.url,
+              target: "_blank",
+              rel: "noopener noreferrer",
+              class: "button button__sm button__transparent-secondary flex-none",
+              title: t("decidim.application.document.download"),
+              data: { "external-link": false } do %>
+    <%= t("decidim.application.document.download") %>
+    <%= icon "download-line" %>
+  <% end %>
+</div>

--- a/app/views/decidim/application/_document.html.erb
+++ b/app/views/decidim/application/_document.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id(document) %>">
   <div class="card__list-content">
-    <%= link_to document.url, target: "_blank", rel: "noopener noreferrer", class: "card__list-title", title: t("decidim.application.document.download") do %>
+    <%= link_to document.url, target: "_blank", rel: "noopener noreferrer", class: "card__list-title", title: t("decidim.application.document.download"), data: { "external-link": false } do %>
       <%= h attachment_title(document) %>
     <% end %>
     <% if document.description.present? %>

--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -283,4 +283,7 @@ Rails.application.config.to_prepare do
   end
 
   Decidim.max_results_options = [6, 9, 12, 15]
+
+  # Insert `app/views` into Cell::ViewModel.view_paths to load application's views
+  Cell::ViewModel.view_paths.insert(1, Rails.root.join("app/views"))
 end


### PR DESCRIPTION
#### :tophat: What? Why?

meetingの添付ドキュメントについて、外部リンクの扱いをやめるよう修正します。

その際、cellからpartialを呼ぶ時にアプリ側のviewsが読み込まれないようだったので、`Cell::ViewModel.view_paths`も修正してみます。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
