### PR TITLE
fix: invitation edit view template terms-of-service

### DIFF
--- a/app/views/decidim/devise/invitations/edit.html.erb
+++ b/app/views/decidim/devise/invitations/edit.html.erb
@@ -1,0 +1,54 @@
+<%= render layout: "layouts/decidim/shared/layout_center" do %>
+
+  <div class="text-center py-12">
+    <h1 class="title-decorator inline-block text-left mb-12"><%= t "devise.invitations.edit.header" %></h1>
+
+    <p class="text-lg text-gray-2">
+      <%= t("devise.invitations.edit.subtitle").html_safe %>
+    </p>
+  </div>
+
+  <%= decidim_form_for resource, namespace: "invitation", as: resource_name, url: invitation_path(resource_name, invite_redirect: params[:invite_redirect]), html: { method: :put, class: "register-form new_user" } do |f| %>
+    <%= form_required_explanation %>
+
+    <div class="form__wrapper">
+      <%= f.hidden_field :invitation_token %>
+
+      <%= f.text_field :nickname, help_text: t("devise.invitations.edit.nickname_help", organization: current_organization_name), required: "required", autocomplete: "nickname" %>
+
+      <% if f.object.class.require_password_on_accepting %>
+        <%= render partial: "decidim/account/password_fields", locals: { form: f, user: :user } %>
+      <% end %>
+    </div>
+
+    <div class="form__wrapper-block">
+      <h4 class="h4"><%= t("tos_title", scope: "decidim.devise.registrations.new") %></h4>
+
+      <div>
+        <% terms_of_service_summary_content_blocks.each do |content_block| %>
+          <%= cell content_block.manifest.cell, content_block %>
+        <% end %>
+      </div>
+
+      <% link = link_to t("terms", scope: "decidim.devise.registrations.new"), page_path("terms-of-service"), target: "_blank" %>
+      <% label = t("tos_agreement", scope: "decidim.devise.registrations.new", link:) %>
+      <%= f.check_box :tos_agreement, label:, required: "required", label_options: { class: "form__wrapper-checkbox-label" } %>
+    </div>
+
+    <div class="form__wrapper-block">
+      <h4 class="h4"><%= t("newsletter_title", scope: "decidim.devise.registrations.new") %></h4>
+      <%= label_tag :"#{resource_name}[newsletter_notifications]", class: "form__wrapper-checkbox-label" do %>
+        <%= check_box_tag :"#{resource_name}[newsletter_notifications]" %>
+        <%= t("newsletter", scope: "decidim.devise.registrations.new") %>
+      <% end %>
+    </div>
+
+    <div class="form__wrapper-block">
+      <button type="submit" class="button button__lg button__secondary">
+        <%= t("devise.invitations.edit.submit_button") %>
+        <%= icon "arrow-right-line", class: "fill-current" %>
+      </button>
+    </div>
+
+  <% end %>
+<% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
認証を必須にしている場合に、プライベート参加者のアカウント作成ページで、利用規約が旧URLになっており、閲覧できない問題の修正

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
