### PR TITLE
feat: 「共有」ボタンと「あなたの意見」ボタンを非表示にする設定を追加

### DIFF
--- a/app/cells/decidim/comments/comment_form/opinion.erb
+++ b/app/cells/decidim/comments/comment_form/opinion.erb
@@ -1,0 +1,18 @@
+<div>
+  <span class="comment__opinion-label"><%= t("decidim.components.add_comment_form.opinion.label") %></span>
+  <div data-opinion-toggle class="comment__opinion-container">
+    <button type="button" aria-pressed="false" data-toggle-ok="true" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.positive_selected") %>">
+      <span><%= t("decidim.components.comment.alignment.in_favor") %></span>
+      <%= icon "thumb-up-line" %>
+    </button>
+    <button type="button" aria-pressed="true" class="is-active" data-toggle-meh="true" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.neutral_selected") %>">
+      <span><%= t("decidim.components.add_comment_form.opinion.neutral") %></span>
+      <%= icon "loader-3-line" %>
+    </button>
+    <button type="button" aria-pressed="false" data-toggle-ko="true" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.negative_selected") %>">
+      <span><%= t("decidim.components.comment.alignment.against") %></span>
+      <%= icon "thumb-down-line" %>
+    </button>
+    <div role="alert" aria-live="assertive" aria-atomic="true" class="selected-state sr-only"></div>
+  </div>
+</div>

--- a/app/cells/decidim/comments/comment_form/opinion.erb
+++ b/app/cells/decidim/comments/comment_form/opinion.erb
@@ -1,4 +1,5 @@
 <div>
+<% if !current_component.settings[:comment_opinion_disabled] || !current_component.settings.comment_opinion_disabled? %>
   <span class="comment__opinion-label"><%= t("decidim.components.add_comment_form.opinion.label") %></span>
   <div data-opinion-toggle class="comment__opinion-container">
     <button type="button" aria-pressed="false" data-toggle-ok="true" data-selected-label="<%= t("decidim.components.add_comment_form.opinion.positive_selected") %>">
@@ -15,4 +16,5 @@
     </button>
     <div role="alert" aria-live="assertive" aria-atomic="true" class="selected-state sr-only"></div>
   </div>
+<% end %>
 </div>

--- a/app/jobs/purge_component_cache_job.rb
+++ b/app/jobs/purge_component_cache_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PurgeComponentCacheJob < ApplicationJob
   def perform(component_id)
     component = Decidim::Component.find(component_id)
@@ -6,9 +8,9 @@ class PurgeComponentCacheJob < ApplicationJob
 
   private
 
-  def clear_all_related_caches(component)
+  def clear_all_related_caches(_component)
     patterns = [
-      "cells/decidim/comments/comment_form/*",
+      "cells/decidim/comments/comment_form/*"
     ]
 
     patterns.each do |pattern|

--- a/app/jobs/purge_component_cache_job.rb
+++ b/app/jobs/purge_component_cache_job.rb
@@ -1,0 +1,19 @@
+class PurgeComponentCacheJob < ApplicationJob
+  def perform(component_id)
+    component = Decidim::Component.find(component_id)
+    clear_all_related_caches(component)
+  end
+
+  private
+
+  def clear_all_related_caches(component)
+    patterns = [
+      "cells/decidim/comments/comment_form/*",
+    ]
+
+    patterns.each do |pattern|
+      count = Rails.cache.delete_matched(pattern)
+      Rails.logger.info "Purged #{count} cache entries matching #{pattern}"
+    end
+  end
+end

--- a/app/views/decidim/proposals/proposals/_proposal_aside.html.erb
+++ b/app/views/decidim/proposals/proposals/_proposal_aside.html.erb
@@ -1,0 +1,42 @@
+<% if current_settings.votes_enabled? && (show_endorsements_card? || current_user) %>
+<section class="layout-aside__section">
+  <div class="proposal__aside-vote layout-aside__ctas-buttons" data-sticky-buttons>
+    <%= render partial: "vote_button", locals: { proposal: @proposal, from_proposals_list: false } unless @proposal.withdrawn? %>
+    <%= render partial: "votes_count", locals: { proposal: @proposal, from_proposals_list: false } %>
+  </div>
+</section>
+<% end %>
+
+<% if (@proposal.amendable? && allowed_to?(:edit, :proposal, proposal: @proposal)) || (amendments_enabled? && @proposal.amendable? && current_component.current_settings.amendment_creation_enabled && can_participate_in_private_space?) || amendments_enabled? && can_react_to_emendation?(@proposal) || @proposal.withdrawable_by?(current_user) %>
+<section class="layout-aside__section layout-aside__buttons">
+  <% if @proposal.amendable? && allowed_to?(:edit, :proposal, proposal: @proposal) %>
+    <%= link_to edit_proposal_path(@proposal), class: "button button__sm button__transparent-secondary w-full" do %>
+    <span><%= t("edit_proposal", scope: "decidim.proposals.proposals.show") %></span>
+    <%= icon "pencil-line" %>
+    <% end %>
+  <% else %>
+    <%= amend_button_for @proposal %>
+  <% end %>
+
+  <% if amendments_enabled? && can_react_to_emendation?(@proposal) %>
+    <%= emendation_actions_for @proposal %>
+  <% end %>
+
+  <% if @proposal.withdrawable_by?(current_user) %>
+    <%= action_authorized_link_to :withdraw, withdraw_proposal_path(@proposal), method: :put, class: "button button__sm button__transparent-secondary w-full", title: t("withdraw_btn_hint", scope: "decidim.proposals.proposals.show" ), data: { confirm: t("withdraw_confirmation_html", scope: "decidim.proposals.proposals.show" ) } do %>
+      <span><%= t("withdraw_proposal", scope: "decidim.proposals.proposals.show") %></span>
+    <% end %>
+  <% end %>
+</section>
+<% end %>
+
+<section class="layout-aside__section">
+  <%= cell "decidim/proposals/proposal_link_to_collaborative_draft", @proposal %>
+  <%= cell "decidim/proposals/proposal_link_to_rejected_emendation", @proposal %>
+</section>
+
+<section class="layout-aside__section actions__secondary">
+  <%= follow_button_for(@proposal) %>
+  <%= cell "decidim/share_button", nil %>
+  <%= cell "decidim/report_button", @proposal %>
+</section>

