### PR TITLE
fix: DecidimAwesome::Config#sub_configs_for のN+1クエリを解消

### DIFF
--- a/config/initializers/decidim_awesome_patches.rb
+++ b/config/initializers/decidim_awesome_patches.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# DecidimAwesome::Config#sub_configs_for のN+1クエリ修正
+#
+# 元の実装はサブ設定キーごとに AwesomeConfig.find_by を個別実行するため、
+# proposals ページで 19クエリ/リクエスト 発生していた。
+# initialize 時に一括取得済みの @vars からRubyレベルで検索することで解消する。
+Decidim::DecidimAwesome::Config.prepend(Module.new do
+  def sub_configs_for(singular_key)
+    return @sub_configs[singular_key] if @sub_configs[singular_key]
+
+    plural_key = singular_key.pluralize.to_sym
+    return {} unless config[plural_key]
+
+    @sub_configs[singular_key] = config[plural_key].to_h do |key, _value|
+      [key, @vars.find { |v| v.var == "#{singular_key}_#{key}" }]
+    end
+  end
+end)


### PR DESCRIPTION
## 概要

proposalsページで `Decidim::DecidimAwesome::AwesomeConfig find` が **19クエリ/リクエスト** 発生していた問題を修正します。

## 原因

`Config#sub_configs_for` が、サブ設定キー（`proposal_custom_field`, `scoped_style`, `scoped_admin` 等）ごとに `AwesomeConfig.find_by(var: ..., organization: ...)` を個別実行していた。

`initialize` 時に `AwesomeConfig.for_organization(organization).includes(:constraints)` で全件一括取得済み（`@vars`）にもかかわらず、そのキャッシュを使っていなかった。

## 修正内容

`sub_configs_for` が個別に `AwesomeConfig.find_by` を呼ぶ代わりに、`@vars`（一括取得済み）からRubyレベルで `find` する実装に変更。

- **変更前**: サブ設定キー数 × 呼び出し種別数 = ~19 クエリ/リクエスト
- **変更後**: 追加クエリ 0件（`initialize` の1クエリのみ）

## 安全性確認

- `for_organization` スコープは `where(organization:)` のみ → `@vars` とクエリ条件が等価
- `add_constraints` はメモリ変更のみ → オブジェクト同一参照で動作に影響なし
- `@vars` のロードタイミング → `config[plural_key]` 評価後に `sub_configs_for` が呼ばれるため、`@vars` はロード済み

## テスト計画

- [ ] ローカルでproposalsページを開き、ログに `AwesomeConfig` のDBクエリが増えていないことを確認
- [ ] 既存のRSpecテストが通ることを確認（`bundle exec rspec spec/`）