### PR TITLE
fix: ディベートでの「共有」ボタンと「あなたの意見」ボタン非表示設定を修正

### DIFF
--- a/app/views/decidim/debates/debates/show.html.erb
+++ b/app/views/decidim/debates/debates/show.html.erb
@@ -1,0 +1,136 @@
+<% add_decidim_meta_tags({
+                           description: translated_attribute(debate.description),
+                           title: present(debate).title,
+                           url: debate_url(debate.id)
+                         }) %>
+
+<%
+edit_link(
+  resource_locator(debate).edit,
+  :update,
+  :debate,
+  debate:
+)
+%>
+
+<%=
+  render partial: "close_debate_modal", locals: {
+    debate:,
+    form: close_debate_form
+  }
+%>
+
+<%= render layout: "layouts/decidim/shared/layout_item", locals: { back_path: debates_path, commentable: debate } do %>
+  <section class="layout-main__section layout-main__heading">
+    <h1 class="h2 decorator">
+      <%== present(debate).title(links: true, html_escape: true) %>
+    </h1>
+
+    <% debate_presenter = Decidim::Debates::DebatePresenter.new(debate) %>
+    <div class="layout-author">
+      <%= cell "decidim/author", debate_presenter.author, skip_profile_link: true %>
+      <% if debate.closed? %>
+        <span class="success label">
+          <%= t("debate_closed", scope: "decidim.debates.debates.show") %>
+        </span>
+      <% end %>
+    </div>
+  </section>
+
+  <section class="layout-main__section">
+    <div class="editor-content">
+      <%= render_debate_description(debate) %>
+    </div>
+  </section>
+
+  <% if debate.closed? || translated_attribute(debate.instructions).present? || translated_attribute(debate.information_updates).present? %>
+    <section class="layout-main__section">
+      <%= cell("decidim/announcement", { title: t("debate_conclusions_are", scope: "decidim.debates.debates.show", date: l(debate.closed_at, format: :decidim_short)), body: simple_format(translated_attribute(debate.conclusions)) }, callout_class: "success") if debate.closed? %>
+
+      <%= cell("decidim/announcement", decidim_sanitize_editor_admin(simple_format(translated_attribute(debate.instructions), {}, sanitize: false))) if translated_attribute(debate.instructions).present? %>
+
+      <%= cell("decidim/announcement", decidim_sanitize_editor_admin(simple_format(translated_attribute(debate.information_updates), {}, sanitize: false)), callout_class: "success") if translated_attribute(debate.information_updates).present? %>
+    </section>
+  <% end %>
+
+  <section class="layout-main__section layout-main__buttons" data-buttons>
+    <% if endorsements_enabled? %>
+      <% if allowed_to?(:endorse, :debate, debate: debate) %>
+        <%= endorsement_buttons_cell(debate) %>
+      <% else %>
+        <%= endorsers_list_cell(debate) %>
+      <% end %>
+    <% end %>
+    <%= cell "decidim/comments_button", nil %>
+
+    <div class="ml-auto">
+      <%= render partial: "decidim/shared/tags", locals: { resource: debate } %>
+    </div>
+  </section>
+  <%= cell "decidim/endorsers_list", debate, layout: :full %>
+
+  <% content_for :aside do %>
+  <% if allowed_to?(:edit, :debate, debate: debate) || admin_allowed_to?(:update, :debate, debate: debate) || allowed_to?(:close, :debate, debate: debate) || admin_allowed_to?(:close, :debate, debate: debate) %>
+    <section class="layout-aside__section layout-aside__buttons">
+      <% if allowed_to?(:edit, :debate, debate: debate) %>
+        <%= link_to t("edit_debate", scope: "decidim.debates.debates.show"), edit_debate_path(debate), class: "button button__secondary button__xl w-full mb-4" %>
+      <% elsif admin_allowed_to?(:update, :debate, debate: debate) %>
+        <%= link_to t("edit_debate", scope: "decidim.debates.debates.show"), resource_locator(debate).edit, class: "button button__secondary button__xl w-full mb-4" %>
+      <% end %>
+      <% close_debate_action_text = (debate.closed? ? "decidim.debates.debates.show.edit_conclusions" : "decidim.debates.debates.show.close_debate" ) %>
+      <% if allowed_to?(:close, :debate, debate: debate) %>
+        <button type="button" data-dialog-open="close-debate" title="<%= t(close_debate_action_text) %>" aria-controls="closeDebateModal" aria-haspopup="dialog" tabindex="0" class="button button__secondary button__xl w-full mb-4">
+          <%= t(close_debate_action_text) %>
+        </button>
+      <% elsif admin_allowed_to?(:close, :debate, debate: debate) %>
+        <%= link_to t(close_debate_action_text), Decidim::EngineRouter.admin_proxy(debate.component).edit_debate_debate_close_path(debate_id: debate.id, id: debate.id), class: "button button__secondary button__xl w-full mb-4" %>
+      <% end %>
+    </section>
+  <% end %>
+  <section class="layout-aside__section">
+    <div class="rounded p-4 bg-background mb-4 divide-y divide-gray-3 [&>*]:py-4 first:[&>*]:pt-0 last:[&>*]:pb-0">
+      <div class="text-gray-2 space-y-1.5">
+        <div class="text-sm flex items-center gap-1">
+          <%= icon "calendar-line", class: "inline-block" %>
+          <span class="text-gray-2 space-y-1.5"><%= t("start", scope: "decidim.debates.models.debate.fields") %> - <%= t("end", scope: "decidim.debates.models.debate.fields") %></span>
+        </div>
+
+        <div class="text-md font-semibold [&>svg]:inline-block">
+          <%= format_date_range(debate.start_time, debate.end_time) || t("open", scope: "decidim.debates.debates.show") %>
+        </div>
+      </div>
+      <div class="text-gray-2 space-y-1.5">
+        <div class="text-sm grid grid-cols-2 gap-1">
+          <div>
+            <span class="block text-center mb-2">
+              <%= t("participants_count", scope: "decidim.debates.debates.show") %>
+            </span>
+            <span class="text-4xl font-bold block text-center"><%= debate_presenter.participants_count %></span>
+          </div>
+          <div>
+            <span class="block text-center mb-2">
+              <%= t("groups_count", scope: "decidim.debates.debates.show") %>
+            </span>
+            <span class="text-4xl font-bold block text-center"><%= debate_presenter.groups_count %></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section class="layout-aside__section actions__secondary">
+    <%= follow_button_for(debate) %>
+    <%= cell "decidim/share_button", nil %>
+    <%= cell "decidim/report_button", debate %>
+  </section>
+
+  <% end %>
+
+  <% content_for :item_footer do %>
+    <%= comments_for debate %>
+    <ul class="metadata__container layout-main__section" data-metadata-footer>
+      <%= content_tag :li, resource_reference(debate), class: "metadata__item" %>
+      <%= content_tag :li, resource_version(debate, versions_path: debate_version_path(debate, debate.versions.count)), class: "metadata__item" %>
+    </ul>
+  <% end %>
+
+<% end %>

