### PR TITLE
fix: do not use html_safe for text and icon

### DIFF
--- a/app/cells/decidim/proposals/proposal_metadata_cell.rb
+++ b/app/cells/decidim/proposals/proposal_metadata_cell.rb
@@ -50,8 +50,8 @@ module Decidim
       def proposal_items_for_map
         [coauthors_item_for_map, comments_count_item, endorsements_count_item, state_item, emendation_item].compact_blank.map do |item|
           {
-            text: item[:text].to_s.html_safe,
-            icon: item[:icon].present? ? icon(item[:icon]).html_safe : nil
+            text: item[:text].to_s,
+            icon: item[:icon].present? ? icon(item[:icon]) : nil
           }
         end
       end
@@ -59,8 +59,11 @@ module Decidim
       def coauthors_item_for_map
         presented_author = official? ? Decidim::Proposals::OfficialAuthorPresenter.new : present(resource.identities.first)
 
+        # CGI.escapeHTML is used (instead of decidim_html_escape) because the popup
+        # template renders this via `{{html text}}` and the presenter returns a
+        # SafeBuffer, which Rails' html_escape helpers would skip.
         {
-          text: presented_author.name,
+          text: CGI.escapeHTML(presented_author.name.to_s),
           icon: "account-circle-line"
         }
       end

--- a/spec/cells/decidim/proposals/proposal_metadata_cell_spec.rb
+++ b/spec/cells/decidim/proposals/proposal_metadata_cell_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# rubocop:disable Rails/SkipsModelValidations
+# update_column intentionally bypasses REGEXP_NAME so we can simulate names
+# inserted before validation was tightened (legacy rows, OmniAuth provider
+# data, etc.). The point of these tests is to verify defense-in-depth at the
+# rendering layer regardless of the input validation.
+
+module Decidim
+  module Proposals
+    describe ProposalMetadataCell, type: :cell do
+      controller Decidim::PagesController
+
+      let(:organization) { create(:organization) }
+      let(:component) { create(:proposal_component, organization:) }
+      let(:user) { create(:user, :confirmed, organization:) }
+      let(:proposal) { create(:proposal, component:, users: [user]) }
+      let(:cell_instance) { cell("decidim/proposals/proposal_metadata", proposal) }
+
+      before do
+        allow(controller).to receive(:current_organization).and_return(organization)
+      end
+
+      describe "#proposal_items_for_map" do
+        subject(:items) { cell_instance.send(:proposal_items_for_map) }
+
+        let(:coauthor_item) { items.first }
+
+        context "when the coauthor name contains an anchor tag" do
+          before { user.update_column(:name, '<a href="http://evil.example">click</a>') }
+
+          it "HTML-escapes the tag in the popup text" do
+            expect(coauthor_item[:text]).to include("&lt;a")
+            expect(coauthor_item[:text]).not_to match(/<a\s/)
+          end
+        end
+
+        context "when the coauthor name is plain" do
+          before { user.update_column(:name, "Alice") }
+
+          it "preserves the name as-is" do
+            expect(coauthor_item[:text]).to eq("Alice")
+          end
+        end
+
+        context "when serialized to JSON for the marker popup" do
+          before { user.update_column(:name, '<a href="http://evil.example">click</a>') }
+
+          it "produces no tag-opening sequence that innerHTML would interpret as HTML" do
+            # The popup template uses {{html text}}, so the JSON string is inserted
+            # as HTML. Browsers decode entity references in innerHTML but do NOT
+            # re-tokenize the decoded characters as tags, so escaped entities are
+            # safe even through {{html ...}}.
+            json = items.to_json
+            expect(json).to include("\\u0026lt;a")
+            expect(json).not_to match(/[^\\]<a\s/)
+          end
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Rails/SkipsModelValidations


### PR DESCRIPTION
#### :tophat: What? Why?

proposals内のmarkerにわたす値の処理を変更します。
手元でhtml_safeをせずに渡された側で処理するようにします。
またpresented_author.nameについてはescapeHTMLしてから渡すようにします。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
