### PR TITLE
fix: redefine invalid `BLOB_REGEX` in decidim-core

### DIFF
--- a/config/initializers/blob_parser_regex_patch.rb
+++ b/config/initializers/blob_parser_regex_patch.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# Back-port of Decidim::ContentParsers::BlobParser from decidim-core v0.30.9
+# onto cfj's current v0.29.x install.
+#
+# The v0.29.x upstream regex defines the URL host part as `((?!/rails).)+`,
+# a greedy negative-lookahead that consumes any character — including HTML
+# tags, quotes, and angle brackets — until it reaches `/rails`. When a body
+# field contains both an external <img src="..."> and an ActiveStorage blob
+# <img src="..."> later on, the regex matches one span starting at the
+# external URL host and ending at the blob URL's filename. `gsub` then
+# replaces that entire span with a single Global ID, destroying the
+# external img tag, the wrapper opening tag, and the blob img's leading
+# `<img src=`. v0.30.x fixed this by switching the host part to
+# URI::DEFAULT_PARSER.make_regexp(%w(https http)) and adopting named
+# captures throughout. The two changes are paired (regex shape + named
+# capture access in replace_blobs), so we ship them together.
+#
+# This patch coexists with `blob_parser_override.rb` (S3 URL extension),
+# which aliases `rewrite` and calls `original_rewrite` — the original
+# `rewrite` then calls our prepended `replace_blobs`.
+#
+# TODO: remove this file once cfj upgrades to decidim-core v0.30.x.
+
+module Decidim
+  module ContentParsers
+    # Mirrors the BlobParser#replace_blobs implementation shipped in
+    # decidim-core v0.30.9. Prepended so its named-capture access matches
+    # the BLOB_REGEX shape installed alongside it below.
+    module BlobParserUpstreamFix
+      private
+
+      def replace_blobs(text)
+        text.gsub(self.class::BLOB_REGEX) do |match|
+          named_captures = Regexp.last_match.named_captures
+
+          type_part = named_captures["type_part"]
+          key_part = named_captures["key_part"]
+
+          variation_key = nil
+          blob =
+            if type_part == "disk"
+              decoded = ActiveStorage.verifier.verified(key_part, purpose: :blob_key)
+              ActiveStorage::Blob.find_by(key: decoded[:key]) if decoded
+            else
+              if type_part.start_with?("representations")
+                variation_part = named_captures["variation_part"]
+                variation_key = generate_variation_key(variation_part)
+              end
+
+              ActiveStorage::Blob.find_signed(key_part)
+            end
+          next match unless blob
+
+          "#{blob.to_global_id}#{"/#{variation_key}" if variation_key}"
+        end
+      end
+    end
+  end
+end
+
+Rails.application.config.to_prepare do
+  Decidim::ContentParsers::BlobParser.send(:remove_const, :BLOB_REGEX) if
+    Decidim::ContentParsers::BlobParser.const_defined?(:BLOB_REGEX, false)
+
+  Decidim::ContentParsers::BlobParser.const_set(
+    :BLOB_REGEX,
+    %r{
+      (?<host_part>
+        #{URI::DEFAULT_PARSER.make_regexp(%w(https http))}
+      )?
+      /rails/active_storage
+      /(?<type_part>blobs/redirect|blobs/proxy|blobs|representations/redirect|representations/proxy|representations|disk)
+      /(?<key_part>[^/]+)
+      (
+        /(?<variation_part>[\w.=-]+)
+      )?
+      /((?:[^\s/"<>']|'(?=[^\s/"<>']))+)
+    }x
+  )
+
+  unless Decidim::ContentParsers::BlobParser.include?(Decidim::ContentParsers::BlobParserUpstreamFix)
+    Decidim::ContentParsers::BlobParser.prepend(Decidim::ContentParsers::BlobParserUpstreamFix)
+  end
+end

--- a/spec/lib/decidim/content_parsers/blob_parser_regex_patch_spec.rb
+++ b/spec/lib/decidim/content_parsers/blob_parser_regex_patch_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Pins the regression fixed by config/initializers/blob_parser_regex_patch.rb.
+#
+# Without the patch, BLOB_REGEX's host part `((?!/rails).)+` matches greedily
+# across HTML, swallowing any external image markup and the wrapper opening
+# tag that sits between an external <img> and a blob <img>. With the patch
+# the regex only consumes characters that can legitimately appear inside a
+# URL literal, so each blob URL is matched in isolation.
+#
+# The cases below intentionally exercise the regex via `gsub` and via the
+# real parser, so a future change that drops the patch (or reverts to the
+# greedy upstream regex) trips at least one expectation.
+describe "Decidim::ContentParsers::BlobParser::BLOB_REGEX (greedy match fix)" do
+  let(:regex) { Decidim::ContentParsers::BlobParser::BLOB_REGEX }
+
+  describe "the constant alone" do
+    let(:external_then_blob) do
+      <<~HTML.delete("\n")
+        <p><img src="https://sample.photos/id/237/200/300"></p>
+        <div class="editor-content-image" data-image=""><img src="http://example.test/rails/active_storage/disk/SOMEKEY/old-admin-form.png" alt="w" width="648"></div>
+      HTML
+    end
+
+    it "does not span across the external <img> when followed by a blob <img>" do
+      match = external_then_blob.match(regex)
+      expect(match).not_to be_nil
+      expect(match[0]).not_to include("sample.photos")
+      expect(match[0]).not_to include("<")
+      expect(match[0]).not_to include('"')
+    end
+
+    it "matches exactly the blob URL substring" do
+      expect(external_then_blob[regex]).to eq(
+        "http://example.test/rails/active_storage/disk/SOMEKEY/old-admin-form.png"
+      )
+    end
+
+    it "leaves intervening HTML intact when used with gsub replacement" do
+      replaced = external_then_blob.gsub(regex) { "[BLOB]" }
+
+      expect(replaced).to include('<img src="https://sample.photos/id/237/200/300">')
+      expect(replaced).to include('<div class="editor-content-image" data-image="">')
+      expect(replaced).to include('<img src="[BLOB]" alt="w" width="648">')
+      expect(replaced).to include("</div>")
+      expect(replaced.scan("[BLOB]").size).to eq(1)
+    end
+
+    it "still matches a single blob URL with no surrounding content" do
+      url = "http://example.test/rails/active_storage/disk/ABC/file.png"
+      expect(url[regex]).to eq(url)
+    end
+
+    it "matches a representations URL with variation key" do
+      url = "http://example.test/rails/active_storage/representations/redirect/SIG/VARIATION/file.png"
+      expect(url[regex]).to eq(url)
+    end
+
+    it "does not match content with no blob URL" do
+      html = '<p>Plain text with <img src="https://example.com/x.png"></p>'
+      expect(html[regex]).to be_nil
+    end
+  end
+
+  describe "via the real parser (`rewrite`)" do
+    # The real parser delegates the lookup to ActiveStorage::Blob.find_signed,
+    # which is exercised in spec/lib/decidim/content_parsers/blob_parser_spec.rb.
+    # Here we only care that the surrounding HTML survives the gsub — the
+    # blob lookup itself may succeed or fall through to `next match`; in
+    # either case the assertions below are valid because they describe what
+    # must NOT happen (markup loss outside the URL literal).
+    let(:external_url) { "https://sample.photos/id/237/200/300" }
+    let(:blob_url) { "/rails/active_storage/disk/SOMEKEY/old-admin-form.png" }
+
+    let(:content) do
+      <<~HTML.delete("\n")
+        <p>test</p>
+        <p>aaaaa</p>
+        <p></p>
+        <p><img src="#{external_url}"></p>
+        <div class="editor-content-image" data-image=""><img src="#{blob_url}" alt="w" width="648"></div>
+      HTML
+    end
+
+    it "preserves the external <img>, the wrapper opening tag, and surrounding HTML" do
+      rewritten = Decidim::ContentParsers::BlobParser.new(content, {}).rewrite
+
+      expect(rewritten).to include("<p>test</p>")
+      expect(rewritten).to include("<p>aaaaa</p>")
+      expect(rewritten).to include(%(<img src="#{external_url}">))
+      expect(rewritten).to include('<div class="editor-content-image" data-image="">')
+      expect(rewritten).to include('alt="w" width="648"')
+    end
+
+    it "does not leave a stray </div> from a destroyed wrapper opening tag" do
+      rewritten = Decidim::ContentParsers::BlobParser.new(content, {}).rewrite
+
+      open_divs = rewritten.scan(/<div\b/).size
+      close_divs = rewritten.scan(%r{</div>}).size
+      expect(open_divs).to eq(close_divs)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

タグエディタで画像が混ざったりすると壊れるケースを修正します。
どうも複数の画像タグをまたいでマッチングする、みたいなことが発生していたようでした。

→さらに調べたところではv0.30.9とかでは修正済みのようで、そちらの修正を持ってきています。
そのためv0.30にアップデートすれば不要になります。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
