### PR TITLE
fix: register CityOS OmniAuth with v1.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "deface"
 gem "image_processing"
 gem "newrelic_rpm"
 
-gem "omniauth-cityos-dcp", git: "https://github.com/TheDesignium/omniauth-cityos-dcp.git", tag: "v1.5.1"
+gem "omniauth-cityos-dcp", git: "https://github.com/TheDesignium/omniauth-cityos-dcp.git", tag: "v1.5.2"
 gem "omniauth-line_login", path: "omniauth-line_login"
 gem "omniauth-rails_csrf_protection"
 

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "deface"
 gem "image_processing"
 gem "newrelic_rpm"
 
-gem "omniauth-cityos-dcp", git: "https://github.com/TheDesignium/omniauth-cityos-dcp.git", tag: "v1.5.0"
+gem "omniauth-cityos-dcp", git: "https://github.com/TheDesignium/omniauth-cityos-dcp.git", tag: "v1.5.1"
 gem "omniauth-line_login", path: "omniauth-line_login"
 gem "omniauth-rails_csrf_protection"
 

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "deface"
 gem "image_processing"
 gem "newrelic_rpm"
 
-gem "omniauth-cityos-dcp", git: "https://github.com/TheDesignium/omniauth-cityos-dcp.git", tag: "v1.4.0"
+gem "omniauth-cityos-dcp", git: "https://github.com/TheDesignium/omniauth-cityos-dcp.git", tag: "v1.5.0"
 gem "omniauth-line_login", path: "omniauth-line_login"
 gem "omniauth-rails_csrf_protection"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/TheDesignium/omniauth-cityos-dcp.git
-  revision: 64c73eb4e9c827cd0186dd12af1408f34c1b9ae5
-  tag: v1.4.0
+  revision: 0c6a487ce4801f8e0e1e2844be4812e9e0006528
+  tag: v1.5.0
   specs:
-    omniauth-cityos-dcp (0.1.0)
-      decidim (>= 0.28.0)
+    omniauth-cityos-dcp (1.5.0)
+      decidim (>= 0.30.0)
       omniauth-oauth2
 
 GIT

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/TheDesignium/omniauth-cityos-dcp.git
-  revision: 3c0bfbb430d0a75f974876ffb5963fbf5c2f3be1
-  tag: v1.5.1
+  revision: aa41ecb68155ae1cbc6316562a2f85952b26c80e
+  tag: v1.5.2
   specs:
-    omniauth-cityos-dcp (1.5.1)
+    omniauth-cityos-dcp (1.5.2)
       omniauth-oauth2
 
 GIT

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,9 @@
 GIT
   remote: https://github.com/TheDesignium/omniauth-cityos-dcp.git
-  revision: 0c6a487ce4801f8e0e1e2844be4812e9e0006528
-  tag: v1.5.0
+  revision: 3c0bfbb430d0a75f974876ffb5963fbf5c2f3be1
+  tag: v1.5.1
   specs:
-    omniauth-cityos-dcp (1.5.0)
-      decidim (>= 0.30.0)
+    omniauth-cityos-dcp (1.5.1)
       omniauth-oauth2
 
 GIT

--- a/app/packs/stylesheets/decidim/cfj/login.scss
+++ b/app/packs/stylesheets/decidim/cfj/login.scss
@@ -7,3 +7,7 @@
           @apply fill-current;
     }
 }
+
+.login__omniauth-button--cityos span {
+    display: inline !important;
+}

--- a/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -1,0 +1,24 @@
+<% is_horizontal = false unless local_assigns.has_key?(:is_horizontal) %>
+<% if Devise.mappings[:user].omniauthable? && current_organization.enabled_omniauth_providers.any? %>
+  <div class="login__omniauth<%= " login__omniauth__horizontal" if is_horizontal %>">
+    <%- current_organization.enabled_omniauth_providers.keys.each do |provider| %>
+      <% provider_key = provider.to_sym %>
+      <% provider_config = current_organization.enabled_omniauth_providers[provider_key] %>
+      <% provider_label = provider_config[:label].presence || provider_name(provider_key) %>
+      <% provider_icon_path = provider_config[:icon_path].presence %>
+      <% link_classes = "login__omniauth-button login__omniauth-button--#{normalize_provider_name(provider_key)}" %>
+      <%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: link_classes, method: :post, title: provider_label do %>
+        <% if provider_key == :cityos_dcp_login %>
+          <%= external_icon(provider_icon_path) if provider_icon_path %>
+          <span><%= provider_label %></span>
+        <% else %>
+          <%= oauth_icon provider_key %>
+          <span class="sr-only"><%= t("devise.shared.links.log_in_with_provider", provider: normalize_provider_name(provider_key).titleize) %></span>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+  <%- if current_organization.sign_in_enabled? %>
+    <span class="login__omniauth-separator"><%= t(".or") %></span>
+  <% end %>
+<% end %>