--- a/app/views/decidim/proposals/proposals/_proposal_aside.html.erb
+++ b/app/views/decidim/proposals/proposals/_proposal_aside.html.erb
@@ -37,6 +37,8 @@
 
 <section class="layout-aside__section actions__secondary">
   <%= follow_button_for(@proposal) %>
+  <% if !current_component.settings[:share_button_disabled] || !current_component.settings.share_button_disabled? %>
   <%= cell "decidim/share_button", nil %>
+  <% end %>
   <%= cell "decidim/report_button", @proposal %>
 </section>

--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -325,4 +325,19 @@ Rails.application.config.to_prepare do
       prepend DecidimProfileActionsDisableMessagePatch
     end
   end
+
+  # ----------------------------------------
+
+  # add settings for comments
+  [:proposals, :debates].each do |component_module|
+    manifest = Decidim.find_component_manifest(component_module)
+    manifest.settings(:global) do |settings|
+      settings.attribute :share_button_disabled, type: :boolean, default: false
+      settings.attribute :comment_opinion_disabled, type: :boolean, default: false
+    end
+
+    manifest.on(:update) do |component|
+      PurgeComponentCacheJob.perform_later(component.id)
+    end
+  end
 end

--- a/config/locales/component_settings.ja.yml
+++ b/config/locales/component_settings.ja.yml
@@ -1,0 +1,13 @@
+ja:
+  decidim:
+    components:
+      proposals:
+        settings:
+          global:
+            share_button_disabled: 共有ボタンを非表示にする
+            comment_opinion_disabled: コメントでのあなたの意見ボタンを非表示にする
+      debates:
+        settings:
+          global:
+            share_button_disabled: 共有ボタンを非表示にする
+            comment_opinion_disabled: コメントでのあなたの意見ボタンを非表示にする


### PR DESCRIPTION
#### :tophat: What? Why?

コンポーネントの設定(settings)に追加して、「共有」ボタンと「あなたの意見」ボタンを非表示にする設定を追加します。

設定は管理画面でのコンポーネントの設定画面から行います。チェックボックスが追加されるので、チェックを入れれば非表示になります。
この設定が行われないコンポーネント種別の場合はチェックボックスが表示されません。現状は提案コンポーネントとディベートコンポーネントが対象です。
なお個別のコンポーネント単位ではなく、コンポーネント種別まるごと適用になるはずです。

コメントの「あなたの意見」ボタンは、cellごとキャッシュされているため、単純に設定を変更しただけでは一定期間キャッシュが聞いて表示・非表示が切り替わりません。そのため、コンポーネントの設定が更新されるとコメントフォームのキャッシュをpurgeする処理（Job）を追加しています。
関係ないキャシュも一部purgeされてしまうようですが、（多少遅くなることはあっても）挙動には影響しないはずです。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

#### 管理画面での設定項目

<img width="464" height="177" alt="設定画面" src="https://github.com/user-attachments/assets/93985f8b-5262-4fd9-a42f-c356416f6a8d" />

#### 「あなたの意見」表示

<img width="878" height="370" alt="あなたの意見表示" src="https://github.com/user-attachments/assets/ac253524-2d0b-423e-a337-524e7e26d50b" />

#### 「あなたの意見」非表示

<img width="878" height="343" alt="あなたの意見非表示" src="https://github.com/user-attachments/assets/1c98444e-febc-40b4-944c-a8fd2cbd5244" />

#### 共有ボタン表示

<img width="337" height="344" alt="共有ボタン表示" src="https://github.com/user-attachments/assets/6ca89629-1ee9-4ee0-9c18-efcf7079ce95" />

#### 共有ボタン非表示

<img width="330" height="295" alt="共有ボタン非表示" src="https://github.com/user-attachments/assets/54a0ae4e-721b-4a0b-ad8c-909060d4467d" />
