### PR TITLE
ci: GitHub Actions を最新バージョンへ更新（checkout v6, setup-node v6, cache v5, aws-actions v6, docker v4/v7）

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: "ap-northeast-1"
           role-duration-seconds: 1200
@@ -42,10 +42,10 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker Build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/_check.yaml
+++ b/.github/workflows/_check.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -61,7 +61,7 @@ jobs:
           - 6379/tcp
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: apt-get
         run: |
@@ -81,7 +81,7 @@ jobs:
           bundler-cache: true
 
       - name: setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.18.3
           cache: 'yarn'
@@ -97,7 +97,7 @@ jobs:
           git rev-parse $(git log --oneline -n 1 app/decidim-packs tmp/shakapacker.lock lib/assets Gemfile.lock yarn.lock | awk '{print $1}') > ASSETS_VERSION
 
       - name: asset cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             public/decidim-packs

--- a/.github/workflows/_deploy.yaml
+++ b/.github/workflows/_deploy.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ inputs.role-to-assume }}
           aws-region: ap-northeast-1
@@ -54,19 +54,19 @@ jobs:
           fi
 
       - name: Checkout decidim-cfj cdk
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: codeforjapan/decidim-cfj-cdk
           path: decidim-cfj-cdk
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/brakeman.yaml
+++ b/.github/workflows/brakeman.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -36,7 +36,7 @@ jobs:
           bundle exec brakeman --format json --output brakeman-results.json --no-exit-on-warn --no-exit-on-error --except EOLRuby
 
       - name: Upload Brakeman results as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: brakeman-results

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
       deploy-env: ${{ steps.output-deploy-env.outputs.deploy-env }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set env to staging
         id: set-env-staging


### PR DESCRIPTION
## Summary

- `actions/checkout` v4 → **v6**
- `actions/setup-node` v4 → **v6**
- `actions/cache` v4 → **v5**
- `aws-actions/configure-aws-credentials` v4 → **v6**
- `docker/setup-buildx-action` v3 → **v4**
- `docker/build-push-action` v6 → **v7**
- `actions/upload-artifact` v4 → **v7**（brakeman.yaml）

## Background

Node.js 20 の GitHub Actions サポートが 2026年6月2日に強制移行、2026年9月16日に削除予定。
各アクションの最新メジャーバージョンは Node.js 24 ランタイムを使用しており、警告を解消する。

破壊的変更の影響確認済み：
- `setup-node@v6` の自動キャッシュ変更は `cache: 'yarn'` を明示指定しているため影響なし
- `configure-aws-credentials@v6` の boolean 入力変更は未使用のため影響なし
- `setup-buildx-action@v4` の非推奨 inputs/outputs 削除は `outputs.name` は対象外のため影響なし
- `build-push-action@v7` の非推奨 env 変数削除は未使用のため影響なし

## Test plan

- [ ] CI が正常に通ることを確認
- [ ] Node.js 20 の deprecation 警告が消えることを確認