### PR TITLE
fix: hardening MultipleAttachments

### DIFF
--- a/config/initializers/multiple_attachments_scope_hardening.rb
+++ b/config/initializers/multiple_attachments_scope_hardening.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module MultipleAttachmentsScopeHardening
+  private
+
+  def update_attachment_title_for(attachment)
+    record = scoped_attachment_for(attachment[:id])
+    return if record.blank?
+
+    record.update(title: title_for(attachment))
+  end
+
+  def scoped_attachment_for(id)
+    owner = documents_attached_to
+    return if id.blank? || owner.blank?
+
+    Decidim::Attachment.find_by(id:, attached_to: owner)
+  end
+end
+
+Rails.application.config.to_prepare do
+  Decidim::MultipleAttachmentsMethods # rubocop:disable Lint/Void
+
+  Decidim::MultipleAttachmentsMethods.prepend(MultipleAttachmentsScopeHardening) unless Decidim::MultipleAttachmentsMethods.include?(MultipleAttachmentsScopeHardening)
+end

--- a/config/initializers/multiple_attachments_scope_hardening.rb
+++ b/config/initializers/multiple_attachments_scope_hardening.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-# Adds a scope condition to the attachment lookup in
-# update_attachment_title_for.
+# Adds a scope condition to the two places where this module writes to an
+# attachment the request identified by id: the title update and the weight
+# assignment fed by keep_ids.
 #
 # Deliberately narrow, because this prepends onto a decidim-core module shared
 # by proposals, collaborative drafts, debates and questionnaire answers:
@@ -10,6 +11,8 @@
 #   as upstream does.
 # - When no owner can be resolved the original behaviour is used, so the patch
 #   can never drop an update that used to succeed.
+# - keep_ids only ever drops ids that are definitely out of scope, so
+#   document_cleanup! keeps destroying exactly what it destroyed before.
 module MultipleAttachmentsScopeHardening
   private
 
@@ -18,6 +21,22 @@ module MultipleAttachmentsScopeHardening
     return unless attachment_in_scope?(record)
 
     record.update(title: title_for(attachment))
+  end
+
+  # Drops only ids whose attachment definitely belongs to another organization,
+  # so the weight assignment in create_attachments cannot reach them. Anything
+  # the check cannot resolve is kept. document_cleanup! also reads this, but it
+  # only iterates attachments of documents_attached_to, which always share its
+  # organization, so nothing it would have kept can be dropped here.
+  def keep_ids
+    super.reject { |id| foreign_attachment?(id) }
+  end
+
+  def foreign_attachment?(id)
+    record = Decidim::Attachment.find_by(id:)
+    return false if record.blank?
+
+    !attachment_in_scope?(record)
   end
 
   # Decidim derives the right to touch an attachment from the right to edit the

--- a/config/initializers/multiple_attachments_scope_hardening.rb
+++ b/config/initializers/multiple_attachments_scope_hardening.rb
@@ -1,20 +1,41 @@
 # frozen_string_literal: true
 
+# Adds a scope condition to the attachment lookup in
+# update_attachment_title_for.
+#
+# Deliberately narrow, because this prepends onto a decidim-core module shared
+# by proposals, collaborative drafts, debates and questionnaire answers:
+#
+# - `find` is kept rather than `find_by`, so a missing id still raises exactly
+#   as upstream does.
+# - When no owner can be resolved the original behaviour is used, so the patch
+#   can never drop an update that used to succeed.
 module MultipleAttachmentsScopeHardening
   private
 
   def update_attachment_title_for(attachment)
-    record = scoped_attachment_for(attachment[:id])
-    return if record.blank?
+    record = Decidim::Attachment.find(attachment[:id])
+    return unless attachment_in_scope?(record)
 
     record.update(title: title_for(attachment))
   end
 
-  def scoped_attachment_for(id)
+  # Decidim derives the right to touch an attachment from the right to edit the
+  # record it hangs off, so comparing against that record is the rule this
+  # should express. Commands that assign @attached_to before build_attachments
+  # runs make it available, and those are checked that way.
+  #
+  # The rest only assign it in run_after_hooks, leaving documents_attached_to
+  # to fall back to the organization. There the record is not knowable yet, so
+  # the check drops to the organization: weaker than the rule, but still the
+  # tenant boundary, and never stricter than what the command can actually
+  # verify.
+  def attachment_in_scope?(record)
     owner = documents_attached_to
