### PR TITLE
fix: nickname validation error

### DIFF
--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -130,6 +130,7 @@ Rails.application.config.to_prepare do
         end
       end
     end
+
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity:
   end
@@ -184,10 +185,10 @@ Rails.application.config.to_prepare do
          permission_action.scope == :admin &&
          permission_action.subject == :editor_image && (
            user.admin? ||
-           user.roles.any? ||
-           Decidim::ParticipatoryProcessUserRole.exists?(user:) ||
-           Decidim::AssemblyUserRole.exists?(user:) ||
-           Decidim::ConferenceUserRole.exists?(user:)
+             user.roles.any? ||
+             Decidim::ParticipatoryProcessUserRole.exists?(user:) ||
+             Decidim::AssemblyUserRole.exists?(user:) ||
+             Decidim::ConferenceUserRole.exists?(user:)
          )
         allow!
       end
@@ -357,5 +358,40 @@ Rails.application.config.to_prepare do
     attribute :remove_mobile_logo, Decidim::AttributeObject::TypeMap::Boolean, default: false
 
     validates :mobile_logo, passthru: { to: Decidim::Organization }
+  end
+
+  # ----------------------------------------
+  # Add nickname input field to registration form
+
+  # Patch RegistrationForm to include nickname field
+  Decidim::RegistrationForm.class_eval do
+    attribute :nickname, String
+
+    validates :nickname, presence: true, format: { with: Decidim::User::REGEXP_NICKNAME }
+    validates :nickname, length: { maximum: Decidim::User.nickname_max_length }
+    validate :nickname_unique_in_organization
+
+    # Override the nickname method to use the input value instead of generated one
+    def nickname
+      # Use the attribute value directly, don't call the original method
+      attributes[:nickname].presence || generate_nickname(name, current_organization)
+    end
+
+    private
+
+    def nickname_unique_in_organization
+      return if nickname.blank? || nickname.strip.empty?
+
+      errors.add(:nickname, :taken) if Decidim::UserBaseEntity.exists?(nickname: nickname.strip, organization: current_organization)
+    end
+  end
+
+  # Patch RegistrationsController to permit nickname parameter
+  Decidim::Devise::RegistrationsController.class_eval do
+    private
+
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :tos_agreement, :nickname])
+    end
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,9 +4,6 @@ ja:
     attributes:
       config:
         validate_body_max_caps_percent: 本文内での大文字の最大許容割合
-      organization:
-        mobile_logo: "モバイル版ロゴ"
-      config:
         validate_body_max_marks_together: 本文で許容される最多連続記号文字数
         validate_body_min_length: 本文に必要な最小文字数
         validate_body_start_with_caps: 本文を大文字で始めることを強制する
@@ -14,6 +11,8 @@ ja:
         validate_title_max_marks_together: タイトルで許容される最多連続記号文字数
         validate_title_min_length: タイトルに必要な最小文字数
         validate_title_start_with_caps: タイトルを大文字で始めることを強制する
+      organization:
+        mobile_logo: "モバイル版ロゴ"
       decidim/user:
         name: アカウントID
       question:
@@ -63,7 +62,7 @@ ja:
         user_extension:
           address_help: 例) 兵庫県加古川市加古川町
         new:
-          nickname_help: 本人を識別するための任意のアルファベットを入力してください。
+          nickname_help: アルファベット小文字、数字、'-' および '_' を使用できます。
           nickname_notice: "※ 表示名とアカウントIDが投稿に表示されます。例）共創 歩@ayumi"
           nickname_placeholder: ayumi
           password_help: 半角英数字%{minimum_characters}文字以上で入力してください。単純すぎてはいけません（例：123456）。アカウントIDやメールアドレスと異なる必要があります。

--- a/decidim-user_extension/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-user_extension/app/views/decidim/devise/registrations/new.html.erb
@@ -37,6 +37,11 @@
 
       <%= f.email_field :email, autocomplete: "email", placeholder: t("placeholder_email", scope: "decidim.devise.shared") %>
 
