### PR TITLE
アンケート回答公開の集計グラフ（複数選択）の集計不具合を修正

### DIFF
--- a/config/initializers/publish_answers_helper_override.rb
+++ b/config/initializers/publish_answers_helper_override.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Override Decidim::Surveys::PublishAnswersHelper#options_column_chart_wrapper.
+#
+# Decidim v0.30's implementation aggregates the published survey column chart with
+#
+#   question.answers.map { |answer| answer.choices.map { ... } }.tally
+#
+# `.map` produces one array of option labels *per answer*, so `.tally` counts unique
+# combinations of options instead of counting each option. For multiple_option
+# questions this renders one bar per answer-combination and labels the x-axis with the
+# stringified array (e.g. `["A","B","C"]`). Single_option questions happen to look
+# correct only because every answer has exactly one choice.
+#
+# Replacing `.map` with `.flat_map` flattens the per-answer arrays into a single list
+# of option labels, so `.tally` counts each selected option. See the verification
+# report in docs/decidim-survey-chart-verification.md.
+Rails.application.config.to_prepare do
+  Decidim::Surveys::PublishAnswersHelper.module_eval do
+    def options_column_chart_wrapper(question)
+      tally = question.answers.flat_map { |answer| answer.choices.map { |choice| translated_attribute(choice.answer_option.body) } }.tally
+
+      column_chart(tally, download: true)
+    end
+  end
+end

--- a/spec/helpers/decidim/surveys/publish_answers_aggregation_spec.rb
+++ b/spec/helpers/decidim/surveys/publish_answers_aggregation_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "decidim/forms/test/factories"
+
+# Regression spec for the survey "publish answers" column chart aggregation.
+#
+# Decidim v0.30's Decidim::Surveys::PublishAnswersHelper#options_column_chart_wrapper
+# aggregates with `question.answers.map { ... }.tally`, which counts *combinations*
+# of selected options per answer instead of counting each option. For multiple_option
+# questions where a single answer selects two or more options, the chart is therefore
+# wrong (one bar per unique combination, labels rendered as stringified arrays).
+#
+# This spec builds a multiple_option question where one answer selects 3 options and
+# two answers select 1 option each, then asserts the chart aggregates *per option*.
+# It FAILS against the current (buggy) helper and PASSES once the aggregation is fixed
+# to `flat_map`.
+module Decidim
+  module Surveys
+    describe PublishAnswersHelper do
+      # The :questionnaire_question factory builds a valid questionnaire attached to a
+      # participatory space, so we do not need to wire up a survey/component by hand.
+      let(:question) do
+        create(:questionnaire_question, question_type: "multiple_option", position: 0)
+      end
+      let(:questionnaire) { question.questionnaire }
+
+      # Three known options so we can assert on exact labels/counts.
+      let!(:option_a) { create(:answer_option, question:, body: { "en" => "Option A", "ja" => "選択肢A" }) }
+      let!(:option_b) { create(:answer_option, question:, body: { "en" => "Option B", "ja" => "選択肢B" }) }
+      let!(:option_c) { create(:answer_option, question:, body: { "en" => "Option C", "ja" => "選択肢C" }) }
+
+      before do
+        # Answer 1: selects A, B and C (multiple selection in a single answer)
+        answer1 = create(:answer, questionnaire:, question:)
+        [option_a, option_b, option_c].each do |opt|
+          create(:answer_choice, answer: answer1, answer_option: opt, matrix_row: nil, body: opt.body["en"])
+        end
+
+        # Answer 2: selects only A
+        answer2 = create(:answer, questionnaire:, question:)
+        create(:answer_choice, answer: answer2, answer_option: option_a, matrix_row: nil, body: option_a.body["en"])
+
+        # Answer 3: selects only C
+        answer3 = create(:answer, questionnaire:, question:)
+        create(:answer_choice, answer: answer3, answer_option: option_c, matrix_row: nil, body: option_c.body["en"])
+      end
+
+      describe "#chart_for_question aggregation for multiple_option" do
+        subject(:chart_html) { helper.chart_for_question(question.id).to_s }
+
+        it "counts each selected option (A=2, B=1, C=2), not the per-answer combination" do
+          # Correct per-option aggregation that Chartkick should receive.
+          expect(chart_html).to include('["Option A",2]')
+          expect(chart_html).to include('["Option B",1]')
+          expect(chart_html).to include('["Option C",2]')
+
+          # And it must NOT emit combination keys (stringified arrays as labels).
+          expect(chart_html).not_to include('[["Option A","Option B","Option C"],1]')
+        end
+      end
+
+      # single_option must keep working after the fix (each answer has exactly one choice).
+      describe "#chart_for_question aggregation for single_option" do
+        let(:single_question) do
+          create(:questionnaire_question, questionnaire:, question_type: "single_option", position: 1)
+        end
+        let!(:s_opt_x) { create(:answer_option, question: single_question, body: { "en" => "X", "ja" => "X" }) }
+        let!(:s_opt_y) { create(:answer_option, question: single_question, body: { "en" => "Y", "ja" => "Y" }) }
+
+        before do
+          # 2 answers pick X, 1 answer picks Y
+          [s_opt_x, s_opt_x, s_opt_y].each do |opt|
+            a = create(:answer, questionnaire:, question: single_question)
+            create(:answer_choice, answer: a, answer_option: opt, matrix_row: nil, body: opt.body["en"])
+          end
+        end
+
+        it "counts each option (X=2, Y=1)" do
+          html = helper.chart_for_question(single_question.id).to_s
+          expect(html).to include('["X",2]')
+          expect(html).to include('["Y",1]')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要 / なぜ

