### PR TITLE
fix: default_locale should be `ja`

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -14,7 +14,7 @@ decidim_default: &decidim_default
   application_name: <%= Decidim::Env.new("DECIDIM_APPLICATION_NAME", "Code for Japan Decidim").to_json %>
   mailer_sender: <%= Decidim::Env.new("DECIDIM_MAILER_SENDER", "info@diycities.jp").to_s %>
   available_locales: <%= Decidim::Env.new("DECIDIM_AVAILABLE_LOCALES", "ca,cs,de,en,es,eu,fi,fr,it,ja,nl,pl,pt,ro").to_array.to_json %>
-  default_locale: <%= Decidim::Env.new("DECIDIM_DEFAULT_LOCALE", "en").to_s %>
+  default_locale: <%= Decidim::Env.new("DECIDIM_DEFAULT_LOCALE", "ja").to_s %>
   force_ssl: <%= Decidim::Env.new("DECIDIM_FORCE_SSL", "auto").default_or_present_if_exists.to_s %>
   enable_html_header_snippets: <%= Decidim::Env.new("DECIDIM_ENABLE_HTML_HEADER_SNIPPETS").to_boolean_string %>
   currency_unit: <%= Decidim::Env.new("DECIDIM_CURRENCY_UNIT", "€").to_s %>


### PR DESCRIPTION
#### :tophat: What? Why?

現状では環境変数を設定しないとlocaleが`en`になるため、無設定でも`ja`になるよう修正します。
環境変数`DECIDIM_DEFAULT_LOCALE`を設定すれば`en`にもできます。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
