### PR TITLE
fix: use AvatarFetcher in ApplicationUploader#remote_url=

### DIFF
--- a/config/initializers/application_uploader_override.rb
+++ b/config/initializers/application_uploader_override.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Override Decidim::ApplicationUploader#remote_url= so the import flows
+# (assemblies, accountability, etc.) fetch remote attachments through a
+# controlled HTTP client instead of `URI.open`.
+#
+# AvatarFetcher is reused as a generic remote-file fetcher with the content-type
+# whitelist disabled. A failed fetch raises SocketError to keep the contract
+# expected by callers like Decidim::Assemblies::AssemblyImporter, whose
+# `rescue` list converts network-level failures into per-attachment warnings
+# rather than aborting the whole import.
+Rails.application.config.to_prepare do
+  Decidim::ApplicationUploader # rubocop:disable Lint/Void
+
+  module DecidimApplicationUploaderRemoteUrlPatch
+    def remote_url=(url)
+      io, filename = Decidim::UserExtension::AvatarFetcher.call(
+        url,
+        allowed_content_types: nil,
+        default_filename: "remote_file"
+      )
+      raise SocketError, "remote_url= fetch failed" unless io
+
+      model.send(mounted_as).attach(io:, filename:)
+    end
+  end
+
+  Decidim::ApplicationUploader.prepend(DecidimApplicationUploaderRemoteUrlPatch)
+end

--- a/decidim-user_extension/app/services/decidim/user_extension/avatar_fetcher.rb
+++ b/decidim-user_extension/app/services/decidim/user_extension/avatar_fetcher.rb
@@ -40,12 +40,14 @@ module Decidim
         OpenSSL::SSL::SSLError
       ].freeze
 
-      def self.call(url)
-        new(url).call
+      def self.call(url, allowed_content_types: ALLOWED_CONTENT_TYPES, default_filename: "avatar")
+        new(url, allowed_content_types:, default_filename:).call
       end
 
-      def initialize(url)
+      def initialize(url, allowed_content_types: ALLOWED_CONTENT_TYPES, default_filename: "avatar")
         @url = url
+        @allowed_content_types = allowed_content_types
+        @default_filename = default_filename
       end
 
       def call
@@ -90,7 +92,7 @@ module Decidim
       end
 
       def read_success(response, uri)
-        return skip("unexpected_content_type: #{response["content-type"]}") unless image_content_type?(response["content-type"])
+        return skip("unexpected_content_type: #{response["content-type"]}") unless acceptable_content_type?(response["content-type"])
         return skip("content_length_exceeded") if response["content-length"].to_i > MAX_BYTES
 
         body = String.new(capacity: MAX_BYTES)
@@ -99,7 +101,7 @@ module Decidim
           return skip("streamed_body_exceeded") if body.bytesize > MAX_BYTES
         end
 
-        [body, File.basename(uri.path.presence || "avatar")]
+        [body, File.basename(uri.path.presence || @default_filename)]
       end
 
       def follow_redirect(response, uri, redirects_remaining)
@@ -134,11 +136,12 @@ module Decidim
         false
       end
 
-      def image_content_type?(content_type)
+      def acceptable_content_type?(content_type)
+        return true if @allowed_content_types.nil?
         return false if content_type.blank?
 
         mime = content_type.split(";").first.to_s.strip.downcase
-        ALLOWED_CONTENT_TYPES.include?(mime)
+        @allowed_content_types.include?(mime)
       end
 
       def skip(reason)