アンケートの「回答を公開」機能で、**複数選択（`multiple_option`）の質問の集計グラフが選択肢ごとに集計されず、「選択肢の組み合わせ」ごとに1本ずつ棒が立ってしまう**不具合を修正します。横軸ラベルも配列の文字列化（例 `["A","B","C"]`）で表示されます。

原因は `Decidim::Surveys::PublishAnswersHelper#options_column_chart_wrapper` の集計式です。

```ruby
# 現行（gem 0.30.9）
tally = question.answers.map { |a| a.choices.map { |c| translated_attribute(c.answer_option.body) } }.tally
```

`.map` は「1回答ごとの選択肢名の配列」を1要素として返すため、`.tally` が
選択肢ではなく**組み合わせ（Array）をキー**に集計してしまいます。
単一選択（`single_option`）は1回答=1選択肢なので、たまたま正しく見えているだけです。

## 再現（実データ）

回答3件（1人目が3つ選択、2人目・3人目が1つずつ選択）を実モデルで作成し、実 helper の出力を確認しました。

| | 集計結果（Chartkick に渡る配列） |
|---|---|
| **現行（バグ）** | `[[["A","B","C"],1],[["A"],1],[["C"],1]]` |
| **修正後** | `[["A",2],["B",1],["C",2]]` |

加古川市テスト環境で観測された実データ（`[[["豊かな自然や河川敷","子育てのしやすさ","安全・安心な暮らし"],1],...]`）と同型であることを確認済みです。

## 修正

```ruby
# 修正: map -> flat_map
tally = question.answers.flat_map { |a| a.choices.map { |c| translated_attribute(c.answer_option.body) } }.tally
```

gem 本体を書き換えず、既存の initializer オーバーライド方式（`config/initializers/*_override.rb`）に合わせて CfJ 側で差し替えます。

## スクリーンショット

<img width="1760" height="2240" alt="chart_compare" src="https://github.com/user-attachments/assets/7472283b-fa95-48be-a02e-aeccfe656897" />

## 影響範囲

- v0.30.0（decidim/decidim#13786 でこの公開機能が追加）〜**現行 `develop` まで未修正**。0.31 以降は `answers`→`responses` へのリネームのみで、`.map{...}.tally` のロジックは同一。
- 本メソッドを使うのは `single_option` / `multiple_option`。`matrix_*` / `sorting` は別メソッドのため影響なし。

## テスト

- `spec/helpers/decidim/surveys/publish_answers_aggregation_spec.rb` を追加。
  - **現行実装では失敗**（`[["A",2]...]` を期待するが `[[["A","B","C"],1]...]` が出る）
  - **オーバーライド適用で通る**（複数選択 A=2/B=1/C=2、単一選択 X=2/Y=1 を検証）

## 補足 / 論点

- 複数選択では「回答者数（`question.answers.count`）」と「選択の延べ数」が一致しなくなります（例では 3 と 5）。見出しや凡例での補足を別途検討する余地があります。
- 根本解決として upstream（decidim/decidim）への Issue + PR も候補です。本 PR は CfJ 側の暫定修正（オーバーライド）です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
