### PR TITLE
fix: add footer_topics in footer

### DIFF
--- a/app/views/layouts/decidim/footer/_main_links.html.erb
+++ b/app/views/layouts/decidim/footer/_main_links.html.erb
@@ -16,3 +16,5 @@
     <% end %>
   </ul>
 </nav>
+
+<%= cell("decidim/footer_topics", nil) %>


### PR DESCRIPTION
#### :tophat: What? Why?

フッターにHelp等をいれるものです。これもv0.29.2からのコピーです。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

↓これの「Help」になるはずです。設定によって項目は変わるはずです（ページを増やせる）。

<img width="610" height="234" src="https://github.com/user-attachments/assets/3d24bc18-3940-4582-8829-70be4d3bec34" />
