### PR TITLE
fix: 管理画面でnicknameが空のユーザーのエラーを修正

### DIFF
--- a/app/views/decidim/admin/officializations/index.html.erb
+++ b/app/views/decidim/admin/officializations/index.html.erb
@@ -20,12 +20,12 @@
       <tbody>
       <% @users.each do |user| %>
         <tr data-user-id="<%= user.id %>">
-          <% if user.nickname.to_s.strip.present? %>
+          <% if user.nickname.present? %>
             <td><%= link_to user.name, decidim.profile_path(user.nickname) %></td>
             <td><%= link_to user.nickname, decidim.profile_path(user.nickname) %></td>
           <% else %>
             <td><%= user.name %></td>
-            <td><%= user.nickname.presence || "" %></td>
+            <td><%= user.nickname %></td>
           <% end %>
           <td><%= l user.created_at, format: :short %></td>
           <td><%= user.officialized? ? t(".officialized") : t(".not_officialized") %></td>

--- a/app/views/decidim/admin/officializations/index.html.erb
+++ b/app/views/decidim/admin/officializations/index.html.erb
@@ -1,0 +1,68 @@
+<% add_decidim_page_title(t("decidim.admin.titles.participants")) %>
+<div class="card" id="user-groups">
+  <div class="item_show__header">
+    <h1 class="item_show__header-title"><%= t "decidim.admin.titles.participants" %></h1>
+  </div>
+  <%= admin_filter_selector %>
+  <div class="table-scroll">
+    <table class="table-list">
+      <thead>
+      <tr>
+        <th><%= sort_link(query, :name, t(".name"), default_order: :desc) %></th>
+        <th><%= sort_link(query, :nickname, t(".nickname"), default_order: :desc) %></th>
+        <th><%= sort_link(query, :created_at, t(".created_at"), default_order: :desc) %></th>
+        <th><%= sort_link(query, :officialized_at, t(".status"), default_order: :desc) %></th>
+        <th><%= t(".badge") %></th>
+        <th><%= sort_link(query, :user_moderation_report_count, t(".reports"), default_order: :desc) %></th>
+        <th><%= t(".actions") %></th>
+      </tr>
+      </thead>
+      <tbody>
+      <% @users.each do |user| %>
+        <tr data-user-id="<%= user.id %>">
+          <% if user.nickname.to_s.strip.present? %>
+            <td><%= link_to user.name, decidim.profile_path(user.nickname) %></td>
+            <td><%= link_to user.nickname, decidim.profile_path(user.nickname) %></td>
+          <% else %>
+            <td><%= user.name %></td>
+            <td><%= user.nickname.presence || "" %></td>
+          <% end %>
+          <td><%= l user.created_at, format: :short %></td>
+          <td><%= user.officialized? ? t(".officialized") : t(".not_officialized") %></td>
+          <td><%= translated_attribute(user.officialized_as) %></td>
+          <td><%= user.report_count %></td>
+
+          <td class="table-list__actions">
+            <% if allowed_to?(:block, :admin_user, user: user) %>
+              <% if user.blocked? %>
+                <%= icon_link_to "forbid-2-line", user_block_path(user_id: user.id), t(".unblock"), class: "action-icon action-icon--disabled", method: :delete %>
+              <% else %>
+                <%= icon_link_to "forbid-2-line", new_user_block_path(user_id: user.id), t(".block"), class: "action-icon action-icon" %>
+              <% end %>
+            <% end %>
+            <% if allowed_to? :show_email, :user, user: user %>
+              <%= icon_link_to "mail-open-line", show_email_officialization_path(user_id: user.id), t(".show_email"), class: "action-icon action-icon--show-email", data: { full_name: user.name, dialog_open: "show-email-modal" } %>
+            <% end %>
+            <% unless user.blocked? %>
+              <% unless current_user == user %>
+                <%= icon_link_to "mail-line", current_or_new_conversation_path_with(user), t("decidim.contact"), class: "action-icon--new" %>
+              <% end %>
+              <% if user.officialized? %>
+                <%= icon "checkbox-circle-line", class: "action-icon action-icon--disabled", role: "img", aria_label: t(".officialize") %>
+                <%= icon_link_to "pencil-line", new_officialization_path(user_id: user.id), t(".reofficialize"), class: "action-icon--new" %>
+                <%= icon_link_to "delete-bin-line", officialization_path(user.id), t(".unofficialize"), method: :delete, class: "action-icon--reject" %>
+              <% else %>
+                <%= icon_link_to "checkbox-circle-line", new_officialization_path(user_id: user.id), t(".officialize"), class: "action-icon--verify" %>
+                <%= icon "pencil-line", class: "action-icon action-icon--disabled", role: "img", aria_label: t(".reofficialize") %>
+                <%= icon "delete-bin-line", class: "action-icon action-icon--disabled", role: "img", aria_label: t(".unofficialize") %>
+              <% end %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+<%= decidim_paginate @users %>
+<%= render "show_email_modal" %>


### PR DESCRIPTION
#### :tophat: What? Why?
参加者一覧でnicknameが空のユーザがいた場合にエラーになる問題の修正

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
