### PR TITLE
fix ProposalPresenter to force `html_escape: true`

### DIFF
--- a/config/initializers/proposal_presenter_override.rb
+++ b/config/initializers/proposal_presenter_override.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# This patch forces `html_escape: true` at the presenter boundary
+Rails.application.config.to_prepare do
+  Decidim::Proposals::ProposalPresenter # rubocop:disable Lint/Void
+
+  module ProposalPresenterAlwaysEscapeTitle
+    # rubocop:disable Lint/UnusedMethodArgument
+    def title(links: false, extras: true, html_escape: false, all_locales: false)
+      super(links:, extras:, html_escape: true, all_locales:)
+    end
+    # rubocop:enable Lint/UnusedMethodArgument
+  end
+
+  Decidim::Proposals::ProposalPresenter.prepend(ProposalPresenterAlwaysEscapeTitle)
+end

--- a/spec/presenters/decidim/proposals/proposal_presenter_override_spec.rb
+++ b/spec/presenters/decidim/proposals/proposal_presenter_override_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# rubocop:disable Rails/SkipsModelValidations
+module Decidim
+  module Proposals
+    describe ProposalPresenter do
+      let(:organization) { create(:organization) }
+      let(:component) { create(:proposal_component, organization:) }
+      let(:user) { create(:user, :confirmed, organization:) }
+      let(:proposal) { create(:proposal, component:, users: [user]) }
+      let(:presenter) { described_class.new(proposal) }
+
+      describe "#title" do
+        context "when the stored title contains a script tag" do
+          before do
+            proposal.update_column(:title, { I18n.locale.to_s => "Hi<script>alert(1)</script>" })
+          end
+
+          it "escapes the tag with the default arguments" do
+            expect(presenter.title).to include("&lt;script&gt;")
+            expect(presenter.title).not_to include("<script>")
+          end
+
+          it "escapes the tag when called with html_escape: true" do
+            expect(presenter.title(html_escape: true)).to include("&lt;script&gt;")
+            expect(presenter.title(html_escape: true)).not_to include("<script>")
+          end
+
+          it "escapes the tag when called with html_escape: false (forced safe)" do
+            expect(presenter.title(html_escape: false)).to include("&lt;script&gt;")
+            expect(presenter.title(html_escape: false)).not_to include("<script>")
+          end
+
+          it "marks the result html_safe" do
+            expect(presenter.title).to be_html_safe
+          end
+        end
+
+        context "when the stored title contains an event-handler attribute" do
+          before do
+            proposal.update_column(:title, { I18n.locale.to_s => "Hi <img src=x onerror=alert(1)>" })
+          end
+
+          it "escapes angle brackets so the tag cannot execute" do
+            expect(presenter.title).not_to match(/<img\b/i)
+            expect(presenter.title).to include("&lt;img")
+          end
+        end
+
+        context "when the stored title is plain text" do
+          before do
+            proposal.update_column(:title, { I18n.locale.to_s => "Hello world" })
+          end
+
+          it "preserves the text unchanged" do
+            expect(presenter.title.to_s).to eq("Hello world")
+          end
+        end
+      end
+
+      describe "#id_and_title" do
+        before do
+          proposal.update_column(:title, { I18n.locale.to_s => "Hi<script>alert(1)</script>" })
+        end
+
+        it "escapes the title portion regardless of html_escape argument" do
+          expect(presenter.id_and_title(html_escape: false)).to include("&lt;script&gt;")
+          expect(presenter.id_and_title(html_escape: false)).not_to include("<script>")
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Rails/SkipsModelValidations


### PR DESCRIPTION
#### :tophat: What? Why?

Decidim::Proposals::ProposalPresenterのHTMLエスケープを変更して、後段でエスケープするよう修正します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

