### PR TITLE
ci: 本番デプロイ先を prd-v030 に変更

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,7 +37,7 @@ jobs:
         id: set-env-production
         if: ${{ needs.release.outputs.created }}
         run: |
-          echo "DEPLOY_ENV=prd-v0292" >> $GITHUB_ENV
+          echo "DEPLOY_ENV=prd-v030" >> $GITHUB_ENV
 
       - name: Output App Env
         id: output-deploy-env


### PR DESCRIPTION
## 概要

本番デプロイ先を `prd-v0292` から `prd-v030` へ切り替えます（`.github/workflows/main.yaml` の `DEPLOY_ENV` 1 行）。release-please がリリースを作成した時の本番デプロイ（`prod` ジョブ）が prd-v030 を対象にします。通常の main への push は従来どおり staging にデプロイされます。

## マージ順序の注意（重要）

以下の順でマージしてください。順番を誤ると本番リリース時に失敗します。

1. **先に CDK 側 PR をマージ**: codeforjapan/decidim-cfj-cdk#98（prd-v030 stage 追加）。CI (`_deploy.yaml`) は decidim-cfj-cdk の main から CDK をチェックアウトするため、prd-v030 が main に無いと `set stage value using -c option`（invalid stage）で失敗する。
2. その後に本 PR をマージ。

## 補足

- prd-v030 環境は構築済みで、`*.diycities.jp` は既に prd-v030 の CloudFront へ無停止で切替済み。
- 本番リリースは main のコードからビルドされるため、v0.30 アプリコードが main に入った後にリリースするのが前提。
