### PR TITLE
ci: actions バージョン更新・Ruby バージョン修正・CDK npm キャッシュ修正

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: "ap-northeast-1"
           role-duration-seconds: 1200
@@ -38,14 +38,14 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker Build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           push: true
           builder: ${{ steps.buildx.outputs.name }}
@@ -54,6 +54,3 @@ jobs:
           context: ./
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-
-

--- a/.github/workflows/_check.yaml
+++ b/.github/workflows/_check.yaml
@@ -6,7 +6,7 @@ on:
       ruby-version:
         type: string
         required: false
-        default: 3.2.6
+        default: 3.3.4
 
 jobs:
   rubocop:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -61,7 +61,7 @@ jobs:
           - 6379/tcp
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: apt-get
         run: |
@@ -74,14 +74,14 @@ jobs:
           which mogrify
           mogrify -version
 
-      - name: Set up Ruby 3.2.6
+      - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby-version }}
           bundler-cache: true
 
       - name: setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.18.3
           cache: 'yarn'
@@ -97,7 +97,7 @@ jobs:
           git rev-parse $(git log --oneline -n 1 app/decidim-packs tmp/shakapacker.lock lib/assets Gemfile.lock yarn.lock | awk '{print $1}') > ASSETS_VERSION
 
       - name: asset cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             public/decidim-packs

--- a/.github/workflows/_deploy.yaml
+++ b/.github/workflows/_deploy.yaml
@@ -27,17 +27,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1800
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ inputs.role-to-assume }}
           aws-region: ap-northeast-1
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Check if ECR Image exists with tag
         if: contains(github.ref, 'tags/v')
@@ -54,35 +54,23 @@ jobs:
           fi
 
       - name: Checkout decidim-cfj cdk
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: codeforjapan/decidim-cfj-cdk
           path: decidim-cfj-cdk
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: decidim-cfj-cdk/package-lock.json
 
-      - name: Cache node modules
-        id: cache-npm
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Install dependencies
+      - name: Install project dependencies
         run: npm install
         working-directory: decidim-cfj-cdk
 
-      - name: Install dependencies
+      - name: Install aws-cdk
         run: npm install -g aws-cdk
         working-directory: decidim-cfj-cdk
 

--- a/.github/workflows/brakeman.yaml
+++ b/.github/workflows/brakeman.yaml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.6
+          ruby-version: 3.3.4
           bundler-cache: true
 
       - name: Run Brakeman scan

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
       deploy-env: ${{ steps.output-deploy-env.outputs.deploy-env }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set env to staging
         id: set-env-staging


### PR DESCRIPTION
## Summary

- **Node.js 20 非推奨対応**: `actions/checkout`, `setup-node`, `cache`, `aws-actions/*`, `docker/*` を最新バージョンへ更新（2026年6月の強制移行前に対応）
- **Ruby バージョン修正**: CI のデフォルトが `3.2.6` になっていたのを実際のアプリバージョン `3.3.4` に統一（`_check.yaml`, `brakeman.yaml`）
- **CDK npm キャッシュ修正**: `_deploy.yaml` のキャッシュキーが `yarn.lock` を参照していたが、パッケージマネージャは npm なので `package-lock.json` を使うよう修正。手動の `actions/cache` ステップを削除し `setup-node@v4` の組み込みキャッシュに統合

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `_check.yaml` | checkout v4, setup-node v4, cache v4, Ruby 3.3.4 |
| `_build.yaml` | checkout v4, configure-aws-credentials v4, ecr-login v2, buildx v3, build-push v6 |
| `_deploy.yaml` | checkout v4, configure-aws-credentials v4, ecr-login v2, setup-node v4 + npm キャッシュ修正 |
| `brakeman.yaml` | checkout v4, Ruby 3.3.4 |
| `main.yaml` | checkout v4 |

## Test plan

- [ ] CI が正常に動作することを確認（branch.yaml が green になること）
- [ ] CDK デプロイの npm キャッシュが効いていることを確認（2回目の実行でキャッシュヒットすること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)