### PR TITLE
feat: show log of last_activities and last_comments in HTML comments

### DIFF
--- a/app/cells/decidim/content_blocks/last_comment/show.erb
+++ b/app/cells/decidim/content_blocks/last_comment/show.erb
@@ -1,3 +1,5 @@
+<!-- DEBUG last_comment: scope=<%= model.scope_name %> scoped_id=<%= model.scoped_resource_id %> comments_query=<%= comments.count %> valid=<%= valid_comments.size %> -->
+<% if valid_comments.any? %>
 <section id="last_comment" class="home__section">
   <div class="home__section-header">
     <h2 class="home__section-title">
@@ -12,3 +14,4 @@
     <%= cell "decidim/last_comment_activities", column_activities %>
   <% end %>
 </section>
+<% end %>

--- a/app/cells/decidim/content_blocks/last_comment_cell.rb
+++ b/app/cells/decidim/content_blocks/last_comment_cell.rb
@@ -8,8 +8,6 @@ module Decidim
       include Decidim::Core::Engine.routes.url_helpers
 
       def show
-        return if valid_comments.empty?
-
         render
       end
 

--- a/app/cells/decidim/content_blocks/participatory_space_last_activity/content.erb
+++ b/app/cells/decidim/content_blocks/participatory_space_last_activity/content.erb
@@ -1,0 +1,11 @@
+<div class="content-block__title">
+  <h2 class="h2 decorator"><%= t("name", scope: "decidim.content_blocks.last_activity") %></h2>
+  <div class="participatory-space__metadata-link-endorsers">
+    <%= render_recent_avatars %>
+  </div>
+  <div class="label text-lg"><%= participants_count %></div>
+</div>
+
+<div class="space-y-4">
+  <%= cell "decidim/activities", activities_query.limit(6), hide_participatory_space: %>
+</div>

--- a/app/cells/decidim/content_blocks/participatory_space_last_activity/content.erb
+++ b/app/cells/decidim/content_blocks/participatory_space_last_activity/content.erb
@@ -1,3 +1,12 @@
+<%
+  _space = resource
+  _raw = Decidim::ActionLog.where(
+    participatory_space_type: _space.class.name,
+    participatory_space_id: _space.id
+  ).count
+  _query_count = activities_query.count
+%>
+<!-- DEBUG last_activity: space=<%= _space.class.name %>#<%= _space.id %> raw=<%= _raw %> query=<%= _query_count %> -->
 <div class="content-block__title">
   <h2 class="h2 decorator"><%= t("name", scope: "decidim.content_blocks.last_activity") %></h2>
   <div class="participatory-space__metadata-link-endorsers">


### PR DESCRIPTION
#### :tophat: What? Why?

とりあえず細かい情報をコメントの形で出力してみるのがよいでしょうか。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