-    return if id.blank? || owner.blank?
+    return true if owner.blank?
+    return record.organization == owner if owner.is_a?(Decidim::Organization)
 
-    Decidim::Attachment.find_by(id:, attached_to: owner)
+    record.attached_to == owner
   end
 end
 

--- a/spec/config/initializers/multiple_attachments_scope_hardening_spec.rb
+++ b/spec/config/initializers/multiple_attachments_scope_hardening_spec.rb
@@ -44,10 +44,27 @@ RSpec.describe "Decidim::MultipleAttachmentsMethods scoping override" do
       expect(translated_attribute(unrelated_attachment.reload.title)).to eq("Unrelated document")
     end
 
-    it "assigns weights from the submitted document ids" do
-      expect(submit(build_form(submitted_documents))).to eq(:ok)
+    # This command assigns @attached_to before build_attachments, so the check
+    # can compare against the record itself rather than the organization. A
+    # document of the same organization but a different record is out of reach.
+    it "leaves a document of the same organization but another record unchanged" do
+      sibling_process = create(:participatory_process, organization:)
+      sibling = create(:attachment, attached_to: sibling_process, title: { "en" => "Sibling document" })
 
-      expect(unrelated_attachment.reload.weight).to eq(0)
+      form = build_form(
+        [
+          {
+            question_id: files_question.id.to_s,
+            body: "",
+            add_documents: [{ id: sibling.id, title: "Renamed" }],
+            documents: [sibling.id.to_s]
+          }
+        ]
+      )
+
+      expect(submit(form)).to eq(:ok)
+
+      expect(translated_attribute(sibling.reload.title)).to eq("Sibling document")
     end
 
     it "leaves the document untouched when no document ids are submitted" do
@@ -67,8 +84,8 @@ RSpec.describe "Decidim::MultipleAttachmentsMethods scoping override" do
       create(:attachment, attached_to: target_process, title: { "en" => "Attached document" })
     end
 
-    # Stands in for the commands that include the module and set @attached_to to
-    # the record they are editing.
+    # Stands in for the commands that assign @attached_to before calling
+    # build_attachments (AnswerQuestionnaire, UpdateProposal, ...).
     let(:command_class) do
       Class.new do
         include Decidim::MultipleAttachmentsMethods
@@ -82,14 +99,84 @@ RSpec.describe "Decidim::MultipleAttachmentsMethods scoping override" do
       end
     end
 
