### PR TITLE
chore: New Relic の取り込み量を削減（span サンプリング抑制・ログ転送停止）

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -21,6 +21,18 @@ common: &default_settings
   distributed_tracing:
     enabled: true
 
+  # 分散トレーシングの span 取り込み量を抑制（既定 2000/分 → 250/分）。
+  # スループット/応答時間/エラー率/DB時間などの集計値は Metric 由来のため影響せず、
+  # 個別トレースのサンプル数だけが減る（遅い/エラーのものは優先して残る）。
+  span_events:
+    max_samples_stored: 250
+
+  # アプリログは CloudWatch(ECS awslogs)に集約し、New Relic への転送は行わない。
+  # Rails の描画ノイズログ(Rendered cell 等)が取り込みコストの大半を占めていたため。
+  application_logging:
+    forwarding:
+      enabled: false
+
   # To disable the agent regardless of other settings, uncomment the following:
   # agent_enabled: false
 


### PR DESCRIPTION
## 概要

New Relic のデータ取り込みが無料枠(100GB/月)を大幅に超過し課金が発生していたため、主因を削減する。`config/newrelic.yml` の2点のみの変更。

## 調査で判明した内訳（prd-v030・7日間）

| 種別 | 量/週 | 月換算 | 内容 |
|---|---|---|---|
| **Span**（分散トレーシング） | 37.7 GB | ~162 GB | 1リクエストあたり多数の datastore/cache span。agent 既定上限(2000/分)で頭打ち |
| Metric | 18.6 GB | ~80 GB | APM のタイムスライスメトリクス（地の量） |
| **Log** | ~6 GB | ~26 GB | ほぼ `Rendered cell decidim/...` の描画ノイズ(INFO) |
| Transaction | 0.4 GB | ~2 GB | ほぼ無視 |
| **合計** | ~63 GB | **~270 GB** | 無料枠 100GB を大幅超過 |

（prd-v0292 は実質停止・Browser は月0.5GB未満で影響軽微）

## 変更

- `span_events.max_samples_stored` を **2000 → 250**
  - Span を約1/8に削減。**集計値（スループット/応答時間/エラー率/DB時間内訳）は Metric 由来のため影響なし**。個別トレースのサンプル数のみ減（遅い/エラーは優先保持）。
- `application_logging.forwarding.enabled` を **false**
  - Rails 描画ノイズログの NR 転送を停止。**ログは CloudWatch(ECS awslogs)に残るため損失なし**。

## 効果試算

約 **270GB/月 → 約90GB/月（無料枠内）**。APM の主要監視（APM ダッシュボード・エラー・サンプリング済みトレース）は維持。

## 補足・残タスク

- Browser(RUM) は取り込み量が僅少のため据え置き。
- さらに質を上げるなら別途 `lograge`（1リクエスト1行の構造化ログ）導入も検討可。
- 反映はデプロイ（agent 再起動）時。
