### PR TITLE
feat(survey): add weight column(table) for surver to reorder items

### DIFF
--- a/app/commands/decidim/cfj/reorder_surveys.rb
+++ b/app/commands/decidim/cfj/reorder_surveys.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Cfj
+    # A command that reorders the surveys of a component.
+    #
+    # It mirrors Decidim::Admin::ReorderComponents, with two differences: the
+    # weights are written to the decidim_cfj_survey_orders side table instead of
+    # a column of the reordered records, and the given order only covers the
+    # surveys of the page the admin is looking at, because the index is
+    # paginated.
+    #
+    # Surveys with no weight are displayed last, so writing weights for the
+    # reordered page alone would push the surveys of the previous pages behind
+    # it. To keep the whole collection consistent, every survey gets the weight
+    # matching the position it is currently displayed at, and the reordered ones
+    # are then written back to the positions they already occupied. The current
+    # order is resolved from the component, so nothing has to be trusted from
+    # the request beyond the ids themselves.
+    class ReorderSurveys < Decidim::Command
+      def initialize(component, order)
+        @component = component
+        @order = order
+      end
+
+      def call
+        return broadcast(:invalid) unless order.is_a?(Array)
+        return broadcast(:invalid) if reordered_ids.blank?
+
+        persist(weights)
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :component, :order
+
+      def weights
+        weights = displayed_ids.each_with_index.to_h { |id, index| [id, index + 1] }
+        positions = reordered_ids.map { |id| weights[id] }.sort
+        reordered_ids.each_with_index { |id, index| weights[id] = positions[index] }
+
+        weights
+      end
+
+      # The whole collection is rewritten on every reorder, so this is a single
+      # statement. The weights are derived positions, never user input, which is
+      # why skipping the model validation is safe here.
+      def persist(weights)
+        # rubocop:disable Rails/SkipsModelValidations
+        SurveyOrder.upsert_all(
+          weights.map { |id, weight| { decidim_surveys_survey_id: id, weight: } },
+          unique_by: :index_decidim_cfj_survey_orders_on_survey,
+          record_timestamps: true
+        )
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+
+      def displayed_ids
+        @displayed_ids ||= SurveyOrder.for_component(component).pluck(:id)
+      end
+
+      def reordered_ids
+        @reordered_ids ||= order.filter_map { |id| Integer(id, exception: false) }.uniq & displayed_ids
+      end
+    end
+  end
+end

--- a/app/models/decidim/cfj/survey_order.rb
+++ b/app/models/decidim/cfj/survey_order.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Cfj
+    # Holds the display order of a survey inside its component.
+    #
+    # Decidim::Surveys::Survey has no order attribute, so the weight lives in
+    # this side table instead of the core one.
+    class SurveyOrder < Decidim::ApplicationRecord
+      self.table_name = "decidim_cfj_survey_orders"
+
+      JOIN_SQL = <<~SQL.squish
+        LEFT OUTER JOIN decidim_cfj_survey_orders
+          ON decidim_cfj_survey_orders.decidim_surveys_survey_id = decidim_surveys_surveys.id
+      SQL
+
+      ORDER_SQL = <<~SQL.squish
+        decidim_cfj_survey_orders.weight ASC NULLS LAST,
+        decidim_surveys_surveys.id ASC
+      SQL
+
+      belongs_to :survey,
+                 class_name: "Decidim::Surveys::Survey",
+                 foreign_key: "decidim_surveys_survey_id",
+                 inverse_of: false
+
+      validates :weight, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+      def self.sorted(scope)
+        scope.joins(JOIN_SQL).order(Arel.sql(ORDER_SQL))
+      end
+
+      def self.for_component(component)
+        sorted(Decidim::Surveys::Survey.where(component:))
+      end
+    end
+  end
+end

