### PR TITLE
Add Japanese translations for `notifications_digest_mailer.*.real_time`

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -142,6 +142,11 @@ ja:
       content_blocks:
         navigation_map:
           view: 表示
+    notifications_digest_mailer:
+      header:
+        real_time: リアルタイム
+      intro:
+        real_time: 'あなたがフォローしているアクティビティに基づいた通知です:'
     notifications_settings:
       show:
         allow_public_contact: フォローしていない人からのダイレクトメッセージを受信する

--- a/spec/mailers/notifications_digest_mailer_spec.rb
+++ b/spec/mailers/notifications_digest_mailer_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Decidim
+  describe NotificationsDigestMailer do
+    let(:organization) { create(:organization, name: "Test Organization") }
+    let(:user) { create(:user, :admin, organization:, locale: "ja", notifications_sending_frequency: "real_time") }
+    let(:decidim) { Decidim::Core::Engine.routes.url_helpers }
+
+    describe "#notifications_digest" do
+      let(:mail) { described_class.digest_mail(user, notification_ids) }
+      let(:notification_ids) { [notification.id] }
+      let(:resource) { create(:proposal, component: create(:component, manifest_name: "proposals")) }
+      let(:notification) { create(:notification, user:, resource:) }
+
+      describe "email body" do
+        it "includes the real-time header translation" do
+          expect(email_body(mail)).to include('<p class="email-header"> リアルタイム </p>')
+        end
+
+        it "includes the real-time intro translation" do
+          expect(email_body(mail)).to include("あなたがフォローしているアクティビティに基づいた通知です:")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

翻訳が漏れていたので追加します

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
