### PR TITLE
fix: PumaWorkerKiller の閾値を CDK のタスク定義から ENV で受け取る

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -24,9 +24,11 @@ pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 before_fork do
   PumaWorkerKiller.config do |config|
-    config.ram = 3072
+    # コンテナの実メモリ量は CDK のタスク定義 (decidim-cfj-cdk) を単一の情報源とする。
+    # ハードコードすると実値と乖離しても気づけないため ENV で受け取る。
+    config.ram = Integer(ENV.fetch("PUMA_WORKER_KILLER_RAM_MB"))
+    config.percent_usage = Float(ENV.fetch("PUMA_WORKER_KILLER_PERCENT_USAGE"))
     config.frequency = 60
-    config.percent_usage = 0.9
     config.rolling_restart_frequency = 24 * 60 * 60
     config.reaper_status_logs = true
     config.pre_term = lambda do |worker|


### PR DESCRIPTION
> [!WARNING]
> **この PR は decidim-cfj-cdk の [#103](https://github.com/codeforjapan/decidim-cfj-cdk/pull/103) に依存します。**
> #103 をマージ・デプロイする前に本 PR をマージすると、**ENV が無く Puma が起動しません**。
> `_deploy.yaml:56-60` が CDK リポジトリの main を ref 指定なしでチェックアウトするためです。
> 事故防止のため Draft にしています。**#103 のマージ後に Ready にしてください。**

#### :tophat: What? Why?

`config/puma.rb` が `config.ram = 3072` をハードコードしていましたが、**タスク定義の実メモリは 4096 MiB** で、どの環境の実態とも一致していませんでした。

この設定は decidim-cfj-cdk 側の `config/<stage>.json` とは**別リポジトリ**にあるため、`memory` を変更しても追従せず、変更がサイレントに無効化される構造でした。

```
config/puma.rb                        decidim-cfj-cdk/config/<stage>.json
  config.ram = 3072  ← ハードコード      ecs.mainApp.memory = 4096
        ↑                                        ↑
        └───── 別リポジトリ。連動しない ──────────┘
```

##### 本番(prd-v030)の実測

この乖離により **PumaWorkerKiller が7日で9回、worker を不要に強制終了**していました。

| 項目 | 値 | 取得元 |
|---|---|---|
| app タスク | cpu 2048 / **memory 4096 MiB** | `describe-task-definition` |
| PWK 閾値 | **2764.8 MiB**（`ram=3072` × `percent_usage=0.9`） | `config/puma.rb` |
| Puma 合計 RSS（7日, n=10,078） | p50 2558 / **p95 2741** / p99 2760 / **max 2764.73** | CloudWatch Logs Insights |
| **OOM reap** | **7日で9回**（約1.3回/日） | 同上 |
| `appContainer` 実使用 | avg 2282 / p95 2578.8 / **max 2598.0 MiB** | Container Insights |
| `nginxContainer` 実使用 | avg 27.0 / **max 30.0 MiB** | Container Insights |
| ECS MemoryUtilization (app) | Average p95 62.8% / **max 64.2%** | CloudWatch |

**`max_mb = 2764.73` が閾値 2764.8 とほぼ一致** ＝ メモリが自然に頭打ちになっているのではなく **reaper に叩き落とされている**状態です。

##### 乖離の原因

PumaWorkerKiller は master と worker の **RSS を単純合計**します。

```ruby
# puma_worker_killer-1.0.0/lib/puma_worker_killer/puma_memory.rb
def get_total(workers = set_workers)
  master_memory = GetProcessMem.new(Process.pid).mb
  worker_memory = workers.values.inject(:+) || 0
  worker_memory + master_memory          # ← RSS の単純合計
end
```

RSS は「そのプロセスが参照している物理ページ」なので、master と 4 worker が共有するページ（Ruby バイナリ、libc、mmap された gem の .so 等）が **5回カウント**されます。cgroup は1回です。

**過大計上量は Container Insights の実測で確定:**

| | PWK の報告 | appContainer の実測(cgroup) | 過大計上 |
|---|---|---|---|
| p95 | 2741 MiB | 2578.8 MiB | **162.2 MiB** |
| max | 2764.73 MiB | 2598.0 MiB | **166.7 MiB** |

検算: appContainer 2598 + nginx 30 = **2628 MiB** ≒ ECS MemoryUtilization max 64.2%（2630 MiB）。

つまり **コンテナに 1466 MiB 余っているのに worker を殺していました**。

#### :clipboard: 変更内容

```diff
 before_fork do
   PumaWorkerKiller.config do |config|
-    config.ram = 3072
+    # コンテナの実メモリ量は CDK のタスク定義 (decidim-cfj-cdk) を単一の情報源とする。
+    # ハードコードすると実値と乖離しても気づけないため ENV で受け取る。
+    config.ram = Integer(ENV.fetch("PUMA_WORKER_KILLER_RAM_MB"))
+    config.percent_usage = Float(ENV.fetch("PUMA_WORKER_KILLER_PERCENT_USAGE"))
     config.frequency = 60
-    config.percent_usage = 0.9
```

##### フォールバックを置かない理由

今回の不具合は「コード側の既定値が実態と乖離していたのに、誰も気づかなかった」ことでした。フォールバックを残すと**同じ構造が残ります**。

引数1つの `ENV.fetch` と `Integer()` / `Float()` により、**設定ミスは即座に、明示的に失敗**します（`.to_i` だと `"abc"` が静かに 0 になる）。

`development` は `config/puma.rb:46` の `workers ... unless Rails.env.development?` により single mode になるため **`before_fork` 自体が実行されず**、この ENV が参照されるのは ECS 上だけです。

##### `percent_usage` を 0.9 → 0.8 に下げる理由

`ram` を実メモリ 4096 にして 0.9 のままだと閾値 3686.4 → 実換算 3521 + nginx 30 = **3551 MiB（86.7%）**。OOM kill まで 545 MiB しかなく安全弁として機能しません。

#### :chart_with_upwards_trend: 閾値の変化

```
PWK 閾値        = 4096 × 0.8 = 3276.8 MiB   （PWK の過大計上込みの見かけ値）
実 appContainer = 3276.8 − 165 = 約 3112 MiB
タスク全体      = 3112 + 30(nginx) = 約 3142 MiB = コンテナの 76.7%
```

| | 現状 | 適用後 |
|---|---|---|
| PWK 閾値（見かけ） | 2764.8 MiB | **3276.8 MiB** |
| 実使用換算（タスク全体） | 約 2628 MiB（**64.2%**） | 約 3142 MiB（**76.7%**） |
| ECS scale-out(70%) との順序 | **PWK が先（逆）** | **scale-out が先（正）** |
| OOM kill(4096) までの余裕 | 1466 MiB | **954 MiB** |
| 期待される reap 頻度 | 1.3回/日 | **ほぼゼロ**（p99 2760 < 3276.8） |

現状は負荷が高まったときに「台を増やす」のではなく「worker を殺す」逆方向の挙動で、`scaleOnMemoryUtilization`（目標70%）が**一度も発動していません**。

##### 閾値を上げてもメモリが暴走しない理由

`config.rolling_restart_frequency = 24 * 60 * 60` が全 worker を24時間ごとに再起動します（実測で7日28回＝設計どおり稼働中）。これが上限を画します。

#### :white_check_mark: 検証（Docker 環境で実施）

| # | 検証 | 結果 |
|---|---|---|
| ① | development で `before_fork` が実行されない | ✅ Puma が明示的に警告し single mode で起動 |
| ② | ENV から `Integer` / `Float` として読める | ✅ `ram=4096` / `percent=0.8` → **閾値 3276.8 MiB** |
| ③ | ENV 未設定で即座に失敗 | ✅ `KeyError: key not found: "PUMA_WORKER_KILLER_RAM_MB"` |
| ④ | 不正値を弾く | ✅ `ArgumentError: invalid value for Integer(): "abc"` |
| ⑤ | cluster mode で PWK が起動 | ✅ `PumaWorkerKiller: Consuming 909.39 mb with master and 2 workers.` |
| — | RuboCop | ✅ no offenses |

#### :arrows_counterclockwise: ロールバック

閾値を戻すだけなのでアプリの再デプロイは不要です。CDK 側で旧値を渡せば元に戻ります。

```typescript
PUMA_WORKER_KILLER_RAM_MB: '3072',
PUMA_WORKER_KILLER_PERCENT_USAGE: '0.9',
```

#### :eyes: デプロイ後に見るもの

| 指標 | 期待 |
|---|---|
| OOM reap 回数（Logs `/Out of memory/`） | **0/週** |
| reap ログの `out of max` | `3276.8 mb` になっていること |
| Puma RSS p99 | 2800〜3100 で頭打ち。**3276 に張り付いたら要再調整** |
| ECS MemoryUtilization (app) | max 70〜78% |
| Slack の worker killed 通知 | **止まるはず** |

#### :clipboard: Subtasks

- [x] Add `CHANGELOG` upgrade notes, if required（release-please 運用のため手編集なし）
- [x] If there's a new public field, add it to GraphQL API（対象外）
- [x] Add documentation regarding the feature（`docs/superpowers/pwk-memory-threshold-fix-plan.md` に実行計画、`prd-infra-issues-2026-08.md` に調査結果）
- [x] Add/modify seeds（対象外）
- [x] Add tests（Puma の設定ファイルのため spec は追加せず、Docker 実機で①〜⑤を検証）

#### :mag: 本 PR の範囲外

| 項目 | 理由 |
|---|---|
| `preload_app!` の有効化 | fork 挙動・DB/Redis コネクション再確立が変わるため単独検証が必要。⚠️ 有効化すると共有ページが増え **PWK の過大計上が 165 MiB より大きくなる**ため `percent_usage` の再調整が要る |
| sidekiq のメモリ設定 | sidekiq に PWK は無い。CDK の `ecs.sidekiq.memory` で独立対応 |
| `WEB_CONCURRENCY` の環境別化 | 現在 CDK 側で `'4'` 固定。メモリ変更と連動させるなら別途設計が必要 |
