### PR TITLE
feat: preserve width/height/class/id on SimpleImage round-trip

### DIFF
--- a/app/packs/src/decidim/cfj/editor/extensions/simple_image/index.js
+++ b/app/packs/src/decidim/cfj/editor/extensions/simple_image/index.js
@@ -38,6 +38,23 @@ export const SimpleImage = Node.create({
       title: {
         default: null,
       },
+      // Preserved so authors editing HTML directly do not lose layout intent
+      // and basic styling hooks. All four pass Loofah's UserInputScrubber /
+      // AdminInputScrubber allowlists, so they round-trip through display as
+      // well — provided the surrounding context allows <img> at all
+      // (admin scope; user scope still strips img regardless).
+      width: {
+        default: null,
+      },
+      height: {
+        default: null,
+      },
+      class: {
+        default: null,
+      },
+      id: {
+        default: null,
+      },
     }
   },
 

--- a/app/packs/src/decidim/cfj/editor/extensions/simple_image/index.test.js
+++ b/app/packs/src/decidim/cfj/editor/extensions/simple_image/index.test.js
@@ -61,6 +61,40 @@ describe("SimpleImage extension (integration via DecidimKit)", () => {
       expect(html).toContain('title="t"');
     });
 
+    it("preserves width and height on round-trip", () => {
+      editor.commands.setContent(
+        '<p><img src="https://example.com/a.png" width="200" height="100"></p>'
+      );
+      expect(editor.getHTML()).toMatchHtml(
+        '<p><img src="https://example.com/a.png" width="200" height="100"></p>'
+      );
+    });
+
+    it("preserves class and id on round-trip", () => {
+      editor.commands.setContent(
+        '<p><img src="https://example.com/a.png" class="thumb" id="hero"></p>'
+      );
+      expect(editor.getHTML()).toMatchHtml(
+        '<p><img src="https://example.com/a.png" class="thumb" id="hero"></p>'
+      );
+    });
+
+    it("does not emit class / id attributes when absent from input", () => {
+      editor.commands.setContent('<p><img src="https://example.com/a.png"></p>');
+      expect(editor.getHTML()).toMatchHtml(
+        '<p><img src="https://example.com/a.png"></p>'
+      );
+    });
+
+    it("preserves the full set of supported attributes together", () => {
+      editor.commands.setContent(
+        '<p><img src="https://example.com/a.png" alt="x" title="t" width="200" height="100" class="ic" id="i1"></p>'
+      );
+      expect(editor.getHTML()).toMatchHtml(
+        '<p><img src="https://example.com/a.png" alt="x" title="t" width="200" height="100" class="ic" id="i1"></p>'
+      );
+    });
+
     it("drops data: URIs (parseHTML excludes them)", () => {
       editor.commands.setContent('<p><img src="data:image/png;base64,AAA"></p>');
       expect(editor.getHTML()).not.toContain("<img");


### PR DESCRIPTION
#### :tophat: What? Why?

SimpleImageにwidth/height/class/id属性を追加する修正です。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