--- a/app/views/decidim/surveys/admin/surveys/index.html.erb
+++ b/app/views/decidim/surveys/admin/surveys/index.html.erb
@@ -1,0 +1,69 @@
+<%#
+  Copy of decidim-surveys' admin index with drag and drop reordering, following
+  the components table (decidim-admin/app/views/decidim/admin/components/_components_table.html.erb).
+
+  The order is stored in the decidim_cfj_survey_orders side table, see
+  config/initializers/surveys_ordering_override.rb for the removal steps.
+
+  This index is paginated, so the sortable list only sends the ids of the
+  current page. Decidim::Cfj::ReorderSurveys resolves their absolute positions
+  server side.
+%>
+<% add_decidim_page_title(t(".title")) %>
+<div class="card">
+  <div class="item_show__header item_show__header--with-action-options">
+    <h1 class="item_show__header-title">
+      <%= t(".title") %>
+      <%= link_to t("actions.new_survey", scope: "decidim.surveys"), surveys_path, method: :post, class: "button button__sm button__secondary" %>
+      <%= render partial: "decidim/admin/components/resource_action" %>
+    </h1>
+  </div>
+  <div class="table-scroll mt-8">
+    <table class="table-list">
+      <thead>
+        <tr>
+          <th class="w-12"><span class="sr-only"><%= t("decidim.cfj.surveys.reorder") %></span></th>
+          <th><%= t("models.survey.fields.title", scope: "decidim.surveys") %></th>
+          <th><%= t("models.survey.fields.questions", scope: "decidim.surveys") %></th>
+          <th><%= t("models.survey.fields.answers", scope: "decidim.surveys") %></th>
+          <th><%= t("models.survey.fields.status", scope: "decidim.surveys") %></th>
+          <th><%= t("actions.title", scope: "decidim.surveys") %></th>
+        </tr>
+      </thead>
+      <tbody class="draggable-table" data-sort-url="<%= reorder_surveys_path %>" data-draggable-table>
+        <% surveys.each do |survey| %>
+          <tr class="draggable-content" draggable="true" data-record-id="<%= survey.id %>">
+            <td class="text-center dragging-handle">
+              <%= icon("draggable", class: "dragger") %>
+            </td>
+            <td><%= decidim_sanitize_translated(survey.title) %></td>
+            <td><%= survey.questionnaire.question_types.size %></td>
+            <td><%= survey.questionnaire.count_participants %></td>
+            <td><%= survey.open? ? t("models.survey.status.open", scope: "decidim.surveys") : t("models.survey.status.closed", scope: "decidim.surveys") %></td>
+            <td class="table-list__actions">
+              <% if survey.questionnaire.answers.any? %>
+                <%= icon_link_to "draft-line", survey_answers_path(survey), t("actions.answers", scope: "decidim.surveys") %>
+              <% end %>
+              <%= icon_link_to "pencil-line", edit_survey_path(survey), t("actions.edit", scope: "decidim.surveys"), class: "action-icon--edit" %>
+              <%= icon_link_to "survey-line", edit_questions_survey_path(survey), t("actions.manage_questions", scope: "decidim.surveys"), class: "action-icon--copy" %>
+              <% if allowed_to? :preview, :questionnaire %>
+              <%= icon_link_to "eye-line", resource_locator(survey).path, t("actions.preview", scope: "decidim.surveys"), class: "action-icon--preview", target: :blank, data: { "external-link": false } %>
+              <% end %>
+              <% if allowed_to?(:update, :questionnaire) %>
+                <% if survey.published? %>
+                  <%= icon_link_to "close-circle-line", unpublish_survey_path(survey), t("actions.unpublish", scope: "decidim.admin"), method: :put, class: "action-icon--unpublish" %>
+                <% elsif survey.clean_after_publish? %>
+                  <%= icon_link_to "check-line", publish_survey_path(survey), t("actions.publish", scope: "decidim.admin"), method: :put, class: "action-icon--publish", data: { confirm: t("actions.answers_alert", scope: "decidim.surveys", answers_count: survey.questionnaire.answers.size) } %>
+                <% else %>
+                  <%= icon_link_to "check-line", publish_survey_path(survey), t("actions.publish", scope: "decidim.admin"), method: :put, class: "action-icon--publish" %>
+                <% end %>
+              <% end %>
+              <%= resource_permissions_link(survey) %>
+              <%= icon_link_to "delete-bin-line", survey_path(survey), t("actions.destroy", scope: "decidim.surveys"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.surveys") } %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/config/initializers/surveys_ordering_override.rb
+++ b/config/initializers/surveys_ordering_override.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Lets admins set the display order of the surveys of a surveys component, both
+# in the admin index and in the public list.
+#
+# Decidim orders neither list: Decidim::Surveys::SurveysController#surveys and
+# Decidim::Surveys::Admin::SurveysController#collection have no ORDER BY, so the
+# order is whatever Postgres returns and it changes when a survey is updated.
+# There is no order attribute in decidim_surveys_surveys either (checked up to
+# the develop branch, 0.33.0.dev), so the weights are stored in the
+# decidim_cfj_survey_orders side table.
+#
+# The drag and drop behaviour is the one used by the components table: the
+# tbody carries [data-draggable-table] and [data-sort-url], and
+# decidim-admin's draggable-table.js sends PUT { order_ids: [...] } to that URL.
+#
+# Removal steps once decidim_surveys_surveys gets its own order column:
+#
+#   1. Copy the weights over with a data migration:
+#      UPDATE decidim_surveys_surveys s SET weight = o.weight
+#      FROM decidim_cfj_survey_orders o
+#      WHERE o.decidim_surveys_survey_id = s.id
+#   2. Delete this initializer, app/models/decidim/cfj/survey_order.rb,
+#      app/commands/decidim/cfj/reorder_surveys.rb and
+#      app/views/decidim/surveys/admin/surveys/index.html.erb
+#   3. Drop the decidim_cfj_survey_orders table
+#
+# The route helper is named reorder_surveys_path on purpose: that is the name
+# `put :reorder, on: :collection` would generate upstream, so the view needs no
+# changes. It cannot be declared inside the surveys resources block from here,
+# because the engine declares `resources :surveys` first and PUT /surveys/:id
+# (update) would swallow PUT /surveys/reorder.
+Decidim::Surveys::AdminEngine.routes.append do
+  put "reorder_surveys", to: "surveys#reorder", as: :reorder_surveys
+end
+
+Rails.application.config.to_prepare do
+  module DecidimCfjSurveysOrderingPatch
+    private
+
+    # Copy of Decidim::Surveys::SurveysController#surveys as of v0.30.9, with
+    # the ordering added. Check it again when upgrading Decidim.
+    def surveys
+      paginate(Decidim::Cfj::SurveyOrder.sorted(search.result)).published
+    end
+  end
+
+  module DecidimCfjSurveysAdminOrderingPatch
+    def reorder
+      enforce_permission_to(:update, :questionnaire)
+
+      Decidim::Cfj::ReorderSurveys.call(current_component, params[:order_ids]) do
+        on(:ok) do
+          head :ok
+        end
+
+        on(:invalid) do
+          head :bad_request
+        end
+      end
+    end
+
+    private
+
+    # Copy of Decidim::Surveys::Admin::SurveysController#collection as of
+    # v0.30.9, with the ordering added. Check it again when upgrading Decidim.
+    def collection
+      @collection ||= Decidim::Cfj::SurveyOrder.for_component(current_component)
+    end
+  end
+
+  Decidim::Surveys::SurveysController.prepend(DecidimCfjSurveysOrderingPatch)
+  Decidim::Surveys::Admin::SurveysController.prepend(DecidimCfjSurveysAdminOrderingPatch)
+end

--- a/config/locales/survey_ordering.en.yml
+++ b/config/locales/survey_ordering.en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  decidim:
+    cfj:
+      surveys:
+        reorder: Reorder

--- a/config/locales/survey_ordering.ja.yml
+++ b/config/locales/survey_ordering.ja.yml
@@ -1,0 +1,6 @@
+---
+ja:
+  decidim:
+    cfj:
+      surveys:
+        reorder: 並び替え

--- a/db/migrate/20260817120000_create_decidim_cfj_survey_orders.rb
+++ b/db/migrate/20260817120000_create_decidim_cfj_survey_orders.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Decidim does not provide an order field for Decidim::Surveys::Survey yet, so
+# the weights are kept outside of the core table. When upstream adds the column,
+# migrating is a single UPDATE (see the removal steps in
+# config/initializers/surveys_ordering_override.rb).
+class CreateDecidimCfjSurveyOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :decidim_cfj_survey_orders do |t|
+      # decidim_surveys_surveys.id is a serial (integer), so the reference is an
+      # integer as well to keep both sides of the foreign key on the same type.
+      t.integer :decidim_surveys_survey_id, null: false
+      t.integer :weight, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :decidim_cfj_survey_orders,
+              :decidim_surveys_survey_id,
+              unique: true,
+              name: "index_decidim_cfj_survey_orders_on_survey"
+
+    add_foreign_key :decidim_cfj_survey_orders,
+                    :decidim_surveys_surveys,
+                    column: :decidim_surveys_survey_id,
+                    on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_05_18_113546) do
+ActiveRecord::Schema[7.0].define(version: 2026_08_17_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "pg_bigm"
@@ -490,6 +490,14 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_18_113546) do
     t.datetime "updated_at", precision: nil, null: false
     t.index ["categorizable_type", "categorizable_id"], name: "decidim_categorizations_categorizable_id_and_type"
     t.index ["decidim_category_id"], name: "index_decidim_categorizations_on_decidim_category_id"
