### PR TITLE
ci: GitHub Actions バージョン更新（checkout v4, setup-node v4, aws-actions v4, docker v6）

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: "ap-northeast-1"
           role-duration-seconds: 1200
@@ -38,7 +38,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -42,10 +42,10 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker Build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           push: true
           builder: ${{ steps.buildx.outputs.name }}
@@ -54,6 +54,7 @@ jobs:
           context: ./
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
 
 
 

--- a/.github/workflows/_check.yaml
+++ b/.github/workflows/_check.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -61,7 +61,7 @@ jobs:
           - 6379/tcp
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: apt-get
         run: |
@@ -81,7 +81,7 @@ jobs:
           bundler-cache: true
 
       - name: setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.18.3
           cache: 'yarn'
@@ -97,7 +97,7 @@ jobs:
           git rev-parse $(git log --oneline -n 1 app/decidim-packs tmp/shakapacker.lock lib/assets Gemfile.lock yarn.lock | awk '{print $1}') > ASSETS_VERSION
 
       - name: asset cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             public/decidim-packs

--- a/.github/workflows/_deploy.yaml
+++ b/.github/workflows/_deploy.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1800
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -54,19 +54,19 @@ jobs:
           fi
 
       - name: Checkout decidim-cfj cdk
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: codeforjapan/decidim-cfj-cdk
           path: decidim-cfj-cdk
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/_deploy.yaml
+++ b/.github/workflows/_deploy.yaml
@@ -30,14 +30,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ inputs.role-to-assume }}
           aws-region: ap-northeast-1
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Check if ECR Image exists with tag
         if: contains(github.ref, 'tags/v')

--- a/.github/workflows/_deploy.yaml
+++ b/.github/workflows/_deploy.yaml
@@ -25,7 +25,7 @@ jobs:
   deploy:
     name: aws cdk
     runs-on: ubuntu-latest
-    timeout-minutes: 1800
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/_deploy.yaml
+++ b/.github/workflows/_deploy.yaml
@@ -72,22 +72,18 @@ jobs:
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('decidim-cfj-cdk/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - name: Install dependencies
+      - name: Install project dependencies
         run: npm install
         working-directory: decidim-cfj-cdk
 
-      - name: Install dependencies
-        run: npm install -g aws-cdk
-        working-directory: decidim-cfj-cdk
-
       - name: cdk deploy
-        run: cdk -c stage=$DEPLOY_ENV -c tag=$IMAGE_TAG deploy --all --require-approval never
+        run: npx cdk -c stage=$DEPLOY_ENV -c tag=$IMAGE_TAG deploy --all --require-approval never
         working-directory: decidim-cfj-cdk
         env:
           AWS_DEFAULT_REGION: 'ap-northeast-1'

--- a/.github/workflows/brakeman.yaml
+++ b/.github/workflows/brakeman.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
       deploy-env: ${{ steps.output-deploy-env.outputs.deploy-env }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set env to staging
         id: set-env-staging


### PR DESCRIPTION
## Summary

- `actions/checkout`, `actions/setup-node`, `actions/cache` を v4 に更新
- `aws-actions/configure-aws-credentials` を v1→v4、`amazon-ecr-login` を v1→v2 に更新
- `docker/setup-buildx-action` を v1→v3、`docker/build-push-action` を v3→v6 に更新（`provenance: false` を追加し ECR 互換性を維持）
- `_deploy.yaml` のキャッシュキーを `yarn.lock` → `decidim-cfj-cdk/package-lock.json` に修正（CDK リポジトリは npm を使用）
- `_deploy.yaml` の `npm install -g aws-cdk` を削除し `npx cdk` に変更（devDependencies でバージョン固定済みのものを使用）
- Node.js バージョンを 22 → 24 に変更（CDK の `package.json` が `>=24.0.0` を要求）
- `timeout-minutes` を 1800（30時間）→ 30（分）に修正（実際のデプロイ時間は約6分）

## Background

- GitHub Actions の Node.js 20 サポートが 2026年6月に終了予定
- IAM trust policy に `aud` 条件がないことを確認済み（configure-aws-credentials v1→v4 の OIDC 互換性に問題なし）
- `build-push-action` v4以降はデフォルトで SLSA provenance を有効化するが、ECR は attestation 非対応のため `provenance: false` が必要

## Test plan

- [ ] CI が正常に通ることを確認
- [ ] staging デプロイが正常に完了することを確認