--- a/app/views/decidim/debates/debates/show.html.erb
+++ b/app/views/decidim/debates/debates/show.html.erb
@@ -119,7 +119,9 @@ edit_link(
   </section>
   <section class="layout-aside__section actions__secondary">
     <%= follow_button_for(debate) %>
+    <% if !current_component.settings[:share_button_disabled] || !current_component.settings.share_button_disabled? %>
     <%= cell "decidim/share_button", nil %>
+    <% end %>
     <%= cell "decidim/report_button", debate %>
   </section>
 


### PR DESCRIPTION
#### :tophat: What? Why?

ディベートで正しく動いていなかったのを修正します。

#### :pushpin: Related Issues
- Related to #720

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

### 通常設定
<img width="271" height="354" alt="スクリーンショット 2025-07-31 19 30 14" src="https://github.com/user-attachments/assets/c51f5b7b-5c1e-455f-b530-f768245c8bdd" />

----

<img width="721" height="362" alt="スクリーンショット 2025-07-31 19 30 31" src="https://github.com/user-attachments/assets/3cefa18b-5dcd-4f05-af27-89645e105349" />

----

### 非表示設定

<img width="302" height="330" alt="スクリーンショット 2025-07-31 19 31 02" src="https://github.com/user-attachments/assets/a7256479-ce0f-4731-acf7-2e09a1c261d4" />

----

<img width="734" height="334" alt="スクリーンショット 2025-07-31 19 30 58" src="https://github.com/user-attachments/assets/7c010ed1-2d7a-4a4a-8e71-ee942065bbc4" />