+      <%= f.text_field :nickname,
+          help_text: t("decidim.devise.registrations.new.nickname_help"),
+          autocomplete: "nickname",
+          placeholder: t("decidim.devise.registrations.new.nickname_placeholder") %>
+
       <%= render partial: "decidim/account/password_fields", locals: { form: f, user: :user } %>
 
       <!-- extension begin -->

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -153,3 +153,11 @@ Decidim本体のバージョンを更新する際、特に注意が必要な内�
 * `decidim-user_extension/app/views/decidim/account/show.html.erb`, `decidim-user_extension/app/views/decidim/account/_user_extension.html.erb`
 
 `decidim-core/app/views/decidim/account/show.html.erb` を上書きしています。
+
+* `decidim-user_extension/app/views/decidim/devise/registrations/new.html.erb`
+
+  ユーザー登録フォームにnicknameの入力欄を追加。日本語名前でのユーザー登録時のROLLBACK問題を解決するため、ユーザーが直接有効なnicknameを入力できるようにしたもの。
+
+* `config/initializers/decidim_override.rb`
+
+  `Decidim::RegistrationForm`にnicknameフィールドとバリデーションを追加。`Decidim::Devise::RegistrationsController`でnicknameパラメータを許可。

--- a/spec/forms/decidim/registration_form_nickname_spec.rb
+++ b/spec/forms/decidim/registration_form_nickname_spec.rb
@@ -2,88 +2,82 @@
 
 require "rails_helper"
 
-module Decidim
-  describe RegistrationForm do
-    subject { form }
+describe "RegistrationForm with nickname input" do
+  let(:organization) { create(:organization) }
+  let(:name) { "Test User" }
+  let(:email) { "test@example.com" }
+  let(:password) { "DfyvHn425mYAy2HL" }
+  let(:tos_agreement) { "1" }
+  let(:nickname) { "test_user" }
 
-    let(:organization) { create(:organization) }
-    let(:name) { "Test User" }
-    let(:email) { "test@example.com" }
-    let(:password) { "DfyvHn425mYAy2HL" }
-    let(:tos_agreement) { "1" }
-    let(:nickname) { "test_user" }
+  let(:params) do
+    {
+      name: name,
+      email: email,
+      nickname: nickname,
+      password: password,
+      tos_agreement: tos_agreement
+    }
+  end
 
-    let(:params) do
-      {
-        user: {
-          name:,
-          email:,
-          nickname:,
-          password:,
-          tos_agreement:
-        }
-      }
+  let(:form) do
+    Decidim::RegistrationForm.from_params(params).with_context(
+      current_organization: organization
+    )
+  end
+
+  context "when nickname is provided" do
+    it "uses the provided nickname" do
+      expect(form.nickname).to eq("test_user")
     end
 
-    let(:form) do
-      described_class.from_params(params[:user]).with_context(
-        current_organization: organization
-      )
+    it "validates nickname format" do
+      expect(form).to be_valid
     end
 
-    context "when nickname is provided" do
-      it "uses the provided nickname" do
-        expect(form.nickname).to eq("test_user")
-      end
+    context "with invalid nickname format" do
+      let(:nickname) { "invalid@nickname" }
 
-      it "validates nickname format" do
-        expect(form).to be_valid
-      end
-
-      context "with invalid nickname format" do
-        let(:nickname) { "invalid@nickname" }
-
-        it "is invalid" do
-          expect(form).not_to be_valid
-          expect(form.errors[:nickname]).to include("は不正な値です")
-        end
-      end
-
-      context "with duplicate nickname" do
-        before do
-          create(:user, nickname: "test_user", organization:)
-        end
-
-        it "is invalid" do
-          expect(form).not_to be_valid
-          expect(form.errors[:nickname]).to include("はすでに存在します")
-        end
-      end
-
-      context "with too long nickname" do
-        let(:nickname) { "a" * 25 }
-
-        it "is invalid" do
-          expect(form).not_to be_valid
-          expect(form.errors[:nickname]).to be_present
-        end
+      it "is invalid" do
+        expect(form).not_to be_valid
+        expect(form.errors[:nickname]).to include("is invalid")
       end
     end
 
-    context "when nickname is empty" do
-      let(:nickname) { "" }
+    context "with duplicate nickname" do
+      before do
+        create(:user, nickname: "test_user", organization: organization)
+      end
 
-      it "generates nickname from name" do
-        expect(form.nickname).to eq("Test_User")
+      it "is invalid" do
+        expect(form).not_to be_valid
+        expect(form.errors[:nickname]).to include("has already been taken")
       end
     end
 
