### PR TITLE
fix: delete:destroy_all タスクの修正と拡張

### DIFF
--- a/app/commands/decidim/organizations/destroy_organization.rb
+++ b/app/commands/decidim/organizations/destroy_organization.rb
@@ -41,7 +41,13 @@ module Decidim
 
         Decidim::ActionLog.where(organization:).delete_all
 
-        Decidim::AssembliesSetting.where(organization:).delete_all
+        ActiveRecord::Base.connection.execute(
+          "DELETE FROM decidim_assemblies_settings WHERE decidim_organization_id = #{organization.id}"
+        )
+
+        ActiveRecord::Base.connection.execute(
+          "DELETE FROM decidim_user_blocks WHERE decidim_user_id IN (SELECT id FROM decidim_users WHERE decidim_organization_id = #{organization.id}) OR blocking_user_id IN (SELECT id FROM decidim_users WHERE decidim_organization_id = #{organization.id})"
+        )
 
         organization.destroy!
 

--- a/app/commands/decidim/organizations/destroy_organization.rb
+++ b/app/commands/decidim/organizations/destroy_organization.rb
@@ -46,7 +46,10 @@ module Decidim
         )
 
         ActiveRecord::Base.connection.execute(
-          "DELETE FROM decidim_user_blocks WHERE decidim_user_id IN (SELECT id FROM decidim_users WHERE decidim_organization_id = #{organization.id}) OR blocking_user_id IN (SELECT id FROM decidim_users WHERE decidim_organization_id = #{organization.id})"
+          "DELETE FROM decidim_user_blocks WHERE decidim_user_id IN " \
+          "(SELECT id FROM decidim_users WHERE decidim_organization_id = #{organization.id}) " \
+          "OR blocking_user_id IN " \
+          "(SELECT id FROM decidim_users WHERE decidim_organization_id = #{organization.id})"
         )
 
         organization.destroy!

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -18,6 +18,8 @@ namespace :delete do
     :destroy_all_participatory_processes,
     :destroy_all_areas,
     :destroy_all_newsletters,
+    :destroy_all_metrics,
+    :destroy_all_short_links,
     :destroy_organization,
     :destroy_all_messages
   ]
@@ -225,7 +227,6 @@ namespace :delete do
     organization = decidim_find_organization
     return unless organization
 
-    form = OpenStruct.new(valid?: true, delete_reason: "Testing")
     Decidim::User.transaction do
       Decidim::User.where(organization:).find_each(batch_size: 100) do |user|
         Decidim::Gamifications::DestroyAllBadges.call(organization, user)
@@ -233,10 +234,11 @@ namespace :delete do
       end
     end
 
-    # Use tranzaction in Decidim::DestroyAccount
+    # Use transaction in Decidim::DestroyAccount
     Decidim::User.where(organization:).find_each(batch_size: 100) do |user|
       puts "destroy user id: #{user.id}"
-      Decidim::DestroyAccount.call(user, form)
+      form = OpenStruct.new(valid?: true, delete_reason: "delete org", current_user: user)
+      Decidim::DestroyAccount.call(form)
     rescue StandardError => e
       puts "Decidim::DestroyAccount failed: #{e.inspect}"
     end
@@ -268,20 +270,50 @@ namespace :delete do
 
     puts "Finish destroy_all_messages"
   end
+
+  desc "Destroy all metrics for a given organization"
+  task destroy_all_metrics: :environment do
+    puts "Start destroy_all_metrics of #{ENV["DECIDIM_ORGANIZATION_NAME"] || ENV["DECIDIM_ORGANIZATION_ID"]}"
+
+    organization = decidim_find_organization
+    return unless organization
+
+    Decidim::Metric.where(decidim_organization_id: organization.id).delete_all
+
+    puts "Finish destroy_all_metrics of #{ENV["DECIDIM_ORGANIZATION_NAME"] || ENV["DECIDIM_ORGANIZATION_ID"]}"
+  end
+
+  desc "Destroy all short links for a given organization"
+  task destroy_all_short_links: :environment do
+    puts "Start destroy_all_short_links of #{ENV["DECIDIM_ORGANIZATION_NAME"] || ENV["DECIDIM_ORGANIZATION_ID"]}"
+
+    organization = decidim_find_organization
+    return unless organization
+
+    Decidim::ShortLink.where(decidim_organization_id: organization.id).delete_all
+
+    puts "Finish destroy_all_short_links of #{ENV["DECIDIM_ORGANIZATION_NAME"] || ENV["DECIDIM_ORGANIZATION_ID"]}"
+  end
 end
 
 private
 
 def decidim_find_organization
-  organization = Decidim::Organization.find_by(name: ENV.fetch("DECIDIM_ORGANIZATION_NAME"))
+  organization = if (id = ENV["DECIDIM_ORGANIZATION_ID"])
+                   Decidim::Organization.find_by(id: id)
+                 elsif (name = ENV["DECIDIM_ORGANIZATION_NAME"])
+                   Decidim::Organization.all.detect { |org| org.attributes["name"].values.include?(name) }
+                 end
 
   unless organization