-    it "updates the title of a document attached to that record" do
-      form = Struct.new(:add_documents).new(
-        [{ id: attached_document.id, title: "Renamed" }.with_indifferent_access]
+    def rename_payload(record)
+      Struct.new(:add_documents, :documents).new(
+        [{ id: record.id, title: "Renamed" }.with_indifferent_access],
+        [record.id]
       )
+    end
 
-      command_class.new(form, target_process).send(:build_attachments)
+    it "updates the title of a document attached to that record" do
+      command_class.new(rename_payload(attached_document), target_process).send(:build_attachments)
 
       expect(translated_attribute(attached_document.reload.title)).to eq("Renamed")
+    end
+  end
+
+  # UpdateDebate and the create commands only assign @attached_to in
+  # run_after_hooks, so documents_attached_to still falls back to the
+  # organization while build_attachments runs. Renaming an attachment of the
+  # record being edited has to keep working in that case.
+  describe "when the command has not assigned the record yet" do
+    let(:target_process) { create(:participatory_process, organization:) }
+    let!(:own_document) do
+      create(:attachment, attached_to: target_process, title: { "en" => "Own document" }, weight: 5)
+    end
+
+    let(:command_class) do
+      Class.new do
+        include Decidim::MultipleAttachmentsMethods
+
+        attr_reader :form
+
+        def initialize(form)
+          @form = form
+        end
+      end
+    end
+
+    let(:form_class) { Struct.new(:add_documents, :documents, :current_organization) }
+
+    it "renames a document belonging to the current organization" do
+      form = form_class.new(
+        [{ id: own_document.id, title: "Renamed" }.with_indifferent_access],
+        [own_document.id],
+        organization
+      )
+
+      command_class.new(form).send(:build_attachments)
+
+      expect(translated_attribute(own_document.reload.title)).to eq("Renamed")
+    end
+
+    it "does not rename a document belonging to another organization" do
+      form = form_class.new(
+        [{ id: unrelated_attachment.id, title: "Renamed" }.with_indifferent_access],
+        [unrelated_attachment.id],
+        organization
+      )
+
+      command_class.new(form).send(:build_attachments)
+
+      expect(translated_attribute(unrelated_attachment.reload.title)).to eq("Unrelated document")
+    end
+
+    # The check compares organizations, so a document attached to a different
+    # record of the same organization is still in scope. Pinned here so the
+    # boundary is explicit.
+    it "renames a document of another record in the same organization" do
+      other_record = create(:participatory_process, organization:)
+      sibling = create(:attachment, attached_to: other_record, title: { "en" => "Sibling document" })
+
+      form = form_class.new(
+        [{ id: sibling.id, title: "Renamed" }.with_indifferent_access],
+        [sibling.id],
+        organization
+      )
+
+      command_class.new(form).send(:build_attachments)
+
+      expect(translated_attribute(sibling.reload.title)).to eq("Renamed")
     end
   end
 end

--- a/spec/config/initializers/multiple_attachments_scope_hardening_spec.rb
+++ b/spec/config/initializers/multiple_attachments_scope_hardening_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Decidim::MultipleAttachmentsMethods scoping override" do
+  include_context "with a questionnaire answer form"
+
+  let(:other_organization) { create(:organization) }
+  let(:other_process) { create(:participatory_process, organization: other_organization) }
+  let!(:unrelated_attachment) do
+    create(
+      :attachment,
+      attached_to: other_process,
+      title: { "en" => "Unrelated document" },
+      weight: 99
+    )
+  end
+
+  describe "document ids submitted with an answer" do
+    let!(:files_question) do
+      create(
+        :questionnaire_question,
+        questionnaire:,
+        question_type: "files",
+        mandatory: false,
+        position: 0
+      )
+    end
+
+    let(:submitted_documents) do
+      [
+        {
+          question_id: files_question.id.to_s,
+          body: "",
+          add_documents: [{ id: unrelated_attachment.id, title: "Renamed" }],
+          documents: [unrelated_attachment.id.to_s]
+        }
+      ]
+    end
+
+    it "leaves the title of a document not attached to the answer unchanged" do
+      expect(submit(build_form(submitted_documents))).to eq(:ok)
+
+      expect(translated_attribute(unrelated_attachment.reload.title)).to eq("Unrelated document")
+    end
+
+    it "assigns weights from the submitted document ids" do
+      expect(submit(build_form(submitted_documents))).to eq(:ok)
+
+      expect(unrelated_attachment.reload.weight).to eq(0)
+    end
+
+    it "leaves the document untouched when no document ids are submitted" do
+      form = build_form([{ question_id: files_question.id.to_s, body: "" }])
+
+      expect(submit(form)).to eq(:ok)
+
+      unrelated_attachment.reload
+      expect(translated_attribute(unrelated_attachment.title)).to eq("Unrelated document")
+      expect(unrelated_attachment.weight).to eq(99)
+    end
+  end
+
+  describe "document ids belonging to the record being attached to" do
+    let(:target_process) { create(:participatory_process, organization:) }
+    let!(:attached_document) do
+      create(:attachment, attached_to: target_process, title: { "en" => "Attached document" })
+    end
+
+    # Stands in for the commands that include the module and set @attached_to to
+    # the record they are editing.
+    let(:command_class) do
+      Class.new do
+        include Decidim::MultipleAttachmentsMethods
+
+        attr_reader :form
+
+        def initialize(form, attached_to)
+          @form = form
+          @attached_to = attached_to
+        end
+      end
+    end
+
+    it "updates the title of a document attached to that record" do
+      form = Struct.new(:add_documents).new(
+        [{ id: attached_document.id, title: "Renamed" }.with_indifferent_access]
+      )
+
+      command_class.new(form, target_process).send(:build_attachments)
+
+      expect(translated_attribute(attached_document.reload.title)).to eq("Renamed")
+    end
+  end
+end

--- a/spec/config/initializers/multiple_attachments_scope_hardening_spec.rb
+++ b/spec/config/initializers/multiple_attachments_scope_hardening_spec.rb
@@ -44,12 +44,18 @@ RSpec.describe "Decidim::MultipleAttachmentsMethods scoping override" do
       expect(translated_attribute(unrelated_attachment.reload.title)).to eq("Unrelated document")
     end
 
+    it "leaves the weight of a document in another organization unchanged" do
+      expect(submit(build_form(submitted_documents))).to eq(:ok)
+
+      expect(unrelated_attachment.reload.weight).to eq(99)
+    end
+
     # This command assigns @attached_to before build_attachments, so the check
     # can compare against the record itself rather than the organization. A
     # document of the same organization but a different record is out of reach.
     it "leaves a document of the same organization but another record unchanged" do
       sibling_process = create(:participatory_process, organization:)
-      sibling = create(:attachment, attached_to: sibling_process, title: { "en" => "Sibling document" })
+      sibling = create(:attachment, attached_to: sibling_process, title: { "en" => "Sibling document" }, weight: 7)
 
       form = build_form(
         [
@@ -64,7 +70,9 @@ RSpec.describe "Decidim::MultipleAttachmentsMethods scoping override" do
 
       expect(submit(form)).to eq(:ok)
 
-      expect(translated_attribute(sibling.reload.title)).to eq("Sibling document")
+      sibling.reload
+      expect(translated_attribute(sibling.title)).to eq("Sibling document")
+      expect(sibling.weight).to eq(7)
     end
 
     it "leaves the document untouched when no document ids are submitted" do
@@ -110,6 +118,46 @@ RSpec.describe "Decidim::MultipleAttachmentsMethods scoping override" do
       command_class.new(rename_payload(attached_document), target_process).send(:build_attachments)
 
       expect(translated_attribute(attached_document.reload.title)).to eq("Renamed")
+    end
+  end
+
+  # keep_ids also decides what document_cleanup! destroys, so the filtering must
+  # never remove an id the owner actually holds.
+  describe "cleanup of the documents held by the record" do
+    let(:target_process) { create(:participatory_process, organization:) }
+    let!(:held_document) do
+      create(:attachment, :with_pdf, attached_to: target_process, title: { "en" => "Held document" })
+    end
+
+    let(:command_class) do
+      Class.new do
+        include Decidim::MultipleAttachmentsMethods
+
+        attr_reader :form
+
+        def initialize(form, attached_to)
+          @form = form
+          @attached_to = attached_to
+        end
+      end
+    end
+
+    let(:form_class) { Struct.new(:add_documents, :documents) }
+
+    it "keeps a document the form still references" do
+      command = command_class.new(form_class.new([], [held_document.id]), target_process)
+
+      command.send(:document_cleanup!)
+
+      expect(Decidim::Attachment.exists?(held_document.id)).to be true
+    end
+
+    it "destroys a document the form no longer references" do
+      command = command_class.new(form_class.new([], []), target_process)
+
+      command.send(:document_cleanup!)
+
+      expect(Decidim::Attachment.exists?(held_document.id)).to be false
     end
   end
 

--- a/spec/support/questionnaire_answer_helpers.rb
+++ b/spec/support/questionnaire_answer_helpers.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Shared setup for the questionnaire answer initializer specs. Drives
+# Decidim::Forms::AnswerQuestionnaire the way the questionnaire answer action
+# does, using ActionController::Parameters so parameter coercion matches a real
+# request.
+RSpec.shared_context "with a questionnaire answer form" do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :confirmed, organization:) }
+  let(:participatory_process) { create(:participatory_process, organization:) }
+  let(:questionnaire) { create(:questionnaire, questionnaire_for: participatory_process) }
+
+  # NOTE: in 0.30.x the QuestionnaireForm attribute is `responses` even though
+  # the persisted model is Decidim::Forms::Answer.
+  def build_form(responses)
+    params = ActionController::Parameters.new(
+      questionnaire: { tos_agreement: "1", responses: }
+    )
+
+    Decidim::Forms::QuestionnaireForm.from_params(params).with_context(
+      current_organization: organization,
+      current_user: user,
+      session_token: "session-token-abc",
+      ip_hash: "ip-hash-abc"
+    )
+  end
+
+  def submit(form)
+    outcome = nil
+    Decidim::Forms::AnswerQuestionnaire.call(form, questionnaire) do
+      on(:ok) { outcome = :ok }
+      on(:invalid) { outcome = :invalid }
+    end
+    outcome
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

`Decidim::MultipleAttachmentsMethods`のチェックを強化します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
