### PR TITLE
Fix data-open-md dropdowns closing on any outside click

### DIFF
--- a/app/packs/entrypoints/decidim_cfj_dropdown_persist_fix.js
+++ b/app/packs/entrypoints/decidim_cfj_dropdown_persist_fix.js
@@ -1,0 +1,3 @@
+import keepDropdownsOpenOnDesktop from "src/decidim/cfj/dropdown_persist_fix"
+
+document.addEventListener("DOMContentLoaded", keepDropdownsOpenOnDesktop)

--- a/app/packs/src/decidim/cfj/dropdown_persist_fix.js
+++ b/app/packs/src/decidim/cfj/dropdown_persist_fix.js
@@ -1,0 +1,25 @@
+import { screens } from 'tailwindcss/defaultTheme'
+
+// a11y-dropdown-component closes any dropdown on outside click regardless of
+// data-open-md, and decidim-core's createDropdown() never reopens it (see
+// app/packs/src/decidim/a11y.js in decidim-core) — this restores it on desktop.
+const isDesktop = () => window.matchMedia(`(min-width: ${screens.md})`).matches
+
+const keepOpenOnDesktop = trigger => {
+  const target = document.getElementById(trigger.dataset.target)
+  if (!target) return
+
+  const reopenIfNeeded = () => {
+    if (isDesktop() && target.getAttribute('aria-hidden') === 'true') {
+      target.setAttribute('aria-hidden', 'false')
+      trigger.setAttribute('aria-expanded', 'true')
+    }
+  }
+
+  new MutationObserver(reopenIfNeeded).observe(target, { attributes: true, attributeFilter: ['aria-hidden'] })
+  window.addEventListener('resize', reopenIfNeeded)
+}
+
+export default () => {
+  document.querySelectorAll('[data-component="dropdown"][data-open-md="true"]').forEach(keepOpenOnDesktop)
+}

--- a/config/initializers/dropdown_persist_fix.rb
+++ b/config/initializers/dropdown_persist_fix.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  Decidim::ApplicationController.class_eval do
+    before_action :add_dropdown_persist_fix_snippet
+
+    private
+
+    def add_dropdown_persist_fix_snippet
+      return unless respond_to?(:snippets)
+      return if @dropdown_persist_fix_snippet_added
+
+      @dropdown_persist_fix_snippet_added = true
+      # javascript_pack_tag can only be called once per page (Shakapacker's guard is per-request, not per pack), and decidim-dev's NeedsDevelopmentTools already uses that call — so resolve the path directly instead.
+      path = helpers.asset_pack_path("decidim_cfj_dropdown_persist_fix.js")
+      snippets.add(:foot, helpers.javascript_include_tag(path, defer: false))
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- decidim-core の `createDropdown()`（`app/packs/src/decidim/a11y.js`）は `data-open-md` を**初期状態を決めるためだけ**に読んでいますが、実際の開閉を担う `a11y-dropdown-component` ライブラリは、トリガー／ドロップダウン本体以外の場所をクリックすると、この属性の値に関わらず**無条件で**閉じてしまい、それを元に戻す処理がどこにもありません。
- これにより、アカウント設定の左サイドバー（`#dropdown-menu-profile`）と検索一覧ページの絞り込みサイドバー（`#dropdown-menu-filters`）の両方に影響します。どちらも `data-open-md="true"` でデスクトップ幅では常に開いたままのはずですが、ページ上の無関係なクリック（通知設定のトグル、絞り込みのラジオボタンなど）をするだけで閉じてしまい、ページを再読み込みしない限り二度と表示されません。
- `data-open-md="true"` を持つトリガーの対象要素の `aria-hidden` を監視し、ビューポートが `md` ブレークポイント以上のときは即座に元に戻す、MutationObserverベースの小さな修正を追加しました。Decidimの `snippets(:foot)` の仕組み（decidim-dev の `NeedsDevelopmentTools` concern が使っているものと同じ）でサイト全体に読み込ませているため、この2箇所だけでなく `data-open-md` を使う今後の実装にも効きます。

## この不具合が「今まで気づかれなかった」理由

JS側の実装ギャップ（`createDropdown()` が `data-open-md` を初期化時にしか見ない）自体は decidim-core 0.29.2（`codeforjapan/decidim-cfj` の `main` ブランチが現在使っているバージョン、kakogawa.diycities.jp 等の既存本番環境相当）の時点から既に存在していました。

しかし 0.29.2 時点の `_layout.scss` には `dropdown-menu` というセレクタ自体が存在せず、`aria-hidden` の値を見た目の表示・非表示に反映するCSSルールがありませんでした。0.30系のTailwind CSS移行で追加された

```scss
[id*="dropdown-menu"][aria-hidden="true"] {
  @apply md:hidden;
}
```

というルールによって、JS側の誤った状態管理が初めて見た目のバグとして表面化しています。つまりJS側の不具合そのものは0.29系にも存在しますが、実害（サイドバーが消える）が出るのは、このCSSルールが入った0.30系以降になります。

## 動作確認
- [x] 再現確認: `/notifications_settings` で、サイドバーと無関係なラジオボタン／トグルをクリックすると、左サイドバー（アカウント/通知の設定/権限/自分のデータ/削除）が消える（`#dropdown-menu-profile` に `aria-hidden="true"` が付き、それを戻す処理が存在しなかった）
- [x] decidim-core純正の挙動であることを確認（このapp独自のドロップダウンJSの上書きは元々存在せず、他の無関係なカスタマイズとは無関係にラジオボタンのクリックだけで再現する）
- [x] 修正後は `/notifications_settings`・`/account`・`/authorizations` のいずれでも同じクリックでサイドバーが消えないことを確認
- [x] 一覧ページの絞り込みサイドバー（`/processes`、`data-open-md="true"` の `dropdown-menu-filters`）でも同じバグがあることを確認し、修正が効くことを確認
- [x] コンソールエラーなし。`javascript_pack_tag` が1リクエストで2回呼ばれないことを確認（本修正は `asset_pack_path` + `javascript_include_tag` でパスを解決しており、decidim-devの`NeedsDevelopmentTools`との衝突を避けている）
- [x] `decidim/decidim` の v0.29.2・v0.29.7・v0.30.9 それぞれのソースを比較し、上記の経緯（JSギャップは0.29系から存在／CSSは0.30系で追加）を確認