-    puts "Organization not found: '#{ENV.fetch("DECIDIM_ORGANIZATION_NAME")}'"
-    puts "Usage: DECIDIM_ORGANIZATION_NAME=<organization name> rails delete::destroy_all"
+    puts "Organization not found."
+    puts "Usage:"
+    puts "  DECIDIM_ORGANIZATION_ID=<id> rails delete:destroy_all"
+    puts "  DECIDIM_ORGANIZATION_NAME=<name> rails delete:destroy_all"
     return
   end
 
-  puts "Organization found: '#{ENV.fetch("DECIDIM_ORGANIZATION_NAME")}' as '#{organization.id}'"
+  puts "Organization found: id=#{organization.id} name=#{organization.attributes["name"].inspect}"
 
   organization
 end

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -273,35 +273,35 @@ namespace :delete do
 
   desc "Destroy all metrics for a given organization"
   task destroy_all_metrics: :environment do
-    puts "Start destroy_all_metrics of #{ENV["DECIDIM_ORGANIZATION_NAME"] || ENV["DECIDIM_ORGANIZATION_ID"]}"
+    puts "Start destroy_all_metrics of #{ENV.fetch("DECIDIM_ORGANIZATION_NAME", nil) || ENV.fetch("DECIDIM_ORGANIZATION_ID", nil)}"
 
     organization = decidim_find_organization
     return unless organization
 
     Decidim::Metric.where(decidim_organization_id: organization.id).delete_all
 
-    puts "Finish destroy_all_metrics of #{ENV["DECIDIM_ORGANIZATION_NAME"] || ENV["DECIDIM_ORGANIZATION_ID"]}"
+    puts "Finish destroy_all_metrics of #{ENV.fetch("DECIDIM_ORGANIZATION_NAME", nil) || ENV.fetch("DECIDIM_ORGANIZATION_ID", nil)}"
   end
 
   desc "Destroy all short links for a given organization"
   task destroy_all_short_links: :environment do
-    puts "Start destroy_all_short_links of #{ENV["DECIDIM_ORGANIZATION_NAME"] || ENV["DECIDIM_ORGANIZATION_ID"]}"
+    puts "Start destroy_all_short_links of #{ENV.fetch("DECIDIM_ORGANIZATION_NAME", nil) || ENV.fetch("DECIDIM_ORGANIZATION_ID", nil)}"
 
     organization = decidim_find_organization
     return unless organization
 
     Decidim::ShortLink.where(decidim_organization_id: organization.id).delete_all
 
-    puts "Finish destroy_all_short_links of #{ENV["DECIDIM_ORGANIZATION_NAME"] || ENV["DECIDIM_ORGANIZATION_ID"]}"
+    puts "Finish destroy_all_short_links of #{ENV.fetch("DECIDIM_ORGANIZATION_NAME", nil) || ENV.fetch("DECIDIM_ORGANIZATION_ID", nil)}"
   end
 end
 
 private
 
 def decidim_find_organization
-  organization = if (id = ENV["DECIDIM_ORGANIZATION_ID"])
-                   Decidim::Organization.find_by(id: id)
-                 elsif (name = ENV["DECIDIM_ORGANIZATION_NAME"])
+  organization = if (id = ENV.fetch("DECIDIM_ORGANIZATION_ID", nil))
+                   Decidim::Organization.find_by(id:)
+                 elsif (name = ENV.fetch("DECIDIM_ORGANIZATION_NAME", nil))
                    Decidim::Organization.all.detect { |org| org.attributes["name"].values.include?(name) }
                  end
 


### PR DESCRIPTION
## Summary

- `DECIDIM_ORGANIZATION_ID` 環境変数による組織検索に対応（従来は `DECIDIM_ORGANIZATION_NAME` のみ）
- 組織名検索を jsonb カラム対応の実装に修正（`find_by(name:)` → `detect` で値一致）
- `Decidim::DestroyAccount.call` のシグネチャを現行 Decidim に合わせて修正（`call(user, form)` → `call(form)` with `current_user: user`）
- `destroy_all_metrics` / `destroy_all_short_links` タスクを追加し、`destroy_organization` より前に実行するよう順序を設定
- `Decidim::AssembliesSetting` モデルが存在しないため `NameError` が発生していた箇所を生 SQL に変更
- `organization.destroy!` 時に `decidim_user_blocks` の FK 制約エラーが発生していた問題を修正（削除前に該当レコードを削除）

## Test plan

- [ ] `DECIDIM_ORGANIZATION_ID=<id> rails delete:destroy_all` で正常に削除できること
- [ ] `DECIDIM_ORGANIZATION_NAME=<name> rails delete:destroy_all` で正常に削除できること
- [ ] `decidim_metrics` / `decidim_short_links` が削除されること
- [ ] `decidim_assemblies_settings` が削除されること
- [ ] `decidim_user_blocks` が削除されること