### PR TITLE
fix: オープンデータのエクスポートが nil の blocking で落ちる問題に対処

### DIFF
--- a/config/initializers/open_data_blocked_user_serializer_override.rb
+++ b/config/initializers/open_data_blocked_user_serializer_override.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Decidim::Exporters::OpenDataBlockedUserSerializer が `resource.blocking` の nil を
+# 想定しておらず、オープンデータのエクスポート全体を落としている問題への対処。
+#
+# moderated_users の collection は `decidim_users.blocked_at` で絞り込むが
+# (decidim-core/lib/decidim/core.rb の open_data_manifests)、serializer は
+# `decidim_users.block_id` 経由の `has_one :blocking` が存在する前提で
+# `justification` を呼ぶ。blocked_at は入っているが block_id が NULL のユーザーが
+# 1 件でもあると NoMethodError になり、ZIP 生成が moderated_users の時点で中断されるため
+# 提案も会議もユーザーも一切出力されず、/open-data/download が 302 を返し続ける。
+#
+# 本番実測 (30日): start 6,215 / done 588 (完走率 9.5%)。
+# 失敗 5,565 件のうち 5,536 件 (99.5%) がこの NoMethodError。
+#
+# decidim 0.30.9 / 0.31.7 / 0.32.1 のいずれでも当該 serializer は同一内容で未修正のため、
+# 上流追従では解消しない。
+#
+# NOTE: 元実装が `resource.blocking.justification` を直接呼ぶ構造のため super は使えない
+# (super の中で例外が起きる)。serialize 全体を差し替える。
+# 元は decidim-core/app/serializers/decidim/exporters/open_data_blocked_user_serializer.rb
+# の v0.30.9 時点の実装で、v0.31.7 / v0.32.1 とも差分なし。
+Rails.application.config.to_prepare do
+  Decidim::Exporters::OpenDataBlockedUserSerializer # rubocop:disable Lint/Void
+
+  module DecidimExportersOpenDataBlockedUserSerializerNilBlockingPatch
+    def serialize
+      blocking = resource.blocking
+      blocking_user = blocking&.blocking_user
+
+      {
+        user_id: resource.user.id,
+        blocked_at: resource.user.blocked_at,
+        about: resource.user.about,
+        reasons: resource.reports.map(&:reason),
+        details: resource.reports.map(&:details),
+        block_reasons: blocking&.justification,
+        blocking_user: blocking_user&.presenter&.name
+      }
+    end
+  end
+
+  Decidim::Exporters::OpenDataBlockedUserSerializer.prepend(
+    DecidimExportersOpenDataBlockedUserSerializerNilBlockingPatch
+  )
+end

--- a/spec/config/initializers/open_data_blocked_user_serializer_override_spec.rb
+++ b/spec/config/initializers/open_data_blocked_user_serializer_override_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Decidim::Exporters::OpenDataBlockedUserSerializer nil blocking override" do
+  subject { Decidim::Exporters::OpenDataBlockedUserSerializer.new(user_moderation).serialize }
+
+  let(:organization) { create(:organization) }
+
+  context "when the blocked user has an associated Decidim::UserBlock" do
+    let!(:user_block) { create(:user_block, organization:) }
+    let(:user_moderation) { create(:user_moderation, user: user_block.user) }
+
+    it "serializes the block reasons and the blocking user" do
+      expect(subject[:block_reasons]).to eq(user_block.justification)
+      expect(subject[:blocking_user]).to eq(user_block.blocking_user.presenter.name)
+    end
+  end
+
+  # decidim-core/lib/decidim/core.rb の open_data_manifests は decidim_users.blocked_at で
+  # 絞り込むが、serializer は decidim_users.block_id 経由の has_one :blocking を前提にしている。
+  # block_id が NULL のまま blocked_at だけ入っているユーザーで NoMethodError にならないこと。
+  context "when the user is blocked but has no associated Decidim::UserBlock" do
+    let(:blocked_user) { create(:user, :blocked, :confirmed, organization:) }
+    let(:user_moderation) { create(:user_moderation, user: blocked_user) }
+
+    it "has no blocking association" do
+      expect(blocked_user.block_id).to be_nil
+      expect(blocked_user.blocking).to be_nil
+    end
+
+    it "does not raise and leaves the block columns empty" do
+      expect { subject }.not_to raise_error
+      expect(subject[:block_reasons]).to be_nil
+      expect(subject[:blocking_user]).to be_nil
+    end
+
+    it "still serializes the user attributes" do
+      expect(subject[:user_id]).to eq(blocked_user.id)
+      expect(subject[:blocked_at]).to be_present
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

**本番のオープンデータが生成できていません。** `/open-data` の全ダウンロードリンクが 302 を返し続けています。

原因は上流 decidim のバグで、`Decidim::Exporters::OpenDataBlockedUserSerializer` が `resource.blocking` の nil を想定していないことです。nil ガードで解消します。

##### 本番(prd-v030)の実測（30日）

```
Decidim::OpenDataJob   start  6,215
                       ├─ done      588  ( 9.5%)
                       ├─ fail    5,565  (89.5%)
                       └─ 差分       62  ( 1.0%)
```

失敗 5,565件の内訳:

| エラー | 件数 | 割合 |
|---|---|---|
| **`NoMethodError`**（`undefined method 'justification' for nil`） | **5,536** | **99.5%** |
| `Errno::ENOENT` | 27 | 0.5% |
| `ActiveStorage::IntegrityError` | 2 | 0.04% |

他ジョブとの比較:

| ジョブ | start | done | 完走率 |
|---|---|---|---|
| **`Decidim::OpenDataJob`** | **6,215** | **588** | **9.5%** 🔴 |
| `Decidim::EmailNotificationsDigestGeneratorJob` | 239,355 | 239,355 | 100% |
| `Decidim::Admin::DestroyPrivateUsersFollowsJob` | 22,718 | 22,718 | 100% |
| `Decidim::ExportJob` | 122 | 122 | 100% |

##### 原因

collection の絞り込み条件と serializer の前提が**別のカラム**を見ています。

```ruby
# decidim-core/lib/decidim/core.rb の open_data_manifests
collection: lambda { |organization|
  Decidim::UserModeration.joins(:user)
    .where(decidim_users: { decidim_organization_id: organization.id })
    .where.not(decidim_users: { blocked_at: nil })      # ← blocked_at で絞る
}
```

```ruby
# decidim-core/app/serializers/decidim/exporters/open_data_blocked_user_serializer.rb:19-20
block_reasons: resource.blocking.justification,               # ← nil ガードなし
blocking_user: resource.blocking.blocking_user.presenter.name
```

```ruby
# decidim-core/app/models/decidim/user.rb:20
has_one :blocking, class_name: "Decidim::UserBlock",
        foreign_key: :id, primary_key: :block_id, dependent: :destroy
```

**`blocked_at` は入っているが `block_id` が NULL（または参照先の `UserBlock` が削除済み）のユーザーが1件でもあると `resource.blocking` が nil を返し、例外になります。**

`moderated_users` は `core_data_manifests` の先頭付近で処理されるため、ZIP 生成の初期段階で落ち、**提案も会議もユーザーも一切出力されません**。

##### 連鎖

```
serializer が nil を想定していない
  → moderated_users で必ず例外 → ZIP 全体が生成されない（完走率 9.5%）
  → /open-data/download が 302（ActiveStorage に添付が無い）
  → OpenDataController#download が 302 の直前に schedule_open_data_generation を呼ぶため
    ダウンロードリンクのクリックごとにジョブが再投入される
  → cron + アクセス駆動 + Sidekiq リトライ25回 で start が 170〜331件/日 に膨張
    （デッドキュー入り 66件も確認）
  → exports キューを占有し sidekiq の CPU が 100% に張り付く
```

実地検証として `/open-data` からダウンロードをクリックしたところ、`OpenDataJob` が enqueue され **0.089秒で `NoMethodError` により fail**（`retry_count: 5`）しました。

#### :warning: バージョン追従では直りません

| バージョン | 当該 serializer |
|---|---|
| v0.30.9 | 未修正 |
| v0.31.7 | **v0.30.9 と差分なし** |
| v0.32.1 | **v0.30.9 と差分なし** |

`open_data_exporter.rb` も 0.31.7 と 0.32.1 で完全に同一（差分ゼロ）です。上流に報告する価値があります。

#### :clipboard: 変更内容

`config/initializers/open_data_blocked_user_serializer_override.rb`（新規）

```ruby
def serialize
  blocking = resource.blocking
  blocking_user = blocking&.blocking_user

  {
    user_id: resource.user.id,
    blocked_at: resource.user.blocked_at,
    about: resource.user.about,
    reasons: resource.reports.map(&:reason),
    details: resource.reports.map(&:details),
    block_reasons: blocking&.justification,
    blocking_user: blocking_user&.presenter&.name
  }
end
```

元実装が `resource.blocking.justification` を直接呼ぶ構造のため **`super` は使えません**（super の中で例外が起きる）。`serialize` 全体を差し替えています。元実装は 0.30.9 / 0.31.7 / 0.32.1 で同一なのでドリフトの心配はありません。

`spec/config/initializers/open_data_blocked_user_serializer_override_spec.rb`（新規）

- `UserBlock` あり → 従来どおり `justification` と blocking user 名が入る
- **`block_id` が nil → 例外を出さず該当列が nil**
- ユーザー属性（`user_id` / `blocked_at`）は変わらず出力される

#### :white_check_mark: 検証（Docker 環境で実施）

| 項目 | 結果 |
|---|---|
| `bin/rails runner` で prepend の適用確認 | ✅ `serialize` の owner が patch モジュール |
| `bundle exec rspec` | ✅ **4 examples, 0 failures** |
| `bundle exec rubocop` | ✅ **no offenses detected** |

#### :clipboard: Subtasks

- [x] Add `CHANGELOG` upgrade notes, if required（release-please 運用のため手編集なし）
- [x] If there's a new public field, add it to GraphQL API（対象外）
- [x] Add documentation regarding the feature（`docs/superpowers/prd-infra-issues-2026-08.md` の問題4 に調査結果を記録）
- [x] Add/modify seeds（対象外）
- [x] Add tests

#### :mag: 本 PR の範囲外（フォローアップ候補）

1. **上流 decidim へ報告** — 0.32.1 でも未修正のため
2. **データ側の確認** — `blocked_at IS NOT NULL AND block_id IS NULL` の件数と発生経緯。本 PR で例外は止まりますが、該当ユーザーのブロック理由は CSV に空で出力されます
3. **`OpenDataExporter` のメモリ最適化** — `data_for_core` の全件一括ロード、`Zip::OutputStream.write_buffer` でのメモリ上 ZIP 構築など実装上の問題は実在します。ただし失敗の主因ではないため（OOM 相当は 62件/1.0% 以下）、本 PR の効果を測ってから判断するのが妥当です
