### PR TITLE
fix: update Cloudfront logo helper to use Cell classes instead of Mailer

### DIFF
--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -365,6 +365,11 @@ Rails.application.config.to_prepare do
     include Decidim::CloudfrontLogoHelper
   end
 
+  # CloudFrontロゴヘルパーをメーラーに追加
+  Decidim::ApplicationMailer.class_eval do
+    helper Decidim::CloudfrontLogoHelper
+  end
+
   # ----------------------------------------
   # Add nickname input field to registration form
 


### PR DESCRIPTION
#### :tophat: What? Why?
Decidim::ApplicationMailerにhelperで読み込むとうまく動かないので、とりあえずrollbackします！

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
