### PR TITLE
ci: cancel superseded PR runs and cache node_modules

### DIFF
--- a/.github/workflows/_check.yaml
+++ b/.github/workflows/_check.yaml
@@ -81,10 +81,17 @@ jobs:
           bundler-cache: true
 
       - name: setup Node
+        id: setup-node
         uses: actions/setup-node@v6
         with:
           node-version: 20.18.3
           cache: 'yarn'
+
+      - name: node_modules cache
+        uses: actions/cache@v6
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('yarn.lock') }}
 
       - name: install yarn
         run: |
@@ -133,10 +140,17 @@ jobs:
           bundler-cache: true
 
       - name: setup Node
+        id: setup-node
         uses: actions/setup-node@v6
         with:
           node-version: 20.18.3
           cache: 'yarn'
+
+      - name: node_modules cache
+        uses: actions/cache@v6
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('yarn.lock') }}
 
       - name: install yarn
         run: |

--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -2,6 +2,11 @@ name: Pull request Check & test
 
 permissions: write-all
 
+# Cancel superseded runs on the same PR so only the latest push is checked.
+concurrency:
+  group: pr-check-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
#### :tophat: What? Why?

- branch.yaml: concurrencyにキャンセルを追加してPRに新しいコミットがpushされると以前のPRのCIはキャンセルするようにします
- _check.yaml: node_modulesをキャッシュするようにします

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
