### PR TITLE
fix: orerride organization_name() to html_escape

### DIFF
--- a/app/views/layouts/decidim/mailer.html.erb
+++ b/app/views/layouts/decidim/mailer.html.erb
@@ -95,9 +95,9 @@
                       <th class="small-12 first columns cityhall-bar">
                         <div class="decidim-logo" style="float: right; text-align: right; padding-right: 16px">
                           <% if @custom_url_for_mail_root.present? %>
-                            <%= link_to organization_name(@organization).html_safe, @custom_url_for_mail_root %>
+                            <%= link_to organization_name(@organization), @custom_url_for_mail_root %>
                           <% else %>
-                            <%= link_to organization_name(@organization).html_safe, decidim.root_url(host: @organization.host) %>
+                            <%= link_to organization_name(@organization), decidim.root_url(host: @organization.host) %>
                           <% end %>
                         </div>
                       </th>

--- a/config/initializers/organization_helper_override.rb
+++ b/config/initializers/organization_helper_override.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# HTML-escape the organization name at the helper level.
+Rails.application.config.to_prepare do
+  Decidim::OrganizationHelper # rubocop:disable Lint/Void
+
+  module DecidimOrganizationHelperEscapeNamePatch
+    def organization_name(organization = current_organization)
+      ERB::Util.html_escape(super)
+    end
+  end
+
+  Decidim::OrganizationHelper.prepend(DecidimOrganizationHelperEscapeNamePatch)
+end

--- a/spec/mailers/newsletter_mailer_spec.rb
+++ b/spec/mailers/newsletter_mailer_spec.rb
@@ -44,6 +44,20 @@ module Decidim
         end
       end
 
+      context "when the organization name contains HTML" do
+        before do
+          # update_column bypasses Decidim's organization name validation to simulate
+          # legacy data or unvalidated updates. The cell override must escape regardless.
+          organization.update_column(:name, { en: '<a href="http://evil.example">click</a>' }) # rubocop:disable Rails/SkipsModelValidations
+        end
+
+        it "HTML-escapes the organization name in the newsletter template" do
+          body = email_body(mail)
+          expect(body).to include("&lt;a")
+          expect(body).not_to match(%r{<a href="http://evil\.example"})
+        end
+      end
+
       context "when the user has a different locale" do
         before do
           user.locale = "ja"


### PR DESCRIPTION
#### :tophat: What? Why?

organization nameの表示の際に、`organization_name(@organization).html_safe`とするのではなく、グローバルで強制的にhtml safeにするようhelperを上書きします。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
