### PR TITLE
fix: add locales in EN

### DIFF
--- a/config/locales/component_settings.en.yml
+++ b/config/locales/component_settings.en.yml
@@ -1,0 +1,13 @@
+en:
+  decidim:
+    components:
+      proposals:
+        settings:
+          global:
+            share_button_disabled: Share button disabled
+            comment_opinion_disabled: Your opinion in comments disabled
+      debates:
+        settings:
+          global:
+            share_button_disabled: Share button disabled
+            comment_opinion_disabled: Your opinion in comments disabled


### PR DESCRIPTION
#### :tophat: What? Why?

#720 で英語版でも日本語のコメントが表示されてしまうので追加しておきます。

#### :pushpin: Related Issues
- Related to #720

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

英語版では以下のようになります。

<img width="606" height="201" alt="locale-en" src="https://github.com/user-attachments/assets/5d0f4bb7-2840-4280-9699-7eb3e9327526" />

