### PR TITLE
fix: improve translation of taxonomy filter `internal_name`

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -20,6 +20,8 @@ ja:
         origin_url: 元のURL
       user:
         avatar: アバター
+      taxonomy_filter:
+        internal_name: 管理用ラベル
       user_extension:
         address: 住所
         birth_year: 生年(西暦)
@@ -37,6 +39,9 @@ ja:
       organization_appearance:
         form:
           mobile_logo_help: "モバイル版で表示されるロゴ画像です。推奨サイズ: 360x120px"
+      taxonomy_filter:
+        table:
+          internal_name: 管理用ラベル
     amendments:
       amendable:
         button: '修正'


### PR DESCRIPTION
#### :tophat: What? Why?

分類フィルターの`内部ラベル`を`管理用ラベル`に変更します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

<img width="400" alt="internal_name" src="https://github.com/user-attachments/assets/ec4d1bfb-3a29-40dd-a3ec-62dd300560c2" />
