### PR TITLE
fix: remove aria attribute as v0.29.2

### DIFF
--- a/app/views/decidim/shared/_filters.html.erb
+++ b/app/views/decidim/shared/_filters.html.erb
@@ -12,7 +12,7 @@
       </span>
     </button>
 
-    <div id="dropdown-menu-filters" aria-hidden="true">
+    <div id="dropdown-menu-filters">
       <% if local_assigns.has_key?(:skip_to_id) %>
         <%= link_to t("skip", scope: "decidim.shared.filter_form_help"), "##{skip_to_id}", class: "filter-skip", role: "menuitem" %>
       <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

v0.29.2の変更に合わせて`aria-hidden`属性を削除します。

アクセシビリティのための修正（読み上げさせてなかったものを読み上げられるようにする）なので、通常のブラウザで閲覧する分には挙動は変わらないはずです。

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