+  end
+
+  create_table "decidim_cfj_survey_orders", force: :cascade do |t|
+    t.integer "decidim_surveys_survey_id", null: false
+    t.integer "weight", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["decidim_surveys_survey_id"], name: "index_decidim_cfj_survey_orders_on_survey", unique: true
   end
 
   create_table "decidim_coauthorships", force: :cascade do |t|
@@ -2110,6 +2118,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_18_113546) do
   add_foreign_key "decidim_budgets_orders", "decidim_budgets_budgets"
   add_foreign_key "decidim_budgets_projects", "decidim_budgets_budgets"
   add_foreign_key "decidim_categorizations", "decidim_categories"
+  add_foreign_key "decidim_cfj_survey_orders", "decidim_surveys_surveys", on_delete: :cascade
   add_foreign_key "decidim_debates_debates", "decidim_scopes"
   add_foreign_key "decidim_editor_images", "decidim_organizations"
   add_foreign_key "decidim_editor_images", "decidim_users", column: "decidim_author_id"

--- a/spec/requests/decidim/surveys/survey_ordering_spec.rb
+++ b/spec/requests/decidim/surveys/survey_ordering_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "decidim/surveys/test/factories"
+
+# Decidim does not order the surveys of a surveys component, neither in the
+# admin index nor in the public list. The order is stored in the
+# decidim_cfj_survey_orders side table, see
+# config/initializers/surveys_ordering_override.rb.
+RSpec.describe "Surveys display order" do
+  include Devise::Test::IntegrationHelpers
+
+  let(:organization) { create(:organization) }
+  let(:admin_user) { create(:user, :admin, :confirmed, organization:) }
+  let(:participatory_process) { create(:participatory_process, organization:) }
+  let(:component) { create(:surveys_component, participatory_space: participatory_process) }
+  let!(:first_survey) { create(:survey, :published, :allow_answers, component:) }
+  let!(:second_survey) { create(:survey, :published, :allow_answers, component:) }
+  let!(:third_survey) { create(:survey, :published, :allow_answers, component:) }
+
+  let(:reorder_path) { Decidim::EngineRouter.admin_proxy(component).reorder_surveys_path }
+
+  before { host! organization.host }
+
+  def weights
+    Decidim::Cfj::SurveyOrder.pluck(:decidim_surveys_survey_id, :weight).to_h
+  end
+
+  def listed_survey_ids
+    get Decidim::EngineRouter.main_proxy(component).root_path
+
+    [first_survey, second_survey, third_survey].filter_map do |survey|
+      path = Decidim::EngineRouter.main_proxy(component).survey_path(survey)
+      position = response.body.index(%(#{path}"))
+      [survey.id, position] if position
+    end.sort_by(&:last).map(&:first)
+  end
+
+  def admin_survey_ids(page = nil)
+    get Decidim::EngineRouter.admin_proxy(component).surveys_path(page:)
+
+    response.body.scan(/data-record-id="(\d+)"/).flatten.map(&:to_i)
+  end
+
+  describe "PUT reorder" do
+    before { sign_in admin_user, scope: :user }
+
+    it "stores the weights following the given order" do
+      put reorder_path, params: { order_ids: [third_survey.id, first_survey.id, second_survey.id] }
+
+      expect(response).to have_http_status(:ok)
+      expect(weights).to eq(third_survey.id => 1, first_survey.id => 2, second_survey.id => 3)
+    end
+
+    it "updates the weights of an already ordered component" do
+      put reorder_path, params: { order_ids: [first_survey.id, second_survey.id, third_survey.id] }
+      put reorder_path, params: { order_ids: [second_survey.id, third_survey.id, first_survey.id] }
+
+      expect(weights).to eq(second_survey.id => 1, third_survey.id => 2, first_survey.id => 3)
+    end
+
+    it "keeps the surveys that were not reordered at their position" do
+      # The sortable list only sends the ids of the page being reordered.
+      put reorder_path, params: { order_ids: [third_survey.id, second_survey.id] }
+
+      expect(weights).to eq(first_survey.id => 1, third_survey.id => 2, second_survey.id => 3)
+      expect(listed_survey_ids).to eq([first_survey.id, third_survey.id, second_survey.id])
+    end
+
+    it "swaps surveys that do not sit next to each other" do
+      fourth_survey = create(:survey, :published, :allow_answers, component:, questionnaire: build(:questionnaire))
+
+      put reorder_path, params: { order_ids: [fourth_survey.id, first_survey.id] }
+
+      expect(weights).to eq(
+        fourth_survey.id => 1,
+        second_survey.id => 2,
+        third_survey.id => 3,
+        first_survey.id => 4
+      )
+    end
+
+    it "ignores surveys of another component" do
+      other_component = create(:surveys_component, participatory_space: participatory_process)
+      other_survey = create(:survey, component: other_component)
+
+      put reorder_path, params: { order_ids: [other_survey.id, first_survey.id] }
+
+      expect(weights).to eq(first_survey.id => 1, second_survey.id => 2, third_survey.id => 3)
+      expect(Decidim::Cfj::SurveyOrder.exists?(decidim_surveys_survey_id: other_survey.id)).to be(false)
+    end
+
+    it "does nothing without an order" do
+      put reorder_path
+
+      expect(response).to have_http_status(:bad_request)
+      expect(weights).to be_empty
+    end
+
+    it "does nothing with an unusable order" do
+      put reorder_path, params: { order_ids: "nope" }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(weights).to be_empty
+    end
+
+    it "does nothing when none of the given ids is usable" do
+      put reorder_path, params: { order_ids: ["nope", ""] }
+
+      expect(response).to have_http_status(:bad_request)
+      expect(weights).to be_empty
+    end
+
+    it "drops the ids that are not numbers and the repeated ones" do
+      put reorder_path, params: { order_ids: [third_survey.id, "nope", third_survey.id, first_survey.id] }
+
+      expect(response).to have_http_status(:ok)
+      expect(weights).to eq(third_survey.id => 1, second_survey.id => 2, first_survey.id => 3)
+    end
+
+    context "when the surveys do not fit in a single page" do
+      # 3 + 24 surveys, so that the second page of the admin index holds 2 of them.
+      let!(:extra_surveys) do
+        Array.new(24) { create(:survey, :published, :allow_answers, component:, questionnaire: build(:questionnaire)) }
+      end
+
+      it "does not change the previous page when the last one is reordered" do
+        first_page = admin_survey_ids
+        second_page = admin_survey_ids(2)
+
+        expect(first_page.size).to eq(25)
+        expect(second_page.size).to eq(2)
+
+        put reorder_path, params: { order_ids: second_page.reverse }
+
+        expect(admin_survey_ids).to eq(first_page)
+        expect(admin_survey_ids(2)).to eq(second_page.reverse)
+      end
+    end
+  end
+
+  describe "GET the admin index" do
+    before { sign_in admin_user, scope: :user }
+
+    it "renders a sortable table pointing at the reorder action" do
+      get Decidim::EngineRouter.admin_proxy(component).surveys_path
+
+      expect(response.body).to include("data-draggable-table")
+      expect(response.body).to include(%(data-sort-url="#{reorder_path}"))
+    end
+
+    it "lists the surveys following the configured order" do
+      Decidim::Cfj::SurveyOrder.create!(decidim_surveys_survey_id: second_survey.id, weight: 1)
+
+      expect(admin_survey_ids).to eq([second_survey.id, first_survey.id, third_survey.id])
+    end
+  end
+
+  describe "PUT reorder without admin rights" do
+    let(:user) { create(:user, :confirmed, organization:) }
+    let(:order_ids) { [third_survey.id, second_survey.id, first_survey.id] }
+
+    before { sign_in user, scope: :user }
+
+    it "does not reach the admin engine as a participant" do
+      # The whole admin engine is behind Decidim::Admin::OrganizationDashboardConstraint,
+      # so a participant does not even get a route.
+      expect { put reorder_path, params: { order_ids: } }
+        .to raise_error(ActionController::RoutingError)
+
+      expect(weights).to be_empty
+    end
+
+    context "when the user is a collaborator of the space" do
+      before do
+        create(:participatory_process_user_role, user:, participatory_process:, role: :collaborator)
+      end
+
+      it "does not change the order" do
+        put reorder_path, params: { order_ids: }
+
+        expect(response).not_to have_http_status(:ok)
+        expect(weights).to be_empty
+      end
+    end
+  end
+
+  describe "destroying a survey" do
+    it "takes its stored weight with it" do
+      Decidim::Cfj::SurveyOrder.create!(decidim_surveys_survey_id: first_survey.id, weight: 1)
+      Decidim::Cfj::SurveyOrder.create!(decidim_surveys_survey_id: second_survey.id, weight: 2)
+
+      first_survey.destroy!
+
+      expect(weights).to eq(second_survey.id => 2)
+    end
+  end
+
+  describe "public index" do
+    it "lists the surveys following the configured order" do
+      Decidim::Cfj::SurveyOrder.create!(decidim_surveys_survey_id: third_survey.id, weight: 1)
+      Decidim::Cfj::SurveyOrder.create!(decidim_surveys_survey_id: first_survey.id, weight: 2)
+      Decidim::Cfj::SurveyOrder.create!(decidim_surveys_survey_id: second_survey.id, weight: 3)
+
+      expect(listed_survey_ids).to eq([third_survey.id, first_survey.id, second_survey.id])
+    end
+
+    it "lists the surveys without a configured order last, by id" do
+      Decidim::Cfj::SurveyOrder.create!(decidim_surveys_survey_id: third_survey.id, weight: 1)
+
+      expect(listed_survey_ids).to eq([third_survey.id, first_survey.id, second_survey.id])
+    end
+
+    it "falls back to the id order when nothing is configured" do
+      expect(listed_survey_ids).to eq([first_survey.id, second_survey.id, third_survey.id])
+    end
+  end
+end

--- a/spec/system/admin/survey_ordering_spec.rb
+++ b/spec/system/admin/survey_ordering_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "decidim/surveys/test/factories"
+
+# Mirrors the components reorder spec of decidim-participatory_processes, since
+# the surveys admin index reuses the same draggable table.
+describe "Admin reorders the surveys of a component" do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization:) }
+  let(:participatory_process) { create(:participatory_process, organization:) }
+  let(:component) { create(:surveys_component, participatory_space: participatory_process) }
+
+  let!(:survey1) { create(:survey, component:, questionnaire: build(:questionnaire, title: { en: "Survey 1", ja: "Survey 1" })) }
+  let!(:survey2) { create(:survey, component:, questionnaire: build(:questionnaire, title: { en: "Survey 2", ja: "Survey 2" })) }
+  let!(:survey3) { create(:survey, component:, questionnaire: build(:questionnaire, title: { en: "Survey 3", ja: "Survey 3" })) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit Decidim::EngineRouter.admin_proxy(component).surveys_path
+  end
+
+  it "changes the order of the surveys" do
+    expect(page.text.index("Survey 1")).to be < page.text.index("Survey 2")
+    expect(page.text.index("Survey 2")).to be < page.text.index("Survey 3")
+
+    first("td.dragging-handle").drag_to(find("tbody.draggable-table tr:last-child"))
+
+    # The drop rearranges the rows right away and sends the new order in the
+    # background, so both have to be waited for before reloading the page.
+    # Where exactly the dragged row lands is up to the sortable library, so only
+    # the fact that the first survey is no longer the first one is asserted.
+    expect(page).to have_css("tbody.draggable-table tr:first-child", text: "Survey 2")
+    wait_for_stored_order
+
+    visit current_path
+
+    expect(page.text.index("Survey 2")).to be < page.text.index("Survey 1")
+
+    expect(weights[survey2.id]).to be < weights[survey1.id]
+  end
+
+  def weights
+    Decidim::Cfj::SurveyOrder.pluck(:decidim_surveys_survey_id, :weight).to_h
+  end
+
+  def wait_for_stored_order
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      sleep 0.05 until weights.keys.sort == [survey1.id, survey2.id, survey3.id].sort
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Surveyの並びを変えられるようにする修正です。

いったん別テーブルを作り、そこに置く形にしています（なので本家に取り込まれたあとに若干移行作業が発生します。が、そのまま取り込まれるかどうかは怪しいので、下手にsurveysテーブルを変えるよりはいったん独自テーブルを追加して、surveysテーブルは手を入れない方がいいかな？という判断です）。

UIとしてはBudgetsに似せているつもりです。ドラッグで移動できます。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

Before:

<img width="846" height="406" alt="survey-original" src="https://github.com/user-attachments/assets/613eb69b-bb81-4fee-a0e5-5d187c93adff" />

After:

https://github.com/user-attachments/assets/723acda5-a5ad-4892-91c0-731da0b9e53e

