### PR TITLE
fix: remove old styles

### DIFF
--- a/app/packs/stylesheets/decidim/cfj/buttons.scss
+++ b/app/packs/stylesheets/decidim/cfj/buttons.scss
@@ -1,9 +1,0 @@
-/* fix decidim-core/app/assets/stylesheets/decidim/modules/_buttons.scss */
-.button--social{
-  padding: 0;
-}
-.button--social__icon,
-.button--social__text{
-  text-align: center;
-  margin: 0;
-}

--- a/app/packs/stylesheets/decidim/cfj/decidim.scss
+++ b/app/packs/stylesheets/decidim/cfj/decidim.scss
@@ -59,21 +59,6 @@
   background-position: center left;
 }
 
-.logo-wrapper {
-  width: 20%;
-}
-
-.user-nickname {
-  .small-11.large-11.columns {
-    width: 88%;
-    float: left;
-  }
-
-  #registration_user_nickname_characters {
-    display: inline-block;
-  }
-}
-
 // overide existing styles
 .navbar {
   background: $menu;

--- a/app/packs/stylesheets/decidim/cfj/settings.scss
+++ b/app/packs/stylesheets/decidim/cfj/settings.scss
@@ -4,4 +4,3 @@ $bgcolor: #fffffe;
 $headline: #28abb9;
 $menu: #2d6187;
 $point-color: #ef4565;
-$paragraph: #5f6c7b;

--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -4,7 +4,6 @@
 //
 //
 // By default this is empty.
-@import "./cfj/buttons";
 @import "./cfj/comment_content";
 @import "./cfj/forms";
 @import "./cfj/media_print";


### PR DESCRIPTION
#### :tophat: What? Why?

都合により #701 のブランチへのPRになっているので、先に #701 がマージされている前提のPRです。

独自に上書きして修正しているCSSについて、不要になっていると思われるものを消します。

- `buttons.scss`については #96 で追加したものですが、redesignによりデザインが大きく変わったこともあり、現在は適用されていません。現在のボタンに合わせて修正することもできなくはないですが、現状のデザインでも特に不満がないのであればこのまま追加したCSS側を消すのでもいいかな？と思われます。
- `decidim.scss`への修正についても、現在該当するクラス名のクラスが使われていないようでした
- `settings.scss`の`$paragraph`ですが、これも使われていないようでした。なお他の`settings.scss`で定義されているCSS変数は現在も使われているようです。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