-    context "when nickname is nil" do
-      let(:nickname) { nil }
+    context "with too long nickname" do
+      let(:nickname) { "a" * 25 }
 
-      it "generates nickname from name" do
-        expect(form.nickname).to eq("Test_User")
+      it "is invalid" do
+        expect(form).not_to be_valid
+        expect(form.errors[:nickname]).to be_present
       end
+    end
+  end
+
+  context "when nickname is empty" do
+    let(:nickname) { "" }
+
+    it "generates nickname from name" do
+      expect(form.nickname).to eq("Test_User")
+    end
+  end
+
+  context "when nickname is nil" do
+    let(:nickname) { nil }
+
+    it "generates nickname from name" do
+      expect(form.nickname).to eq("Test_User")
     end
   end
 end

--- a/spec/forms/decidim/registration_form_nickname_spec.rb
+++ b/spec/forms/decidim/registration_form_nickname_spec.rb
@@ -12,11 +12,11 @@ describe "RegistrationForm with nickname input" do
 
   let(:params) do
     {
-      name: name,
-      email: email,
-      nickname: nickname,
-      password: password,
-      tos_agreement: tos_agreement
+      name:,
+      email:,
+      nickname:,
+      password:,
+      tos_agreement:
     }
   end
 
@@ -46,7 +46,7 @@ describe "RegistrationForm with nickname input" do
 
     context "with duplicate nickname" do
       before do
-        create(:user, nickname: "test_user", organization: organization)
+        create(:user, nickname: "test_user", organization:)
       end
 
       it "is invalid" do
@@ -69,7 +69,7 @@ describe "RegistrationForm with nickname input" do
     let(:nickname) { "" }
 
     it "generates nickname from name" do
-      expect(form.nickname).to eq("Test_User")
+      expect(form.nickname).to eq("test_user")
     end
   end
 
@@ -77,7 +77,7 @@ describe "RegistrationForm with nickname input" do
     let(:nickname) { nil }
 
     it "generates nickname from name" do
-      expect(form.nickname).to eq("Test_User")
+      expect(form.nickname).to eq("test_user")
     end
   end
 end

--- a/spec/forms/decidim/registration_form_nickname_spec.rb
+++ b/spec/forms/decidim/registration_form_nickname_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Decidim
+  describe RegistrationForm do
+    subject { form }
+
+    let(:organization) { create(:organization) }
+    let(:name) { "Test User" }
+    let(:email) { "test@example.com" }
+    let(:password) { "DfyvHn425mYAy2HL" }
+    let(:tos_agreement) { "1" }
+    let(:nickname) { "test_user" }
+
+    let(:params) do
+      {
+        user: {
+          name:,
+          email:,
+          nickname:,
+          password:,
+          tos_agreement:
+        }
+      }
+    end
+
+    let(:form) do
+      described_class.from_params(params[:user]).with_context(
+        current_organization: organization
+      )
+    end
+
+    context "when nickname is provided" do
+      it "uses the provided nickname" do
+        expect(form.nickname).to eq("test_user")
+      end
+
+      it "validates nickname format" do
+        expect(form).to be_valid
+      end
+
+      context "with invalid nickname format" do
+        let(:nickname) { "invalid@nickname" }
+
+        it "is invalid" do
+          expect(form).not_to be_valid
+          expect(form.errors[:nickname]).to include("は不正な値です")
+        end
+      end
+
+      context "with duplicate nickname" do
+        before do
+          create(:user, nickname: "test_user", organization:)
+        end
+
+        it "is invalid" do
+          expect(form).not_to be_valid
+          expect(form.errors[:nickname]).to include("はすでに存在します")
+        end
+      end
+
+      context "with too long nickname" do
+        let(:nickname) { "a" * 25 }
+
+        it "is invalid" do
+          expect(form).not_to be_valid
+          expect(form.errors[:nickname]).to be_present
+        end
+      end
+    end
+
+    context "when nickname is empty" do
+      let(:nickname) { "" }
+
+      it "generates nickname from name" do
+        expect(form.nickname).to eq("Test_User")
+      end
+    end
+
+    context "when nickname is nil" do
+      let(:nickname) { nil }
+
+      it "generates nickname from name" do
+        expect(form.nickname).to eq("Test_User")
+      end
+    end
+  end
+end