--- a/spec/config/initializers/application_uploader_override_spec.rb
+++ b/spec/config/initializers/application_uploader_override_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Decidim::ApplicationUploader#remote_url= override" do
+  let(:organization) { create(:organization) }
+  let(:model) do
+    create(:attachment, attached_to: create(:participatory_process, organization:))
+  end
+  let(:uploader) { model.attached_uploader(:file) }
+  let(:url) { "https://cdn.example.com/file.png" }
+  let(:host) { "cdn.example.com" }
+  let(:public_ip) { "203.0.113.10" }
+  let(:body) { "FILEDATA" }
+  let(:original_filename) { model.file.filename.to_s }
+
+  before do
+    allow(Resolv).to receive(:getaddresses).with(host).and_return([public_ip])
+  end
+
+  context "with a public URL serving any content type" do
+    before do
+      stub_request(:get, url).to_return(
+        status: 200, body:, headers: { "Content-Type" => "application/pdf" }
+      )
+    end
+
+    it "replaces the attached file" do
+      uploader.remote_url = url
+      expect(model.file.filename.to_s).to eq("file.png")
+      expect(model.file.download).to eq(body)
+    end
+  end
+
+  context "with a URL pointing to a private IP" do
+    let(:url) { "http://internal.example.com/file.png" }
+
+    before do
+      allow(Resolv).to receive(:getaddresses).with("internal.example.com").and_return(["10.0.0.5"])
+    end
+
+    it "raises SocketError and does not replace the file" do
+      original = original_filename
+      expect { uploader.remote_url = url }.to raise_error(SocketError)
+      expect(model.file.filename.to_s).to eq(original)
+    end
+  end
+
+  context "with a non-HTTP scheme" do
+    let(:url) { "file:///etc/passwd" }
+
+    it "raises SocketError and does not replace the file" do
+      original = original_filename
+      expect { uploader.remote_url = url }.to raise_error(SocketError)
+      expect(model.file.filename.to_s).to eq(original)
+    end
+  end
+
+  context "when the upstream returns 404" do
+    before { stub_request(:get, url).to_return(status: 404) }
+
+    it "raises SocketError and does not replace the file" do
+      original = original_filename
+      expect { uploader.remote_url = url }.to raise_error(SocketError)
+      expect(model.file.filename.to_s).to eq(original)
+    end
+  end
+
+  context "when the URL has no path" do
+    let(:url) { "https://cdn.example.com" }
+
+    before do
+      stub_request(:get, url).to_return(status: 200, body:, headers: { "Content-Type" => "image/png" })
+    end
+
+    it "uses the fallback filename" do
+      uploader.remote_url = url
+      expect(model.file.filename.to_s).to eq("remote_file")
+    end
+  end
+end

--- a/spec/services/decidim/user_extension/avatar_fetcher_spec.rb
+++ b/spec/services/decidim/user_extension/avatar_fetcher_spec.rb
@@ -228,4 +228,51 @@ RSpec.describe Decidim::UserExtension::AvatarFetcher do
       end
     end
   end
+
+  describe ".call with allowed_content_types: nil" do
+    subject(:result) { described_class.call(url, allowed_content_types: nil) }
+
+    context "when the response is text/html" do
+      before do
+        stub_request(:get, url).to_return(
+          status: 200, body:, headers: { "Content-Type" => "text/html" }
+        )
+      end
+
+      it "still returns the body" do
+        io, = result
+        expect(io.read).to eq(body)
+      end
+    end
+
+    context "when the Content-Type is missing" do
+      before { stub_request(:get, url).to_return(status: 200, body:) }
+
+      it "still returns the body" do
+        io, = result
+        expect(io.read).to eq(body)
+      end
+    end
+
+    context "when the host resolves to a private IP" do
+      before { stub_dns(host, "10.0.0.5") }
+
+      it "is still rejected by the SSRF guard" do
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe ".call with default_filename:" do
+    subject(:result) { described_class.call(url, allowed_content_types: nil, default_filename: "import") }
+
+    let(:url) { "https://cdn.example.com" }
+
+    before { stub_request(:get, url).to_return(status: 200, body:) }
+
+    it "uses the provided fallback filename" do
+      _io, filename = result
+      expect(filename).to eq("import")
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

先ほど #803 で入れた AvatarFetcher を他の用途にも流用させるものです。
そのためAvatarFetcherにも少し手を入れています。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
