### PR TITLE
remove setImage in SimpleImage; use original function

### DIFF
--- a/app/packs/src/decidim/cfj/editor/extensions/simple_image/index.js
+++ b/app/packs/src/decidim/cfj/editor/extensions/simple_image/index.js
@@ -48,15 +48,4 @@ export const SimpleImage = Node.create({
   renderHTML({ HTMLAttributes }) {
     return ['img', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)]
   },
-
-  addCommands() {
-    return {
-      setImage: options => ({ commands }) => {
-        return commands.insertContent({
-          type: this.name,
-          attrs: options,
-        })
-      },
-    }
-  },
 })


### PR DESCRIPTION
#### :tophat: What? Why?

画像アップロードの挙動に問題があるようなので、SimpleImage拡張内のsetImageを消してみます。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
