### PR TITLE
fix: Sanitize user name in presenters

### DIFF
--- a/config/initializers/user_presenter_override.rb
+++ b/config/initializers/user_presenter_override.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Sanitize user name rendering across presenters.
+# - Tightens the name format validation to reject newlines as well.
+# - Ensures UserPresenter#name and Log::UserPresenter#present_user_name
+#   return sanitized output before being rendered as HTML-safe strings.
+
+Rails.application.config.to_prepare do
+  Decidim::UserBaseEntity # rubocop:disable Lint/Void
+  Decidim::UserPresenter # rubocop:disable Lint/Void
+  Decidim::Log::UserPresenter # rubocop:disable Lint/Void
+
+  Decidim::UserBaseEntity.send(:remove_const, :REGEXP_NAME) if Decidim::UserBaseEntity.const_defined?(:REGEXP_NAME, false)
+  Decidim::UserBaseEntity.const_set(:REGEXP_NAME, /\A(?!.*[<>?%&\^*#@()\[\]=+:;"{}\\|\n\r])/m)
+
+  Decidim::UserBaseEntity.validators_on(:name).each do |validator|
+    next unless validator.instance_of?(ActiveModel::Validations::FormatValidator)
+
+    fixed_options = validator.options.dup
+    fixed_options[:with] = Decidim::UserBaseEntity::REGEXP_NAME
+    validator.instance_eval do
+      @options = fixed_options.freeze
+    end
+  end
+
+  module UserPresenterSanitizeName
+    def name
+      decidim_sanitize_translated(__getobj__.name)
+    end
+  end
+
+  module LogUserPresenterSanitizeName
+    def present_user_name
+      decidim_sanitize_translated(extra["name"]).html_safe
+    end
+  end
+
+  Decidim::UserPresenter.include(Decidim::SanitizeHelper)
+  Decidim::UserPresenter.prepend(UserPresenterSanitizeName)
+
+  Decidim::Log::UserPresenter.include(Decidim::SanitizeHelper)
+  Decidim::Log::UserPresenter.prepend(LogUserPresenterSanitizeName)
+end

--- a/spec/presenters/decidim/user_presenter_override_spec.rb
+++ b/spec/presenters/decidim/user_presenter_override_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Decidim
+  describe UserPresenter do
+    let(:organization) { create(:organization) }
+
+    describe "#name" do
+      subject { described_class.new(user).name }
+
+      let(:user) do
+        create(:user, organization:).tap do |u|
+          u.update_column(:name, "Alice<script>alert(1)</script>") # rubocop:disable Rails/SkipsModelValidations
+        end
+      end
+
+      it "strips script tags" do
+        expect(subject).not_to include("<script>")
+        expect(subject).not_to include("</script>")
+      end
+    end
+  end
+
+  describe Log::UserPresenter do
+    subject { described_class.new(user, view_helpers, extra) }
+
+    let(:user) { nil }
+    let(:view_helpers) { ActionController::Base.helpers }
+    let(:extra) { { "name" => "Alice<script>alert(1)</script>", "nickname" => "alice" } }
+
+    describe "#present" do
+      it "strips script tags from the rendered name" do
+        expect(subject.present).not_to include("<script>")
+        expect(subject.present).not_to include("</script>")
+      end
+    end
+  end
+
+  describe UserBaseEntity do
+    describe "::REGEXP_NAME" do
+      it "rejects names containing a newline" do
+        expect(described_class::REGEXP_NAME.match?("Alice\nBob")).to be false
+      end
+
+      it "rejects names containing a carriage return" do
+        expect(described_class::REGEXP_NAME.match?("Alice\rBob")).to be false
+      end
+
+      it "accepts normal names" do
+        expect(described_class::REGEXP_NAME.match?("Alice Liddell")).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

`Decidim::UserPresenter#name` と `Decidim::Log::UserPresenter#present_user_name`が返すユーザー名を無害化するように override を追加します。
あわせて`Decidim::UserBaseEntity::REGEXP_NAME` の name フォーマット検証を、改行文字も拒否するように強化します。

#### :pushpin: Related Issues

- Related to decidim/decidim#15939

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
