### PR TITLE
fix: increase PumaWorkerKiller RAM limit to 3072 MB

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -24,7 +24,7 @@ pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 before_fork do
   PumaWorkerKiller.config do |config|
-    config.ram = 2048
+    config.ram = 3072
     config.frequency = 60
     config.percent_usage = 0.9
     config.rolling_restart_frequency = 24 * 60 * 60


### PR DESCRIPTION
#### :tophat: What? Why?
負荷テストを踏まえて、PumaWorkerKillerのramの最適化

現在の2048 MBの上限では、ワーカー2つでも高負荷時にメモリ閾値に達してワーカーがkillされていた

**現在の構成**:
   - ECSタスク: 2 vCPU / **4096 MB** メモリ
   - Pumaワーカー数: 2（`WEB_CONCURRENCY=2`）
   - PumaWorkerKiller RAM上限: **2048 MB**（= コンテナメモリの50%）
   - キル閾値: 2048 × 0.9 = **1,843 MB**

**変更後**:
   - PumaWorkerKiller RAM上限: **3072 MB**（= コンテナメモリの75%）
   - キル閾値: 3072 × 0.9 = **2,765 MB**
   - コンテナの残り1024 MBはnginxサイドカー・OS・その他プロセス用に確保
   - 将来のワーカー数3への引き上げにも対応可能なヘッドルーム確保
   - 残り約1,300 MBの余裕があり、nginx等の他プロセスに十分

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