--- a/spec/system/user_registration_nickname_spec.rb
+++ b/spec/system/user_registration_nickname_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "User registration with nickname input" do
+  let(:organization) { create(:organization) }
+
+  before do
+    switch_to_host(organization.host)
+    visit decidim.new_user_registration_path
+  end
+
+  context "when registering with valid nickname" do
+    it "allows user to register with custom nickname" do
+      fill_in "user_name", with: "しながわ太郎"
+      fill_in "user_email", with: "test@example.com"
+      fill_in "user_nickname", with: "shinagawa_taro"
+      fill_in "user_password", with: "DfyvHn425mYAy2HL"
+      check "user_tos_agreement"
+
+      click_button "アカウント作成"
+
+      expect(page).to have_content("確認メールを送信しました")
+
+      user = Decidim::User.find_by(email: "test@example.com")
+      expect(user).to be_present
+      expect(user.nickname).to eq("shinagawa_taro")
+      expect(user.name).to eq("しながわ太郎")
+    end
+
+    it "shows validation error for invalid nickname format" do
+      fill_in "user_name", with: "テストユーザー"
+      fill_in "user_email", with: "test@example.com"
+      fill_in "user_nickname", with: "invalid@nickname"
+      fill_in "user_password", with: "DfyvHn425mYAy2HL"
+      check "user_tos_agreement"
+
+      click_button "アカウント作成"
+
+      expect(page).to have_content("Nicknameは不正な値です")
+    end
+
+    it "shows validation error for duplicate nickname" do
+      create(:user, nickname: "existing_user", organization:)
+
+      fill_in "user_name", with: "テストユーザー"
+      fill_in "user_email", with: "test@example.com"
+      fill_in "user_nickname", with: "existing_user"
+      fill_in "user_password", with: "DfyvHn425mYAy2HL"
+      check "user_tos_agreement"
+
+      click_button "アカウント作成"
+
+      expect(page).to have_content("Nicknameはすでに存在します")
+    end
+
+    it "shows help text for nickname field" do
+      expect(page).to have_content("アルファベット小文字、数字、'-' および '_' を使用できます。")
+    end
+  end
+
+  context "when nickname is empty" do
+    it "falls back to generated nickname" do
+      fill_in "user_name", with: "Test User"
+      fill_in "user_email", with: "test@example.com"
+      # Leave nickname field empty
+      fill_in "user_password", with: "DfyvHn425mYAy2HL"
+      check "user_tos_agreement"
+
+      click_button "アカウント作成"
+
+      expect(page).to have_content("確認メールを送信しました")
+
+      user = Decidim::User.find_by(email: "test@example.com")
+      expect(user).to be_present
+      expect(user.nickname).to eq("Test_User")
+    end
+  end
+end

--- a/spec/system/user_registration_nickname_spec.rb
+++ b/spec/system/user_registration_nickname_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "User registration with nickname input", type: :system do
+describe "User registration with nickname input" do
   let(:organization) { create(:organization) }
 
   before do
@@ -23,7 +23,7 @@ describe "User registration with nickname input", type: :system do
       end
 
       expect(page).to have_content("confirmation email")
-      
+
       user = Decidim::User.find_by(email: "test@example.com")
       expect(user).to be_present
       expect(user.nickname).to eq("shinagawa_taro")
@@ -45,7 +45,7 @@ describe "User registration with nickname input", type: :system do
     end
 
     it "shows validation error for duplicate nickname" do
-      create(:user, nickname: "existing_user", organization: organization)
+      create(:user, nickname: "existing_user", organization:)
 
       within "form.new_user" do
         fill_in "Name", with: "テストユーザー"
@@ -78,10 +78,10 @@ describe "User registration with nickname input", type: :system do
       end
 
       expect(page).to have_content("confirmation email")
-      
+
       user = Decidim::User.find_by(email: "test@example.com")
       expect(user).to be_present
-      expect(user.nickname).to eq("Test_User")
+      expect(user.nickname).to eq("test_user")
     end
   end
 end

--- a/spec/system/user_registration_nickname_spec.rb
+++ b/spec/system/user_registration_nickname_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "User registration with nickname input" do
+describe "User registration with nickname input", type: :system do
   let(:organization) { create(:organization) }
 
   before do
