### PR TITLE
fix: add nickname validations to `Decidim::OmniauthRegistrationForm`

### DIFF
--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -371,7 +371,7 @@ Rails.application.config.to_prepare do
   end
 
   # ----------------------------------------
-  # Add nickname input field to registration form
+  # Add nickname input field to registration form and omniauth registration form
 
   # Patch RegistrationForm to include nickname field
   Decidim::RegistrationForm.class_eval do
@@ -402,6 +402,21 @@ Rails.application.config.to_prepare do
 
     def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :tos_agreement, :nickname])
+    end
+  end
+
+  # Patch RegistrationForm to include nickname field
+  Decidim::OmniauthRegistrationForm.class_eval do
+    validates :nickname, presence: true, format: { with: Decidim::User::REGEXP_NICKNAME }
+    validates :nickname, length: { maximum: Decidim::User.nickname_max_length }
+    validate :nickname_unique_in_organization
+
+    private
+
+    def nickname_unique_in_organization
+      return if nickname.blank? || nickname.strip.empty?
+
+      errors.add(:nickname, :taken) if Decidim::UserBaseEntity.exists?(nickname: nickname.strip, organization: current_organization)
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

`Decidim::RegistrationForm`と同じように`Decidim::OmniauthRegistrationForm`にもvalidationを追加します

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

<img width="810" height="614" alt="omniauth_registration" src="https://github.com/user-attachments/assets/741214e6-4d9c-475b-afd0-eb671f30c771" />

