### PR TITLE
fix: attached images should not be external-link

### DIFF
--- a/app/cells/decidim/images_panel/show.erb
+++ b/app/cells/decidim/images_panel/show.erb
@@ -1,0 +1,7 @@
+<div class="grid grid-cols-1 md:grid-cols-4 gap-6">
+  <% photos.each_with_index do |photo, index| %>
+    <%= link_to photo.big_url, target: "_blank", rel: "noopener", class: "overflow-hidden rounded aspect-video" do %>
+      <%= image_tag photo.thumbnail_url, class:"w-full h-full object-cover", alt: strip_tags(translated_attribute(photo.title)) %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/cells/decidim/images_panel/show.erb
+++ b/app/cells/decidim/images_panel/show.erb
@@ -1,6 +1,6 @@
 <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
   <% photos.each_with_index do |photo, index| %>
-    <%= link_to photo.big_url, target: "_blank", rel: "noopener", class: "overflow-hidden rounded aspect-video" do %>
+    <%= link_to photo.big_url, target: "_blank", rel: "noopener", class: "overflow-hidden rounded aspect-video", data: { "external-link": false } do %>
       <%= image_tag photo.thumbnail_url, class:"w-full h-full object-cover", alt: strip_tags(translated_attribute(photo.title)) %>
     <% end %>
   <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

添付した画像へのリンクが外部リンクにならないようにします。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