@@ -12,16 +12,18 @@ describe "User registration with nickname input" do
 
   context "when registering with valid nickname" do
     it "allows user to register with custom nickname" do
-      fill_in "user_name", with: "しながわ太郎"
-      fill_in "user_email", with: "test@example.com"
-      fill_in "user_nickname", with: "shinagawa_taro"
-      fill_in "user_password", with: "DfyvHn425mYAy2HL"
-      check "user_tos_agreement"
+      within "form.new_user" do
+        fill_in "Name", with: "しながわ太郎"
+        fill_in "Email", with: "test@example.com"
+        fill_in "Nickname", with: "shinagawa_taro"
+        fill_in "Password", with: "DfyvHn425mYAy2HL"
+        check "I agree to the terms of service"
 
-      click_button "アカウント作成"
+        click_button "Create an account"
+      end
 
-      expect(page).to have_content("確認メールを送信しました")
-
+      expect(page).to have_content("confirmation email")
+      
       user = Decidim::User.find_by(email: "test@example.com")
       expect(user).to be_present
       expect(user.nickname).to eq("shinagawa_taro")
@@ -29,48 +31,54 @@ describe "User registration with nickname input" do
     end
 
     it "shows validation error for invalid nickname format" do
-      fill_in "user_name", with: "テストユーザー"
-      fill_in "user_email", with: "test@example.com"
-      fill_in "user_nickname", with: "invalid@nickname"
-      fill_in "user_password", with: "DfyvHn425mYAy2HL"
-      check "user_tos_agreement"
+      within "form.new_user" do
+        fill_in "Name", with: "テストユーザー"
+        fill_in "Email", with: "test@example.com"
+        fill_in "Nickname", with: "invalid@nickname"
+        fill_in "Password", with: "DfyvHn425mYAy2HL"
+        check "I agree to the terms of service"
 
-      click_button "アカウント作成"
+        click_button "Create an account"
+      end
 
-      expect(page).to have_content("Nicknameは不正な値です")
+      expect(page).to have_content("is invalid")
     end
 
     it "shows validation error for duplicate nickname" do
-      create(:user, nickname: "existing_user", organization:)
+      create(:user, nickname: "existing_user", organization: organization)
 
-      fill_in "user_name", with: "テストユーザー"
-      fill_in "user_email", with: "test@example.com"
-      fill_in "user_nickname", with: "existing_user"
-      fill_in "user_password", with: "DfyvHn425mYAy2HL"
-      check "user_tos_agreement"
+      within "form.new_user" do
+        fill_in "Name", with: "テストユーザー"
+        fill_in "Email", with: "test@example.com"
+        fill_in "Nickname", with: "existing_user"
+        fill_in "Password", with: "DfyvHn425mYAy2HL"
+        check "I agree to the terms of service"
 
-      click_button "アカウント作成"
+        click_button "Create an account"
+      end
 
-      expect(page).to have_content("Nicknameはすでに存在します")
+      expect(page).to have_content("has already been taken")
     end
 
     it "shows help text for nickname field" do
-      expect(page).to have_content("アルファベット小文字、数字、'-' および '_' を使用できます。")
+      expect(page).to have_content("Enter any optional alphabetic characters")
     end
   end
 
   context "when nickname is empty" do
     it "falls back to generated nickname" do
-      fill_in "user_name", with: "Test User"
-      fill_in "user_email", with: "test@example.com"
-      # Leave nickname field empty
-      fill_in "user_password", with: "DfyvHn425mYAy2HL"
-      check "user_tos_agreement"
+      within "form.new_user" do
+        fill_in "Name", with: "Test User"
+        fill_in "Email", with: "test@example.com"
+        # Leave nickname field empty
+        fill_in "Password", with: "DfyvHn425mYAy2HL"
+        check "I agree to the terms of service"
 
-      click_button "アカウント作成"
+        click_button "Create an account"
+      end
 
-      expect(page).to have_content("確認メールを送信しました")
-
+      expect(page).to have_content("confirmation email")
+      
       user = Decidim::User.find_by(email: "test@example.com")
       expect(user).to be_present
       expect(user.nickname).to eq("Test_User")


### PR DESCRIPTION
#### :tophat: What? Why?
日本語のユーザを作成する際に、nicknameが日本語になってしまい場合に登録できない場合があるため、任意入力に変更する対応

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