--- a/config/initializers/omniauth_cityos_dcp.rb
+++ b/config/initializers/omniauth_cityos_dcp.rb
@@ -20,6 +20,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 
     provider(
       :cityos_dcp_login,
+      cookie_store: Rails.application.config.session_store.to_s.include?("CookieStore"),
       setup: setup_cityos_dcp_provider_proc(
         :cityos_dcp_login,
         client_id: :client_id,

--- a/config/initializers/omniauth_cityos_dcp.rb
+++ b/config/initializers/omniauth_cityos_dcp.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+def setup_cityos_dcp_provider_proc(provider, config_mapping = {})
+  lambda do |env|
+    request = Rack::Request.new(env)
+    organization = Decidim::Organization.find_by(host: request.host)
+    provider_config = organization.enabled_omniauth_providers[provider]
+
+    config_mapping.each do |option_key, config_key|
+      env["omniauth.strategy"].options[option_key] = provider_config[config_key]
+    end
+  end
+end
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  omniauth_config = Rails.application.secrets[:omniauth]
+
+  if omniauth_config && omniauth_config[:cityos_dcp_login].present?
+    require "omniauth-cityos-dcp"
+
+    provider(
+      :cityos_dcp_login,
+      setup: setup_cityos_dcp_provider_proc(
+        :cityos_dcp_login,
+        client_id: :client_id,
+        client_secret: :client_secret,
+        service_id: :service_id,
+        policy: :policy,
+        scope: :scope,
+        opt_api_base_url: :opt_api_base_url,
+        authorization_url: :authorization_url,
+        optin_url: :optin_url
+      )
+    )
+  end
+end

--- a/config/initializers/omniauth_cityos_dcp.rb
+++ b/config/initializers/omniauth_cityos_dcp.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
-def setup_cityos_dcp_provider_proc(provider, config_mapping = {})
+require Rails.root.join("lib/decidim/cfj/cityos_omniauth_configuration").to_s
+
+def setup_cityos_dcp_provider_proc(_provider, config_mapping = {})
   lambda do |env|
     request = Rack::Request.new(env)
     organization = Decidim::Organization.find_by(host: request.host)
-    provider_config = organization.enabled_omniauth_providers[provider]
+    raise Decidim::Cfj::CityosOmniauthConfiguration::Error, "cityos_organization_not_found" unless organization
+
+    provider_config = Decidim::Cfj::CityosOmniauthConfiguration.provider_config(organization)
+    raise Decidim::Cfj::CityosOmniauthConfiguration::Error, "cityos_provider_disabled" unless provider_config
+
+    missing_keys = Decidim::Cfj::CityosOmniauthConfiguration.missing_keys(provider_config)
+    raise Decidim::Cfj::CityosOmniauthConfiguration::Error, "cityos_configuration_missing" if missing_keys.any?
 
     config_mapping.each do |option_key, config_key|
       env["omniauth.strategy"].options[option_key] = provider_config[config_key]

--- a/config/initializers/omniauth_logging.rb
+++ b/config/initializers/omniauth_logging.rb
@@ -3,7 +3,13 @@
 module OmniAuth
   module Logging
     def call_app!(env = @env)
-      ActiveSupport::Notifications.instrument("omniauth.auth.succeed", auth: env["omniauth.auth"]) if env["omniauth.auth"]
+      if env["omniauth.auth"]
+        ActiveSupport::Notifications.instrument(
+          "omniauth.auth.succeed",
+          provider: env["omniauth.auth"]["provider"],
+          request_id: env["action_dispatch.request_id"] || env["HTTP_X_REQUEST_ID"]
+        )
+      end
       super
     end
   end
@@ -13,10 +19,9 @@ end
 OmniAuth::Strategy.prepend(OmniAuth::Logging)
 
 ActiveSupport::Notifications.subscribe("omniauth.auth.succeed") do |_name, start, finish, _id, payload|
-  auth = payload[:auth]
-  provider = auth["provider"]
-  uid = auth["uid"]
-  email = auth.dig("info", "email") || "N/A"
+  provider = payload[:provider].to_s.delete("\r\n")[0, 64]
+  request_id = payload[:request_id].to_s.delete("\r\n")[0, 128]
+  duration_ms = ((finish - start) * 1000).round(1)
 
-  Rails.logger.info "[OmniAuth] Duration: #{start} - #{finish}, Provider: #{provider}, UID: #{uid}, Email: #{email}, Auth Data: #{auth.inspect}"
+  Rails.logger.info "[OmniAuth] result=success provider=#{provider} duration_ms=#{duration_ms} request_id=#{request_id}"
 end

--- a/config/locales/cityos_dcp_login.en.yml
+++ b/config/locales/cityos_dcp_login.en.yml
@@ -3,7 +3,6 @@ en:
     system:
       organizations:
         omniauth_settings:
-          icon_path: Icon URL
           cityos_dcp_login:
             client_id: Client ID
             client_secret: Client secret

--- a/config/locales/cityos_dcp_login.en.yml
+++ b/config/locales/cityos_dcp_login.en.yml
@@ -1,0 +1,16 @@
+en:
+  decidim:
+    system:
+      organizations:
+        omniauth_settings:
+          icon_path: Icon URL
+          cityos_dcp_login:
+            client_id: Client ID
+            client_secret: Client secret
+            service_id: Service ID
+            policy: Policy
+            scope: Scope
+            opt_api_base_url: Opt-in API base URL
+            optin_url: Opt-in URL
+            authorization_url: Authorization endpoint URL
+            label: Login button display name

--- a/config/locales/cityos_dcp_login.ja.yml
+++ b/config/locales/cityos_dcp_login.ja.yml
@@ -1,0 +1,16 @@
+ja:
+  decidim:
+    system:
+      organizations:
+        omniauth_settings:
+          icon_path: アイコンURL
+          cityos_dcp_login:
+            client_id: クライアントID
+            client_secret: クライアントシークレット
+            service_id: サービスID
+            policy: ポリシー
+            scope: 認可範囲
+            opt_api_base_url: オプトインAPI用のベースURL
+            optin_url: オプトイン画面のURL
+            authorization_url: 認可エンドポイントのベースURL
+            label: ログインボタン表示名

--- a/config/locales/cityos_dcp_login.ja.yml
+++ b/config/locales/cityos_dcp_login.ja.yml
@@ -3,7 +3,6 @@ ja:
     system:
       organizations:
         omniauth_settings:
-          icon_path: アイコンURL
           cityos_dcp_login:
             client_id: クライアントID
             client_secret: クライアントシークレット

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -149,8 +149,8 @@ default: &default
       client_secret: <%= ENV["OMNIAUTH_LINE_LOGIN_CHANNEL_SECRET"] %>
     cityos_dcp_login:
       enabled: false
-      client_id: <%= ENV["OMNIAUTH_CITYOS_DCP_CLIENT_ID"] %>
-      client_secret: <%= ENV["OMNIAUTH_CITYOS_DCP_CLIENT_SECRET"] %>
+      client_id: <%= ENV["OMNIAUTH_CITYOS_DCP_CLIENT_ID"].to_s.empty? ? ENV["OMNIAUTH_CITYOS_DCP_LOGIN_CLIENT_ID"] : ENV["OMNIAUTH_CITYOS_DCP_CLIENT_ID"] %>
+      client_secret: <%= ENV["OMNIAUTH_CITYOS_DCP_CLIENT_SECRET"].to_s.empty? ? ENV["OMNIAUTH_CITYOS_DCP_LOGIN_CLIENT_SECRET"] : ENV["OMNIAUTH_CITYOS_DCP_CLIENT_SECRET"] %>
       service_id: <%= ENV["OMNIAUTH_CITYOS_DCP_SERVICE_ID"] %>
       policy: <%= ENV["OMNIAUTH_CITYOS_DCP_POLICY"] %>
       scope: <%= ENV["OMNIAUTH_CITYOS_DCP_SCOPE"] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -147,6 +147,18 @@ default: &default
       enabled: false
       client_id: <%= ENV["OMNIAUTH_LINE_LOGIN_CHANNEL_ID"] %>
       client_secret: <%= ENV["OMNIAUTH_LINE_LOGIN_CHANNEL_SECRET"] %>
+    cityos_dcp_login:
+      enabled: false
+      client_id: <%= ENV["OMNIAUTH_CITYOS_DCP_CLIENT_ID"] %>
+      client_secret: <%= ENV["OMNIAUTH_CITYOS_DCP_CLIENT_SECRET"] %>
+      service_id: <%= ENV["OMNIAUTH_CITYOS_DCP_SERVICE_ID"] %>
+      policy: <%= ENV["OMNIAUTH_CITYOS_DCP_POLICY"] %>
+      scope: <%= ENV["OMNIAUTH_CITYOS_DCP_SCOPE"] %>
+      opt_api_base_url: <%= ENV["OMNIAUTH_CITYOS_DCP_OPT_API_BASE_URL"] %>
+      optin_url: <%= ENV["OMNIAUTH_CITYOS_DCP_OPTIN_URL"] %>
+      authorization_url: <%= ENV["OMNIAUTH_CITYOS_DCP_AUTHORIZATION_URL"] %>
+      label: <%= ENV["OMNIAUTH_CITYOS_DCP_LABEL"] %>
+      icon_path: <%= ENV["OMNIAUTH_CITYOS_DCP_ICON_PATH"] %>
   geocoder:
     here_api_key: <%= ENV["GEOCODER_API_KEY"] %>
   maps:
@@ -185,6 +197,18 @@ development:
       enabled: true
       client_id:
       client_secret:
+    cityos_dcp_login:
+      enabled: false
+      client_id:
+      client_secret:
+      service_id:
+      policy:
+      scope:
+      opt_api_base_url:
+      optin_url:
+      authorization_url:
+      label:
+      icon_path:
 
 test:
   <<: *default

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -226,6 +226,18 @@ test:
       enabled: true
       client_id:
       client_secret:
+    cityos_dcp_login:
+      enabled: false
+      client_id:
+      client_secret:
+      service_id:
+      policy:
+      scope:
+      opt_api_base_url:
+      optin_url:
+      authorization_url:
+      label:
+      icon_path:
   elections:
     <<: *elections_default
     bulletin_board_server: <%= Decidim::Env.new("ELECTIONS_BULLETIN_BOARD_SERVER", 'http://bulletin-board.lvh.me:5017/api').to_s %>

--- a/lib/decidim/cfj/cityos_omniauth_configuration.rb
+++ b/lib/decidim/cfj/cityos_omniauth_configuration.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Cfj
+    module CityosOmniauthConfiguration
+      PROVIDER = :cityos_dcp_login
+      REQUIRED_KEYS = [
+        :client_id,
+        :client_secret,
+        :service_id,
+        :policy,
+        :scope,
+        :opt_api_base_url,
+        :authorization_url,
+        :optin_url
+      ].freeze
+
+      class Error < StandardError; end
+
+      module_function
+
+      def provider_config(organization)
+        organization.enabled_omniauth_providers[PROVIDER]
+      end
+
+      def missing_keys(provider_config)
+        return REQUIRED_KEYS if provider_config.nil?
+
+        REQUIRED_KEYS.select do |key|
+          value = provider_config[key]
+          value.nil? || value.to_s.strip.empty?
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/cityos_omniauth.rake
+++ b/lib/tasks/cityos_omniauth.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+namespace :cityos_omniauth do
+  desc "Validate effective CityOS OmniAuth settings without printing their values"
+  task preflight: :environment do
+    failures = []
+    enabled_count = 0
+
+    Decidim::Organization.find_each do |organization|
+      provider_config = Decidim::Cfj::CityosOmniauthConfiguration.provider_config(organization)
+      next unless provider_config
+
+      enabled_count += 1
+      missing_keys = Decidim::Cfj::CityosOmniauthConfiguration.missing_keys(provider_config)
+      failures << [organization.id, missing_keys] if missing_keys.any?
+    rescue StandardError
+      failures << [organization.id, [:configuration_unreadable]]
+    end
+
+    if failures.any?
+      failures.each do |organization_id, missing_keys|
+        message = "CityOS configuration invalid: " \
+                  "organization_id=#{organization_id} missing=#{missing_keys.join(",")}"
+        warn message
+      end
+      abort "CityOS OmniAuth preflight failed for #{failures.size} organization(s)"
+    end
+
+    puts "CityOS OmniAuth preflight passed: enabled_organizations=#{enabled_count}"
+  end
+end

--- a/spec/config/initializers/omni_auth/logging_spec.rb
+++ b/spec/config/initializers/omni_auth/logging_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OmniAuth::Logging do
+  it "publishes only non-sensitive success metadata" do
+    events = []
+    subscription = ActiveSupport::Notifications.subscribe("omniauth.auth.succeed") do |*args|
+      events << args.last
+    end
+
+    app = Class.new do
+      def call_app!(_env)
+        [200, {}, []]
+      end
+    end
+    app.prepend(described_class)
+
+    auth = OmniAuth::AuthHash.new(
+      provider: "cityos_dcp_login",
+      uid: "personal-id",
+      info: { email: "person@example.com" },
+      credentials: { token: "bearer-secret", refresh_token: "refresh-secret" }
+    )
+    env = {
+      "omniauth.auth" => auth,
+      "action_dispatch.request_id" => "request-id"
+    }
+
+    app.new.call_app!(env)
+
+    expect(events.last).to eq(provider: "cityos_dcp_login", request_id: "request-id")
+    expect(events.last.to_s).not_to include("personal-id", "person@example.com", "bearer-secret", "refresh-secret")
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription) if subscription
+  end
+
+  it "writes a sanitized success log" do
+    allow(Rails.logger).to receive(:info)
+
+    ActiveSupport::Notifications.instrument(
+      "omniauth.auth.succeed",
+      provider: "cityos_dcp_login\nforged",
+      request_id: "request-id\nforged"
+    )
+
+    expect(Rails.logger).to have_received(:info).with(
+      match(/result=success provider=cityos_dcp_loginforged .* request_id=request-idforged/)
+    )
+  end
+end

--- a/spec/config/initializers/omniauth_cityos_dcp_spec.rb
+++ b/spec/config/initializers/omniauth_cityos_dcp_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "CityOS OmniAuth integration" do
+  it "registers the CityOS authorization and callback routes" do
+    routes = Decidim::Core::Engine.routes.url_helpers
+
+    expect(routes).to respond_to(:user_cityos_dcp_login_omniauth_authorize_path)
+    expect(routes).to respond_to(:user_cityos_dcp_login_omniauth_callback_path)
+  end
+
+  it "uses Decidim's standard icon path labels" do
+    key = "decidim.system.organizations.omniauth_settings.icon_path"
+
+    expect(I18n.t(key, locale: :ja)).to eq("アイコンのパス")
+    expect(I18n.t(key, locale: :en)).to eq("Icon path")
+  end
+
+  it "does not require a CityOS icon by default" do
+    expect(Rails.application.secrets.dig(:omniauth, :cityos_dcp_login, :icon_path)).to be_nil
+  end
+end

--- a/spec/config/initializers/omniauth_cityos_dcp_spec.rb
+++ b/spec/config/initializers/omniauth_cityos_dcp_spec.rb
@@ -20,4 +20,32 @@ RSpec.describe "CityOS OmniAuth integration" do
   it "does not require a CityOS icon by default" do
     expect(Rails.application.secrets.dig(:omniauth, :cityos_dcp_login, :icon_path)).to be_nil
   end
+
+  it "keeps the legacy client credential environment names as fallbacks" do
+    secrets = Rails.root.join("config/secrets.yml").read
+
+    expect(secrets).to include("OMNIAUTH_CITYOS_DCP_LOGIN_CLIENT_ID")
+    expect(secrets).to include("OMNIAUTH_CITYOS_DCP_LOGIN_CLIENT_SECRET")
+  end
+
+  it "reports missing required settings without exposing their values" do
+    configuration = Decidim::Cfj::CityosOmniauthConfiguration
+    provider_config = configuration::REQUIRED_KEYS.index_with { |key| "value-for-#{key}" }
+    provider_config[:client_secret] = ""
+
+    expect(configuration.missing_keys(provider_config)).to eq([:client_secret])
+  end
+
+  it "rejects an unknown host with a stable failure code" do
+    env = Rack::MockRequest.env_for("/users/auth/cityos_dcp_login", "HTTP_HOST" => "unknown.example")
+    env["omniauth.strategy"] = double(options: {})
+    allow(Decidim::Organization).to receive(:find_by).and_return(nil)
+
+    setup = setup_cityos_dcp_provider_proc(:cityos_dcp_login, client_id: :client_id)
+
+    expect { setup.call(env) }.to raise_error(
+      Decidim::Cfj::CityosOmniauthConfiguration::Error,
+      "cityos_organization_not_found"
+    )
+  end
 end


### PR DESCRIPTION
## 概要

Decidim v0.30環境でCityOS OmniAuthを利用できるよう、親アプリ側のprovider登録、組織別設定、表示・翻訳を追加し、standalone化した `omniauth-cityos-dcp v1.5.2` を参照します。

## 変更内容

- `omniauth-cityos-dcp v1.5.2` をGitタグとrevisionで固定
- CityOS OmniAuth providerのinitializer登録とauthorize/callback routeの生成
- 組織ごとのCityOS設定をSystem画面から編集可能にするlocaleを追加
- アイコンURL未設定時は設定されたlabelだけを表示
- 旧client credential環境変数名を移行期間中のfallbackとして維持
- 必須設定を値を出力せず検査する `cityos_omniauth:preflight` を追加
- OmniAuth成功ログからUID、Email、AuthHash、access token、refresh tokenを除外
- provider、処理時間、request IDだけをサニタイズしてINFOログへ出力

## `app/` 配下の変更について（レビュー項目）

以下の2ファイルを変更しています。

- `app/views/decidim/devise/shared/_omniauth_buttons.html.erb`
- `app/packs/stylesheets/decidim/cfj/login.scss`

Decidim 0.30.9標準のOmniAuth partialは、アイコン未設定時にprovider名から `cityos-fill` を解決しようとするため、未登録アイコンで表示エラーになります。また、System画面で組織ごとに設定した `label` を通常表示する経路がありません。

今回の要件である「アイコンは任意」「アイコン未設定時も編集可能なlabelを表示」を満たすため、CityOSの場合だけアイコンの有無を判定してlabelを表示するhost側overrideを置いています。他providerはDecidim標準の `oauth_icon` とアクセシブルラベルを利用する分岐を維持しています。

この対応は認証strategyの責務ではないため、standaloneの `omniauth-cityos-dcp` gemには含めず、Decidimとの表示統合を所有するhost側に置いています。一方でDecidim標準partialのoverrideになるため、Decidim更新時には標準partialとの差分確認が必要です。将来的に共通化が必要になった場合は、Decidim連携専用gemへの分離またはDecidim本体への汎用対応を再検討します。

レビューでは、次の点が許容できるか確認してください。

- CityOS固有処理がCityOSの分岐とCSSクラスに限定されていること
- アイコン未設定時にlabelのみ表示されること
- アイコン設定時にアイコンとlabelが表示されること
- CityOS以外のprovider表示を変更していないこと
- Decidim 0.30系を利用する間、partial overrideをhost側で保守する判断が妥当であること

## 確認結果

- Docker内でgem単体テスト成功: RSpec 6件、Minitest 4件・13 assertions
- 親側CityOS関連テスト成功: RSpec 8件
- 公開済みv1.5.2タグから `bundle install` 成功
- 親プロセスが `omniauth-cityos-dcp v1.5.2` をロードすることを確認
- CityOS authorize/callback route生成を確認
- アイコン未設定時のlabel表示を確認
- System設定の日本語・英語翻訳を確認
- `cityos_omniauth:preflight` 成功

dsn側ではCIが動作しない前提のため、上記はローカルDocker環境で確認しています。

## デプロイ・ロールバック

v1.4へ実行時に自動fallbackする処理は設けません。旧環境変数をロールバック期間中は保持し、問題発生時はgemだけでなく、対応する親コミットとDockerイメージを組み合わせて旧構成へ戻します。
