### PR TITLE
fix: CloseMeetingReminderGenerator の space_admins メモ化バグを修正

### DIFF
--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -462,18 +462,20 @@ Rails.application.config.to_prepare do
 
   # Fix CloseMeetingReminderGenerator#space_admins cross-organization memoization bug
   # @space_admins ||= はインスタンス変数にメモ化するため、全組織をまたいで同じ管理者リストが
-  # 使い回されてしまう。メモ化を除去して毎回正しい組織の管理者を返すようにする。
+  # 使い回されてしまう。component.id をキーにしたハッシュでメモ化し、組織ごとに正しい管理者を返す。
   module DecidimMeetingsCloseMeetingReminderGeneratorPatch
     private
 
     def space_admins(component)
-      sa = if component.participatory_space.respond_to?(:user_roles)
-             component.participatory_space.user_roles(:admin).collect(&:user)
-           else
-             []
-           end
-      global_admins = component.organization.admins
-      (global_admins + sa).uniq
+      @space_admins ||= {}
+      @space_admins[component.id] ||= begin
+        sa = if component.participatory_space.respond_to?(:user_roles)
+               component.participatory_space.user_roles(:admin).collect(&:user)
+             else
+               []
+             end
+        (component.organization.admins + sa).uniq
+      end
     end
   end
 

--- a/config/initializers/decidim_override.rb
+++ b/config/initializers/decidim_override.rb
@@ -457,4 +457,33 @@ Rails.application.config.to_prepare do
       end
     end
   end
+
+  # ----------------------------------------
+
+  # Fix CloseMeetingReminderGenerator#space_admins cross-organization memoization bug
+  # @space_admins ||= はインスタンス変数にメモ化するため、全組織をまたいで同じ管理者リストが
+  # 使い回されてしまう。メモ化を除去して毎回正しい組織の管理者を返すようにする。
+  module DecidimMeetingsCloseMeetingReminderGeneratorPatch
+    private
+
+    def space_admins(component)
+      sa = if component.participatory_space.respond_to?(:user_roles)
+             component.participatory_space.user_roles(:admin).collect(&:user)
+           else
+             []
+           end
+      global_admins = component.organization.admins
+      (global_admins + sa).uniq
+    end
+  end
+
+  Decidim::Meetings::CloseMeetingReminderGenerator # rubocop:disable Lint/Void
+
+  module Decidim
+    module Meetings
+      class CloseMeetingReminderGenerator
+        prepend DecidimMeetingsCloseMeetingReminderGeneratorPatch
+      end
+    end
+  end
 end

--- a/spec/services/decidim/meetings/close_meeting_reminder_generator_spec.rb
+++ b/spec/services/decidim/meetings/close_meeting_reminder_generator_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Decidim::Meetings::CloseMeetingReminderGenerator do
         create(:meeting, :published, :official, component: component_b, end_time: 3.days.ago)
       end
 
-      it "org_b の公式ミーティングリマインダーを org_b の管理者にのみ送る" do
+      it "各組織の公式ミーティングリマインダーをその組織の管理者にのみ送る" do
         queued_records = []
         allow(Decidim::Meetings::SendCloseMeetingReminderJob).to receive(:perform_later) do |record|
           queued_records << record
@@ -34,10 +34,10 @@ RSpec.describe Decidim::Meetings::CloseMeetingReminderGenerator do
 
         generator.generate
 
+        org_a_meeting_reminders = queued_records.select { |r| r.remindable == official_meeting_a }
         org_b_meeting_reminders = queued_records.select { |r| r.remindable == official_meeting_b }
-        users = org_b_meeting_reminders.map { |r| r.reminder.user }
-        expect(users).not_to include(admin_a)
-        expect(users).to include(admin_b)
+        expect(org_a_meeting_reminders.map { |r| r.reminder.user }).to contain_exactly(admin_a)
+        expect(org_b_meeting_reminders.map { |r| r.reminder.user }).to contain_exactly(admin_b)
       end
     end
   end

--- a/spec/services/decidim/meetings/close_meeting_reminder_generator_spec.rb
+++ b/spec/services/decidim/meetings/close_meeting_reminder_generator_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Decidim::Meetings::CloseMeetingReminderGenerator do
+  subject(:generator) { described_class.new }
+
+  describe "#generate" do
+    context "when multiple organizations exist (cross-organization bug)" do
+      let(:org_a) { create(:organization) }
+      let(:org_b) { create(:organization) }
+
+      let!(:admin_a) { create(:user, :admin, organization: org_a) }
+      let!(:admin_b) { create(:user, :admin, organization: org_b) }
+
+      let(:space_a) { create(:participatory_process, :with_steps, organization: org_a) }
+      let(:component_a) { create(:meeting_component, participatory_space: space_a) }
+
+      let(:space_b) { create(:participatory_process, :with_steps, organization: org_b) }
+      let(:component_b) { create(:meeting_component, participatory_space: space_b) }
+
+      let!(:official_meeting_a) do
+        create(:meeting, :published, :official, component: component_a, end_time: 3.days.ago)
+      end
+      let!(:official_meeting_b) do
+        create(:meeting, :published, :official, component: component_b, end_time: 3.days.ago)
+      end
+
+      it "org_b の公式ミーティングリマインダーを org_b の管理者にのみ送る" do
+        queued_records = []
+        allow(Decidim::Meetings::SendCloseMeetingReminderJob).to receive(:perform_later) do |record|
+          queued_records << record
+        end
+
+        generator.generate
+
+        org_b_meeting_reminders = queued_records.select { |r| r.remindable == official_meeting_b }
+        users = org_b_meeting_reminders.map { |r| r.reminder.user }
+        expect(users).not_to include(admin_a)
+        expect(users).to include(admin_b)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 問題

`CloseMeetingReminderGenerator#space_admins` が `@space_admins ||=` でインスタンス変数にメモ化されているため、複数組織をまたいで `generate` が実行されると、最初に処理した組織の管理者リストがすべての後続コンポーネントに使い回されます。

**再現した事象（2026-05-27）**: いのち会議（inochi-forum.org）の公式ミーティングリマインダーが、世田谷区（youth-setagaya-test.makeour.city）の管理者へ世田谷区ブランドで誤送信されました。

## 原因

```ruby
# decidim-meetings-0.29.2
def space_admins(component)
  @space_admins ||= begin   # component を無視してインスタンス変数にキャッシュ
    ...
  end
end
```

`generate` は全組織の全 meetings コンポーネントを横断して処理しますが、`@space_admins` は最初の呼び出しでキャッシュされ、以降は異なる組織のコンポーネントが渡されても同じ管理者リストが返ります。

## 修正

`decidim_override.rb` に `prepend` パッチを追加し、`space_admins` メソッドのインスタンス変数メモ化を除去しました。呼び出しごとに渡された `component` の組織に基づいて管理者を返します。

## テスト

2組織を用意し、org_b の公式ミーティングリマインダーが org_a の管理者に送られないことを RSpec で確認しています。