### PR TITLE
robots.txt: AI学習ボット遮断と全体クロール禁止設定の修正

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,45 @@
-# the following adds a rule for all bots to not index any page that contains a profile or search
+# -------------------------------------------------
+# (1) AI学習用Bot・悪質Botのブロック
+# -------------------------------------------------
+
+# Meta AI学習ボット（OGPクローラー facebookexternalhit とは別物）
+User-agent: FacebookBot
+Disallow: /
+
+# Meta AI学習エージェント（CPUスパイクの主因、2026年5月障害）
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+# OpenAI GPT学習ボット
+User-agent: GPTBot
+Disallow: /
+
+# Anthropic Claude学習ボット
+User-agent: ClaudeBot
+Disallow: /
+
+# Google AI学習制御トークン
+User-agent: Google-Extended
+Disallow: /
+
+# ByteDance Bytespider（robots.txt無視の実績あり、記録目的で記載）
+User-agent: Bytespider
+Disallow: /
+
+# CommonCrawl（AI学習データセットの主要ソース）
+User-agent: CCBot
+Disallow: /
+
+# -------------------------------------------------
+# (2) 一般検索エンジン：許可 + Decidim動的URLのブロック
+# -------------------------------------------------
+
 User-agent: *
 Disallow: /profiles/
 Disallow: /search
 Disallow: /*/versions
 Disallow: /sitemap.xml
-Disallow: /
+# フィルタ・並び替えURLはBotの網羅的アクセスによる高負荷の原因
+Disallow: /*?*filter
+Disallow: /*?*order
+Disallow: /*?*per_page

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -30,6 +30,14 @@ Disallow: /
 User-agent: CCBot
 Disallow: /
 
+# Apple AI学習ボット（通常検索クローラーのApplebotとは別物）
+User-agent: Applebot-Extended
+Disallow: /
+
+# Amazon Alexa AI学習ボット
+User-agent: Amazonbot
+Disallow: /
+
 # -------------------------------------------------
 # (2) 一般検索エンジン：許可 + Decidim動的URLのブロック
 # -------------------------------------------------


### PR DESCRIPTION
## Summary

- `Disallow: /` を削除 — Googleクロールを全拒否していた設定を解除し、検索インデックス不具合を解消
- AI学習ボット7種を全パス Disallow（Meta-ExternalAgent / FacebookBot / GPTBot / ClaudeBot / Google-Extended / Bytespider / CCBot）
- フィルタ・並び替えパラメータ付きURL（`filter` / `order` / `per_page`）を Disallow — Decidim提案一覧の動的生成によるCPU高負荷対策

## 背景

2026年5月22日に発生したCPU100%スパイク障害の主因は `Meta-ExternalAgent` による `/assemblies` への大量アクセス（2,009リクエスト、うち947件が2秒超）。また現行の `Disallow: /` によりGoogleクロールが全拒否されており、検索結果に「このページの情報はありません」と表示される状態が続いていた。

## 各ボットの仕様と対応根拠

| User-agent | 種別 | robots.txt遵守 | ブロック根拠 |
|---|---|---|---|
| Meta-ExternalAgent | Meta AI学習ボット | ○ | 障害の直接原因 |
| FacebookBot | Meta AI学習ボット | ○ | Meta-ExternalAgentと同系統（※OGPクローラーの `facebookexternalhit` とは別物） |
| GPTBot | OpenAI学習ボット | ○ | AI学習データ収集 |
| ClaudeBot | Anthropic学習ボット | ○ | AI学習データ収集 |
| Google-Extended | Google AI学習制御 | ○ | Gemini等への学習データ提供を制御するトークン |
| Bytespider | ByteDance | ✗（無視実績あり） | 高負荷ボット、記録目的でも記載 |
| CCBot | CommonCrawl | ○ | AI学習データセット（C4, The Pile等）の主要ソース |

## Test plan

- [ ] Google Search Console でクロールエラーが解消されることを確認
- [ ] `curl -A "Meta-ExternalAgent" https://diycities.jp/robots.txt` でDisallow: / が返ることを確認
- [ ] `curl -A "Googlebot" https://diycities.jp/robots.txt` でfilter/order/per_page のみDisallowになることを確認
- [ ] facebookexternalhit（OGPクローラー）がブロックされていないことを確認