### PR TITLE
fix: オープンデータのエクスポートが nil の reportable で落ちる問題に対処

### DIFF
--- a/config/initializers/open_data_moderation_serializer_override.rb
+++ b/config/initializers/open_data_moderation_serializer_override.rb
@@ -62,24 +62,23 @@ module DecidimExportersOpenDataModerationSerializerNilReportablePatch
   # URL 生成は壊れた参照で複数種類の例外を投げうる。
   # 1 レコードのために組織全体のエクスポートを止めないよう、握って nil を返す。
   #
-  # 例外クラスを列挙して絞ると、URL 生成の別経路で投げられる例外を取りこぼして
-  # 同じ障害を繰り返す。EngineRouter は route helper を method_missing で呼ぶため
-  # NameError 系だけでなく ActionController::UrlGenerationError も投げうる。
+  # 例外クラスを列挙して絞ると URL 生成の別経路を取りこぼして同じ障害を繰り返す。
+  # EngineRouter は route helper を method_missing で呼ぶため、NameError 系だけでなく
+  # ActionController::UrlGenerationError も投げうる。よって StandardError を広く受ける。
   #
-  # 一方で StandardError を素通しすると一時的な DB エラーまで飲み込み、
-  # 「参照が消えている」のか「引けなかっただけ」なのか区別できないまま
-  # 空の URL を正常な公開データとして出力してしまう。
-  # そこで広く受けたうえで、一時障害だけは再送出して顕在化させる。
-  # ActiveRecord::StatementInvalid は QueryCanceled だけでなく
-  # PG::UndefinedTable / NoDatabaseError のような恒久的な失敗も含むため使わない。
-  # それらを再送出すると 1 レコードのために毎回エクスポートが止まり続ける。
-  # ConnectionTimeoutError (プール枯渇) は ConnectionNotEstablished の子孫。
-  TRANSIENT_ERRORS = [
-    ActiveRecord::QueryCanceled,
-    ActiveRecord::LockWaitTimeout,
-    ActiveRecord::ConnectionNotEstablished
-  ].freeze
-
+  # 一時的な DB 障害まで握って空の URL を公開データとして出す懸念はあるが、
+  # 一時障害と恒久障害を例外クラスで判別するのは PostgreSQL では成立しない。
+  # PostgreSQLAdapter#translate_exception が ConnectionNotEstablished に変換するのは
+  # メッセージが /connection is closed/i に一致した場合だけで、実際の接続断
+  # (server closed the connection unexpectedly) やデッドロックは素の
+  # StatementInvalid に落ちる。逆に StatementInvalid には PG::UndefinedTable の
+  # ような恒久的な失敗も含まれる。
+  #
+  # 代わりに、DB 障害はこの rescue を抜けた先で必ず顕在化することに依存する。
+  # OpenDataExporter#data_for_all_resources は moderations の後に users /
+  # user_groups / taxonomies と全コンポーネント・全空間を順に処理しており、
+  # いずれも DB アクセスを伴う。接続が落ちていればそちらで例外になり ZIP は
+  # 生成されないため、壊れたデータが正常な成果物として公開されることはない。
   def safe_reported_url
     reportable = resource.reportable
 
@@ -91,8 +90,6 @@ module DecidimExportersOpenDataModerationSerializerNilReportablePatch
     end
 
     reportable.reported_content_url
-  rescue *TRANSIENT_ERRORS
-    raise
   rescue StandardError => e
     log_missing_reported_url("#{e.class}: #{e.message}")
     nil

--- a/config/initializers/open_data_moderation_serializer_override.rb
+++ b/config/initializers/open_data_moderation_serializer_override.rb
@@ -74,29 +74,41 @@ module DecidimExportersOpenDataModerationSerializerNilReportablePatch
   # StatementInvalid に落ちる。逆に StatementInvalid には PG::UndefinedTable の
   # ような恒久的な失敗も含まれる。
   #
-  # 代わりに、DB 障害はこの rescue を抜けた先で必ず顕在化することに依存する。
+  # 接続断であれば、この rescue を抜けた先で必ず顕在化する。
   # OpenDataExporter#data_for_all_resources は moderations の後に users /
   # user_groups / taxonomies と全コンポーネント・全空間を順に処理しており、
-  # いずれも DB アクセスを伴う。接続が落ちていればそちらで例外になり ZIP は
-  # 生成されないため、壊れたデータが正常な成果物として公開されることはない。
+  # いずれも DB アクセスを伴うため、接続が落ちていればそちらで例外になり
+  # ZIP は生成されない。
+  #
+  # ただし接続が生きたままのクエリ単位の失敗 (RDS の statement_timeout による
+  # PG::QueryCanceled 等) はここで握られ、後続は成功しうる。その場合
+  # reported_url だけが欠けた ZIP が正常な成果物として公開される。
+  # 件数を数えて閾値超過で再送出する案もあるが、serializer はレコードごとに
+  # 生成されるためクラス変数などの状態を持たせることになり、ジョブ間で
+  # リセットされない・スレッド安全でないという別の問題を招く。
+  # 集計と打ち切りは本来 OpenDataJob 側の責務なので、ここでは扱わない。
+  # 系統的な破損は warn ログの件数で検知する (上流 issue: decidim/decidim#17574)。
   def safe_reported_url
     reportable = resource.reportable
 
     if reportable.nil?
       # 物理削除とゴミ箱行きの両方がここに来る。どちらか断定できないため
       # 「解決できない」とだけ記録する。
-      log_missing_reported_url("reportable could not be resolved (deleted or trashed)")
+      # ゴミ箱行きは管理者の通常運用で発生し、エクスポートのたびに件数分出るため
+      # info に留め、異常を示す例外側の warn を埋もれさせない。
+      log_missing_reported_url(:info, "reportable could not be resolved (deleted or trashed)")
       return nil
     end
 
     reportable.reported_content_url
   rescue StandardError => e
-    log_missing_reported_url("#{e.class}: #{e.message}")
+    log_missing_reported_url(:warn, "#{e.class}: #{e.message}")
     nil
   end
 
-  def log_missing_reported_url(reason)
-    Rails.logger.warn(
+  def log_missing_reported_url(level, reason)
+    Rails.logger.public_send(
+      level,
       "[open_data] failed to build reported_url for Decidim::Moderation " \
       "id=#{resource.id} reportable=#{resource.decidim_reportable_type}##{resource.decidim_reportable_id}: " \
       "#{reason}"

--- a/config/initializers/open_data_moderation_serializer_override.rb
+++ b/config/initializers/open_data_moderation_serializer_override.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Decidim::Exporters::OpenDataModerationSerializer が `resource.reportable` の nil を
+# 想定しておらず、オープンデータのエクスポート全体を落としている問題への対処。
+#
+# Decidim::Moderation#reportable はポリモーフィック関連のため DB の外部キー制約を張れず、
+# 参照先 (提案・コメント等) が物理削除されると dangling になる。
+# moderations の collection (decidim-core/lib/decidim/core.rb の open_data_manifests) は
+# hidden スコープで絞り込むだけで reportable の存在を確認しないため、
+# 1 件でも壊れたレコードがあると NoMethodError になり ZIP 生成が中断される。
+#
+# 本番実測: hidden な moderation 88 件のうち reportable が nil なのは 1 件だけだが、
+# その 1 件のせいで当該組織のオープンデータが一切出力されなくなっていた。
+#
+# decidim 0.30.9 / 0.31.7 / 0.32.1 / develop のいずれでも当該 serializer は
+# 同一内容で未修正のため、上流追従では解消しない (上流 issue: decidim/decidim#17574)。
+#
+# NOTE: 元実装が `resource.reportable.reported_content_url` を直接呼ぶ構造のため
+# super は使えない (super の中で例外が起きる)。serialize 全体を差し替える。
+# 元は decidim-core/app/serializers/decidim/exporters/open_data_moderation_serializer.rb
+# の v0.30.9 時点の実装で、v0.31.7 / v0.32.1 とも差分なし。
+Rails.application.config.to_prepare do
+  Decidim::Exporters::OpenDataModerationSerializer # rubocop:disable Lint/Void
+
+  module DecidimExportersOpenDataModerationSerializerNilReportablePatch
+    def serialize
+      {
+        id: resource.id,
+        hidden_at: resource.hidden_at,
+        report_count: resource.report_count,
+        reported_url: resource.reportable&.reported_content_url,
+        reportable_type: resource.decidim_reportable_type,
+        reportable_id: resource.decidim_reportable_id,
+        reported_content: resource.reported_content,
+        reports: {
+          reasons: resource.reports.map(&:reason),
+          locale: resource.reports.map(&:locale),
+          details: resource.reports.map(&:details)
+        }
+      }
+    end
+  end
+
+  Decidim::Exporters::OpenDataModerationSerializer.prepend(
+    DecidimExportersOpenDataModerationSerializerNilReportablePatch
+  )
+end

--- a/config/initializers/open_data_moderation_serializer_override.rb
+++ b/config/initializers/open_data_moderation_serializer_override.rb
@@ -1,16 +1,32 @@
 # frozen_string_literal: true
 
-# Decidim::Exporters::OpenDataModerationSerializer が `resource.reportable` の nil を
-# 想定しておらず、オープンデータのエクスポート全体を落としている問題への対処。
+# Decidim::Exporters::OpenDataModerationSerializer の reported_url 生成が
+# 壊れた参照で例外を投げ、オープンデータのエクスポート全体を落としている問題への対処。
 #
-# Decidim::Moderation#reportable はポリモーフィック関連のため DB の外部キー制約を張れず、
-# 参照先 (提案・コメント等) が物理削除されると dangling になる。
 # moderations の collection (decidim-core/lib/decidim/core.rb の open_data_manifests) は
-# hidden スコープで絞り込むだけで reportable の存在を確認しないため、
-# 1 件でも壊れたレコードがあると NoMethodError になり ZIP 生成が中断される。
+# participatory_space と hidden でしか絞り込まないため、URL を生成できないレコードが
+# 1 件でもあると ZIP 生成が moderations の時点で中断され、
+# 提案も会議もユーザーも一切出力されなくなる。
 #
-# 本番実測: hidden な moderation 88 件のうち reportable が nil なのは 1 件だけだが、
-# その 1 件のせいで当該組織のオープンデータが一切出力されなくなっていた。
+# 到達しうる例外が単一ではないため、個別の nil ガードではなく
+# reported_url の計算全体を rescue する。本番で確認できたのは以下の 2 経路。
+#
+#   1. reportable が nil
+#      Decidim::Moderation#reportable はポリモーフィック関連で DB の外部キー制約を
+#      張れないため、参照先が物理削除されると dangling になる。
+#
+#   2. reportable は残っているが reportable.component が nil
+#      Decidim::Component は SoftDeletable (acts_as_paranoid) だが
+#      Decidim::HasComponent の belongs_to :component は with_deleted を付けていない。
+#      管理画面からコンポーネントをゴミ箱に入れると、中の提案やコメントは
+#      trash されないまま component だけが引けなくなる。
+#      その状態で reported_content_url を呼ぶと
+#      ResourceLocatorPresenter#route_proxy が EngineRouter.main_proxy(component || target)
+#      に target を渡し、Proposal/Comment は mounted_engine を持たないため
+#      NoMethodError: undefined method `mounted_engine' になる。
+#
+# 本番実測 (hidden な moderation 88 件): 1 が 1 件、2 が 1 件。
+# この 2 件のせいで該当する 2 組織のオープンデータが一切出力されていなかった。
 #
 # decidim 0.30.9 / 0.31.7 / 0.32.1 / develop のいずれでも当該 serializer は
 # 同一内容で未修正のため、上流追従では解消しない (上流 issue: decidim/decidim#17574)。
@@ -28,7 +44,7 @@ Rails.application.config.to_prepare do
         id: resource.id,
         hidden_at: resource.hidden_at,
         report_count: resource.report_count,
-        reported_url: resource.reportable&.reported_content_url,
+        reported_url: safe_reported_url,
         reportable_type: resource.decidim_reportable_type,
         reportable_id: resource.decidim_reportable_id,
         reported_content: resource.reported_content,
@@ -38,6 +54,21 @@ Rails.application.config.to_prepare do
           details: resource.reports.map(&:details)
         }
       }
+    end
+
+    private
+
+    # URL 生成は壊れた参照で複数種類の例外を投げうる。
+    # 1 レコードのために組織全体のエクスポートを止めないよう、握って nil を返す。
+    def safe_reported_url
+      resource.reportable&.reported_content_url
+    rescue StandardError => e
+      Rails.logger.warn(
+        "[open_data] failed to build reported_url for Decidim::Moderation " \
+        "id=#{resource.id} reportable=#{resource.decidim_reportable_type}##{resource.decidim_reportable_id}: " \
+        "#{e.class}: #{e.message}"
+      )
+      nil
     end
   end
 

--- a/config/initializers/open_data_moderation_serializer_override.rb
+++ b/config/initializers/open_data_moderation_serializer_override.rb
@@ -39,72 +39,75 @@
 # super は使えない (super の中で例外が起きる)。serialize 全体を差し替える。
 # 元は decidim-core/app/serializers/decidim/exporters/open_data_moderation_serializer.rb
 # の v0.30.9 時点の実装で、v0.31.7 / v0.32.1 とも差分なし。
-Rails.application.config.to_prepare do
-  Decidim::Exporters::OpenDataModerationSerializer # rubocop:disable Lint/Void
-
-  module DecidimExportersOpenDataModerationSerializerNilReportablePatch
-    def serialize
-      {
-        id: resource.id,
-        hidden_at: resource.hidden_at,
-        report_count: resource.report_count,
-        reported_url: safe_reported_url,
-        reportable_type: resource.decidim_reportable_type,
-        reportable_id: resource.decidim_reportable_id,
-        reported_content: resource.reported_content,
-        reports: {
-          reasons: resource.reports.map(&:reason),
-          locale: resource.reports.map(&:locale),
-          details: resource.reports.map(&:details)
-        }
+module DecidimExportersOpenDataModerationSerializerNilReportablePatch
+  def serialize
+    {
+      id: resource.id,
+      hidden_at: resource.hidden_at,
+      report_count: resource.report_count,
+      reported_url: safe_reported_url,
+      reportable_type: resource.decidim_reportable_type,
+      reportable_id: resource.decidim_reportable_id,
+      reported_content: resource.reported_content,
+      reports: {
+        reasons: resource.reports.map(&:reason),
+        locale: resource.reports.map(&:locale),
+        details: resource.reports.map(&:details)
       }
-    end
-
-    private
-
-    # URL 生成は壊れた参照で複数種類の例外を投げうる。
-    # 1 レコードのために組織全体のエクスポートを止めないよう、握って nil を返す。
-    #
-    # 例外クラスを列挙して絞ると、URL 生成の別経路で投げられる例外を取りこぼして
-    # 同じ障害を繰り返す。EngineRouter は route helper を method_missing で呼ぶため
-    # NameError 系だけでなく ActionController::UrlGenerationError も投げうる。
-    #
-    # 一方で StandardError を素通しすると一時的な DB エラーまで飲み込み、
-    # 「参照が消えている」のか「引けなかっただけ」なのか区別できないまま
-    # 空の URL を正常な公開データとして出力してしまう。
-    # そこで広く受けたうえで、一時障害だけは再送出して顕在化させる。
-    TRANSIENT_ERRORS = [
-      ActiveRecord::StatementInvalid,
-      ActiveRecord::ConnectionNotEstablished
-    ].freeze
-
-    def safe_reported_url
-      reportable = resource.reportable
-
-      if reportable.nil?
-        # 物理削除とゴミ箱行きの両方がここに来る。どちらか断定できないため
-        # 「解決できない」とだけ記録する。
-        log_missing_reported_url("reportable could not be resolved (deleted or trashed)")
-        return nil
-      end
-
-      reportable.reported_content_url
-    rescue *TRANSIENT_ERRORS
-      raise
-    rescue StandardError => e
-      log_missing_reported_url("#{e.class}: #{e.message}")
-      nil
-    end
-
-    def log_missing_reported_url(reason)
-      Rails.logger.warn(
-        "[open_data] failed to build reported_url for Decidim::Moderation " \
-        "id=#{resource.id} reportable=#{resource.decidim_reportable_type}##{resource.decidim_reportable_id}: " \
-        "#{reason}"
-      )
-    end
+    }
   end
 
+  private
+
+  # URL 生成は壊れた参照で複数種類の例外を投げうる。
+  # 1 レコードのために組織全体のエクスポートを止めないよう、握って nil を返す。
+  #
+  # 例外クラスを列挙して絞ると、URL 生成の別経路で投げられる例外を取りこぼして
+  # 同じ障害を繰り返す。EngineRouter は route helper を method_missing で呼ぶため
+  # NameError 系だけでなく ActionController::UrlGenerationError も投げうる。
+  #
+  # 一方で StandardError を素通しすると一時的な DB エラーまで飲み込み、
+  # 「参照が消えている」のか「引けなかっただけ」なのか区別できないまま
+  # 空の URL を正常な公開データとして出力してしまう。
+  # そこで広く受けたうえで、一時障害だけは再送出して顕在化させる。
+  # ActiveRecord::StatementInvalid は QueryCanceled だけでなく
+  # PG::UndefinedTable / NoDatabaseError のような恒久的な失敗も含むため使わない。
+  # それらを再送出すると 1 レコードのために毎回エクスポートが止まり続ける。
+  # ConnectionTimeoutError (プール枯渇) は ConnectionNotEstablished の子孫。
+  TRANSIENT_ERRORS = [
+    ActiveRecord::QueryCanceled,
+    ActiveRecord::LockWaitTimeout,
+    ActiveRecord::ConnectionNotEstablished
+  ].freeze
+
+  def safe_reported_url
+    reportable = resource.reportable
+
+    if reportable.nil?
+      # 物理削除とゴミ箱行きの両方がここに来る。どちらか断定できないため
+      # 「解決できない」とだけ記録する。
+      log_missing_reported_url("reportable could not be resolved (deleted or trashed)")
+      return nil
+    end
+
+    reportable.reported_content_url
+  rescue *TRANSIENT_ERRORS
+    raise
+  rescue StandardError => e
+    log_missing_reported_url("#{e.class}: #{e.message}")
+    nil
+  end
+
+  def log_missing_reported_url(reason)
+    Rails.logger.warn(
+      "[open_data] failed to build reported_url for Decidim::Moderation " \
+      "id=#{resource.id} reportable=#{resource.decidim_reportable_type}##{resource.decidim_reportable_id}: " \
+      "#{reason}"
+    )
+  end
+end
+
+Rails.application.config.to_prepare do
   Decidim::Exporters::OpenDataModerationSerializer.prepend(
     DecidimExportersOpenDataModerationSerializerNilReportablePatch
   )

--- a/config/initializers/open_data_moderation_serializer_override.rb
+++ b/config/initializers/open_data_moderation_serializer_override.rb
@@ -60,15 +60,33 @@ Rails.application.config.to_prepare do
 
     # URL 生成は壊れた参照で複数種類の例外を投げうる。
     # 1 レコードのために組織全体のエクスポートを止めないよう、握って nil を返す。
+    #
+    # rescue する例外は実際に観測した壊れ方に絞る。StandardError まで広げると
+    # 一時的な DB エラー (ActiveRecord::StatementInvalid 等) も飲み込んでしまい、
+    # 「参照が消えている」のか「引けなかっただけ」なのか区別できないまま
+    # 空の URL を正常な公開データとして出力することになる。
+    # NameError は NoMethodError (mounted_engine 不在) と
+    # 型名を解決できないケースの両方を含む。
     def safe_reported_url
-      resource.reportable&.reported_content_url
-    rescue StandardError => e
+      reportable = resource.reportable
+
+      if reportable.nil?
+        log_missing_reported_url("dangling reportable")
+        return nil
+      end
+
+      reportable.reported_content_url
+    rescue NameError, ActiveRecord::RecordNotFound => e
+      log_missing_reported_url("#{e.class}: #{e.message}")
+      nil
+    end
+
+    def log_missing_reported_url(reason)
       Rails.logger.warn(
         "[open_data] failed to build reported_url for Decidim::Moderation " \
         "id=#{resource.id} reportable=#{resource.decidim_reportable_type}##{resource.decidim_reportable_id}: " \
-        "#{e.class}: #{e.message}"
+        "#{reason}"
       )
-      nil
     end
   end
 

--- a/config/initializers/open_data_moderation_serializer_override.rb
+++ b/config/initializers/open_data_moderation_serializer_override.rb
@@ -11,9 +11,13 @@
 # 到達しうる例外が単一ではないため、個別の nil ガードではなく
 # reported_url の計算全体を rescue する。本番で確認できたのは以下の 2 経路。
 #
-#   1. reportable が nil
+#   1. reportable が解決できず nil になる
 #      Decidim::Moderation#reportable はポリモーフィック関連で DB の外部キー制約を
 #      張れないため、参照先が物理削除されると dangling になる。
+#      加えて Decidim::Proposals::Proposal と Decidim::Meetings::Meeting は
+#      SoftDeletable であり belongs_to :reportable に with_deleted が無いため、
+#      「提案をゴミ箱に入れただけ」でも nil になる。実運用ではこちらの方が起きやすい。
+#      いずれの経路でも例外ではなく nil が返る (実測確認済み)。
 #
 #   2. reportable は残っているが reportable.component が nil
 #      Decidim::Component は SoftDeletable (acts_as_paranoid) だが
@@ -61,22 +65,33 @@ Rails.application.config.to_prepare do
     # URL 生成は壊れた参照で複数種類の例外を投げうる。
     # 1 レコードのために組織全体のエクスポートを止めないよう、握って nil を返す。
     #
-    # rescue する例外は実際に観測した壊れ方に絞る。StandardError まで広げると
-    # 一時的な DB エラー (ActiveRecord::StatementInvalid 等) も飲み込んでしまい、
+    # 例外クラスを列挙して絞ると、URL 生成の別経路で投げられる例外を取りこぼして
+    # 同じ障害を繰り返す。EngineRouter は route helper を method_missing で呼ぶため
+    # NameError 系だけでなく ActionController::UrlGenerationError も投げうる。
+    #
+    # 一方で StandardError を素通しすると一時的な DB エラーまで飲み込み、
     # 「参照が消えている」のか「引けなかっただけ」なのか区別できないまま
-    # 空の URL を正常な公開データとして出力することになる。
-    # NameError は NoMethodError (mounted_engine 不在) と
-    # 型名を解決できないケースの両方を含む。
+    # 空の URL を正常な公開データとして出力してしまう。
+    # そこで広く受けたうえで、一時障害だけは再送出して顕在化させる。
+    TRANSIENT_ERRORS = [
+      ActiveRecord::StatementInvalid,
+      ActiveRecord::ConnectionNotEstablished
+    ].freeze
+
     def safe_reported_url
       reportable = resource.reportable
 
       if reportable.nil?
-        log_missing_reported_url("dangling reportable")
+        # 物理削除とゴミ箱行きの両方がここに来る。どちらか断定できないため
+        # 「解決できない」とだけ記録する。
+        log_missing_reported_url("reportable could not be resolved (deleted or trashed)")
         return nil
       end
 
       reportable.reported_content_url
-    rescue NameError, ActiveRecord::RecordNotFound => e
+    rescue *TRANSIENT_ERRORS
+      raise
+    rescue StandardError => e
       log_missing_reported_url("#{e.class}: #{e.message}")
       nil
     end

--- a/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
+++ b/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
@@ -66,36 +66,28 @@ RSpec.describe "Decidim::Exporters::OpenDataModerationSerializer nil reportable 
     end
   end
 
-  # 一時障害まで握り潰すと、空の URL が正常な公開データとして出力されてしまう。
-  context "when the url generation hits a transient database error" do
-    let(:reportable) { create(:proposal, component:) }
-    let(:moderation) { create(:moderation, :hidden, reportable:) }
+  # 例外クラスを列挙して絞ると別経路を取りこぼすため StandardError を広く受ける。
+  # 一時障害と恒久障害は例外クラスで判別できない (PostgreSQL の接続断もデッドロックも
+  # 素の StatementInvalid に落ちる) ので、ここでは区別せず握って nil を返す。
+  # DB 障害はこの rescue を抜けた先の他マニフェスト処理で顕在化する。
+  [
+    [ActiveRecord::StatementInvalid, "server closed the connection unexpectedly"],
+    [ActionController::UrlGenerationError, "no route matches"],
+    [NoMethodError, "undefined method `mounted_engine'"]
+  ].each do |error_class, message|
+    context "when the url generation raises #{error_class}" do
+      let(:reportable) { create(:proposal, component:) }
+      let(:moderation) { create(:moderation, :hidden, reportable:) }
 
-    before do
-      allow(moderation).to receive(:reportable)
-        .and_raise(ActiveRecord::QueryCanceled, "statement timeout")
-    end
+      before do
+        allow(moderation).to receive(:reportable).and_return(reportable)
+        allow(reportable).to receive(:reported_content_url).and_raise(error_class, message)
+      end
 
-    it "re-raises instead of publishing an empty url" do
-      expect { subject }.to raise_error(ActiveRecord::QueryCanceled)
-    end
-  end
-
-  # 一方 ActiveRecord::StatementInvalid には PG::UndefinedTable のような恒久的な失敗も
-  # 含まれる。これを再送出すると 1 レコードのために毎回エクスポートが止まり続けるため、
-  # 握って nil を返す側に倒す。
-  context "when the url generation hits a permanent schema error" do
-    let(:reportable) { create(:proposal, component:) }
-    let(:moderation) { create(:moderation, :hidden, reportable:) }
-
-    before do
-      allow(moderation).to receive(:reportable)
-        .and_raise(ActiveRecord::StatementInvalid, "relation does not exist")
-    end
-
-    it "does not raise and leaves the reported url empty" do
-      expect { subject }.not_to raise_error
-      expect(subject[:reported_url]).to be_nil
+      it "does not raise and leaves the reported url empty" do
+        expect { subject }.not_to raise_error
+        expect(subject[:reported_url]).to be_nil
+      end
     end
   end
 

--- a/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
+++ b/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe "Decidim::Exporters::OpenDataModerationSerializer nil reportable override" do
-  subject { Decidim::Exporters::OpenDataModerationSerializer.new(moderation).serialize }
+  subject { described_serializer.new(moderation).serialize }
+
+  let(:described_serializer) { Decidim::Exporters::OpenDataModerationSerializer }
 
   let(:organization) { create(:organization) }
   let(:participatory_process) { create(:participatory_process, organization:) }
@@ -18,13 +20,14 @@ RSpec.describe "Decidim::Exporters::OpenDataModerationSerializer nil reportable 
     end
 
     # override は serialize 全体を差し替えているため、上流がフィールドを追加しても
-    # 気づかずに欠落しうる。キー集合を固定して差分を検知する。
+    # 気づかずに欠落しうる。ハードコードした一覧と比べても「今の形」同士の比較にしかならず
+    # 上流の変更を検知できないので、super_method で上流実装を直接呼んで突き合わせる。
     it "keeps the upstream key set" do
-      expect(subject.keys).to contain_exactly(
-        :id, :hidden_at, :report_count, :reported_url,
-        :reportable_type, :reportable_id, :reported_content, :reports
-      )
-      expect(subject[:reports].keys).to contain_exactly(:reasons, :locale, :details)
+      serializer = described_serializer.new(moderation)
+      upstream = described_serializer.instance_method(:serialize).super_method.bind(serializer).call
+
+      expect(subject.keys).to match_array(upstream.keys)
+      expect(subject[:reports].keys).to match_array(upstream[:reports].keys)
     end
   end
 

--- a/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
+++ b/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe "Decidim::Exporters::OpenDataModerationSerializer nil reportable 
     it "serializes the reported url" do
       expect(subject[:reported_url]).to eq(reportable.reported_content_url)
     end
+
+    # override は serialize 全体を差し替えているため、上流がフィールドを追加しても
+    # 気づかずに欠落しうる。キー集合を固定して差分を検知する。
+    it "keeps the upstream key set" do
+      expect(subject.keys).to contain_exactly(
+        :id, :hidden_at, :report_count, :reported_url,
+        :reportable_type, :reportable_id, :reported_content, :reports
+      )
+      expect(subject[:reports].keys).to contain_exactly(:reasons, :locale, :details)
+    end
   end
 
   # Decidim::Moderation#reportable はポリモーフィック関連のため DB の外部キー制約を張れず、
@@ -43,6 +53,38 @@ RSpec.describe "Decidim::Exporters::OpenDataModerationSerializer nil reportable 
       expect(subject[:id]).to eq(moderation.id)
       expect(subject[:reportable_id]).to eq(reportable.id)
       expect(subject[:reportable_type]).to eq(reportable.class.name)
+      expect(subject[:hidden_at]).to be_present
+    end
+  end
+
+  # Decidim::Component は SoftDeletable だが Decidim::HasComponent の belongs_to は
+  # with_deleted を付けていないため、管理画面からコンポーネントをゴミ箱に入れると
+  # reportable は残ったまま reportable.component だけが nil になる。
+  # その状態で reported_content_url を呼ぶと EngineRouter が target に対して
+  # mounted_engine を呼び NoMethodError になる。
+  context "when the reportable's component has been soft-deleted" do
+    let(:reportable) { create(:proposal, component:) }
+    let!(:moderation) { create(:moderation, :hidden, reportable:) }
+
+    before do
+      component.destroy
+      moderation.reload
+      reportable.reload
+    end
+
+    it "still resolves the reportable but not its component" do
+      expect(moderation.reportable).to be_present
+      expect(reportable.component).to be_nil
+    end
+
+    it "does not raise and leaves the reported url empty" do
+      expect { subject }.not_to raise_error
+      expect(subject[:reported_url]).to be_nil
+    end
+
+    it "still serializes the moderation attributes" do
+      expect(subject[:id]).to eq(moderation.id)
+      expect(subject[:reportable_id]).to eq(reportable.id)
       expect(subject[:hidden_at]).to be_present
     end
   end

--- a/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
+++ b/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
@@ -19,15 +19,19 @@ RSpec.describe "Decidim::Exporters::OpenDataModerationSerializer nil reportable 
       expect(subject[:reported_url]).to eq(reportable.reported_content_url)
     end
 
-    # override は serialize 全体を差し替えているため、上流がフィールドを追加しても
-    # 気づかずに欠落しうる。ハードコードした一覧と比べても「今の形」同士の比較にしかならず
-    # 上流の変更を検知できないので、super_method で上流実装を直接呼んで突き合わせる。
-    it "keeps the upstream key set" do
-      serializer = described_serializer.new(moderation)
-      upstream = described_serializer.instance_method(:serialize).super_method.bind(serializer).call
+    # override は serialize 全体を差し替えているため、上流がフィールドを追加したり
+    # 値の算出方法を変えたりしても気づかずに取り残される。ハードコードした一覧と比べても
+    # 「今の形」同士の比較にしかならないので、super_method で上流実装を直接呼んで
+    # 戻り値ごと突き合わせる。
+    it "matches the upstream output for a healthy record" do
+      overridden = described_serializer.instance_method(:serialize).super_method
 
-      expect(subject.keys).to match_array(upstream.keys)
-      expect(subject[:reports].keys).to match_array(upstream[:reports].keys)
+      # 上流が修正されて initializer を削除したらここで気づけるようにする。
+      expect(overridden).not_to be_nil,
+                                "override が適用されていない。上流が修正済みなら initializer と本 spec を削除すること"
+
+      upstream = overridden.bind(described_serializer.new(moderation)).call
+      expect(subject).to eq(upstream)
     end
   end
 
@@ -57,6 +61,43 @@ RSpec.describe "Decidim::Exporters::OpenDataModerationSerializer nil reportable 
       expect(subject[:reportable_id]).to eq(reportable.id)
       expect(subject[:reportable_type]).to eq(reportable.class.name)
       expect(subject[:hidden_at]).to be_present
+    end
+  end
+
+  # 一時障害まで握り潰すと、空の URL が正常な公開データとして出力されてしまう。
+  context "when the url generation hits a transient database error" do
+    let(:reportable) { create(:proposal, component:) }
+    let(:moderation) { create(:moderation, :hidden, reportable:) }
+
+    before do
+      allow(moderation).to receive(:reportable)
+        .and_raise(ActiveRecord::StatementInvalid, "statement timeout")
+    end
+
+    it "re-raises instead of publishing an empty url" do
+      expect { subject }.to raise_error(ActiveRecord::StatementInvalid)
+    end
+  end
+
+  # Decidim::Proposals::Proposal は SoftDeletable であり belongs_to :reportable に
+  # with_deleted が無いため、ゴミ箱に入れるだけで reportable が nil になる。
+  # 実運用ではこちらの方が物理削除より起きやすい。
+  context "when the reportable has been trashed" do
+    let(:reportable) { create(:proposal, component:) }
+    let!(:moderation) { create(:moderation, :hidden, reportable:) }
+
+    before do
+      reportable.destroy
+      moderation.reload
+    end
+
+    it "resolves the reportable to nil" do
+      expect(moderation.reportable).to be_nil
+    end
+
+    it "does not raise and leaves the reported url empty" do
+      expect { subject }.not_to raise_error
+      expect(subject[:reported_url]).to be_nil
     end
   end
 

--- a/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
+++ b/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
@@ -26,9 +26,11 @@ RSpec.describe "Decidim::Exporters::OpenDataModerationSerializer nil reportable 
     it "matches the upstream output for a healthy record" do
       overridden = described_serializer.instance_method(:serialize).super_method
 
-      # 上流が修正されて initializer を削除したらここで気づけるようにする。
-      expect(overridden).not_to be_nil,
-                                "override が適用されていない。上流が修正済みなら initializer と本 spec を削除すること"
+      # 親クラス Decidim::Exporters::Serializer も serialize を定義しているため、
+      # override 未適用でも super_method は非 nil (親のメソッド) になる。
+      # nil 判定では検知できないので owner を確認する。
+      expect(overridden&.owner).to eq(described_serializer),
+                                   "override が適用されていない。上流が修正済みなら initializer と本 spec を削除すること"
 
       upstream = overridden.bind(described_serializer.new(moderation)).call
       expect(subject).to eq(upstream)
@@ -71,11 +73,29 @@ RSpec.describe "Decidim::Exporters::OpenDataModerationSerializer nil reportable 
 
     before do
       allow(moderation).to receive(:reportable)
-        .and_raise(ActiveRecord::StatementInvalid, "statement timeout")
+        .and_raise(ActiveRecord::QueryCanceled, "statement timeout")
     end
 
     it "re-raises instead of publishing an empty url" do
-      expect { subject }.to raise_error(ActiveRecord::StatementInvalid)
+      expect { subject }.to raise_error(ActiveRecord::QueryCanceled)
+    end
+  end
+
+  # 一方 ActiveRecord::StatementInvalid には PG::UndefinedTable のような恒久的な失敗も
+  # 含まれる。これを再送出すると 1 レコードのために毎回エクスポートが止まり続けるため、
+  # 握って nil を返す側に倒す。
+  context "when the url generation hits a permanent schema error" do
+    let(:reportable) { create(:proposal, component:) }
+    let(:moderation) { create(:moderation, :hidden, reportable:) }
+
+    before do
+      allow(moderation).to receive(:reportable)
+        .and_raise(ActiveRecord::StatementInvalid, "relation does not exist")
+    end
+
+    it "does not raise and leaves the reported url empty" do
+      expect { subject }.not_to raise_error
+      expect(subject[:reported_url]).to be_nil
     end
   end
 

--- a/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
+++ b/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Decidim::Exporters::OpenDataModerationSerializer nil reportable override" do
+  subject { Decidim::Exporters::OpenDataModerationSerializer.new(moderation).serialize }
+
+  let(:organization) { create(:organization) }
+  let(:participatory_process) { create(:participatory_process, organization:) }
+  let(:component) { create(:proposal_component, participatory_space: participatory_process) }
+
+  context "when the moderation has an associated reportable" do
+    let(:reportable) { create(:proposal, component:) }
+    let(:moderation) { create(:moderation, :hidden, reportable:) }
+
+    it "serializes the reported url" do
+      expect(subject[:reported_url]).to eq(reportable.reported_content_url)
+    end
+  end
+
+  # Decidim::Moderation#reportable はポリモーフィック関連のため DB の外部キー制約を張れず、
+  # 参照先が物理削除されると dangling になる。collection は hidden スコープで絞り込むだけで
+  # reportable の存在を確認しないため、nil でも NoMethodError にならないこと。
+  context "when the reportable no longer exists" do
+    let(:reportable) { create(:proposal, component:) }
+    let!(:moderation) { create(:moderation, :hidden, reportable:) }
+
+    before do
+      reportable.class.where(id: reportable.id).delete_all
+      moderation.reload
+    end
+
+    it "has no reportable" do
+      expect(moderation.reportable).to be_nil
+    end
+
+    it "does not raise and leaves the reported url empty" do
+      expect { subject }.not_to raise_error
+      expect(subject[:reported_url]).to be_nil
+    end
+
+    it "still serializes the moderation attributes" do
+      expect(subject[:id]).to eq(moderation.id)
+      expect(subject[:reportable_id]).to eq(reportable.id)
+      expect(subject[:reportable_type]).to eq(reportable.class.name)
+      expect(subject[:hidden_at]).to be_present
+    end
+  end
+end

--- a/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
+++ b/spec/config/initializers/open_data_moderation_serializer_override_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe "Decidim::Exporters::OpenDataModerationSerializer nil reportable 
       expect(subject[:reported_url]).to be_nil
     end
 
+    # ゴミ箱行きは管理者の通常運用で発生するため warn だと件数分ノイズになる。
+    # 異常を示す例外側の warn と区別できるようにする。
+    it "logs at info rather than warn" do
+      allow(Rails.logger).to receive(:info)
+      allow(Rails.logger).to receive(:warn)
+
+      subject
+
+      expect(Rails.logger).to have_received(:info).with(/could not be resolved/)
+      expect(Rails.logger).not_to have_received(:warn)
+    end
+
     it "still serializes the moderation attributes" do
       expect(subject[:id]).to eq(moderation.id)
       expect(subject[:reportable_id]).to eq(reportable.id)
@@ -87,6 +99,14 @@ RSpec.describe "Decidim::Exporters::OpenDataModerationSerializer nil reportable 
       it "does not raise and leaves the reported url empty" do
         expect { subject }.not_to raise_error
         expect(subject[:reported_url]).to be_nil
+      end
+
+      it "logs at warn" do
+        allow(Rails.logger).to receive(:warn)
+
+        subject
+
+        expect(Rails.logger).to have_received(:warn).with(/#{error_class}/)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

**#869 の続きです。** `moderated_users` の `NoMethodError` を解消した結果、その次に処理される `moderations` で隠れていた問題が表に出ました。

`moderations` の collection は `participatory_space` と `hidden` でしか絞り込まないため、**URL を生成できないレコードが1件でもあると ZIP 生成が中断され、提案も会議もユーザーも一切出力されません。**

```ruby
# decidim-core/app/serializers/decidim/exporters/open_data_moderation_serializer.rb:17
reported_url: resource.reportable.reported_content_url,   # ← 壊れた参照で例外
```

##### 到達しうる失敗経路は1つではありません

本番の全 moderation を実際に走査して確認したところ、**2種類の経路**がありました。

**① `reportable` が nil**

`Decidim::Moderation#reportable` は**ポリモーフィック関連**のため DB の外部キー制約を張れず、参照先（提案・コメント等）が物理削除されると dangling になります。

```ruby
belongs_to :reportable, foreign_key: "decidim_reportable_id",
           foreign_type: "decidim_reportable_type", polymorphic: true, touch: true
```

**② `reportable` は残っているが `reportable.component` が nil**

`Decidim::Component` は `SoftDeletable`（`acts_as_paranoid`）ですが、`Decidim::HasComponent` の `belongs_to :component` に `with_deleted` が付いていません。

```ruby
# decidim-core/lib/decidim/has_component.rb:12
belongs_to :component, foreign_key: "decidim_component_id", class_name: "Decidim::Component", touch: true
```

**管理画面からコンポーネントをゴミ箱に入れると、中の提案やコメントは trash されないまま `component` だけが引けなくなります。** その状態で `reported_content_url` を呼ぶと、

```
reported_content_url
  → ResourceLocatorPresenter#index / #url
  → route_proxy → EngineRouter.main_proxy(component || target)   # component が nil なので target を渡す
  → target.mounted_engine
```

`mounted_engine` は `Decidim::Component` と `Decidim::Participable` にしか定義されていないため、Proposal/Comment では `NoMethodError: undefined method 'mounted_engine'` になります。

こちらは**管理画面から普通に到達できる経路**です。

##### 本番の実測

`hidden` な moderation を全件走査した結果です。

```
ok = 86 / reportable が nil = 1 / component が nil = 1 / その他 = 0
```

**この2件のせいで、該当する2組織のオープンデータが一切出力されていませんでした。**

- ① `nishiaizu.makeour.city`
- ② `_delete_tsukubaihss_diycities_jp` の `Decidim::Comments::Comment id=12563`

なお本番デプロイ（v1.20.0、#869 込み）後に `OpenDataJob` の完走率は **9.5% → 64%** に改善しています。本 PR は残る失敗のうちこの2件を解消します。

#### :warning: バージョン追従では直りません

当該 serializer は **0.30.9 / 0.31.7 / 0.32.1 / develop のいずれでも同一内容で未修正**です（差分ゼロ）。

上流には issue を作成済みです（`moderated_users` と GraphQL の2箇所について）。本件も同 issue にフォローアップとして報告予定です。

- decidim/decidim#17574

#### :clipboard: 変更内容

`config/initializers/open_data_moderation_serializer_override.rb`（新規）

**個別の nil ガードではなく、URL 生成全体を rescue します。**

```ruby
reported_url: safe_reported_url,

private

def safe_reported_url
  reportable = resource.reportable

  if reportable.nil?
    # 物理削除とゴミ箱行きの両方がここに来る。どちらか断定できないため
    # 「解決できない」とだけ記録する。
    log_missing_reported_url("reportable could not be resolved (deleted or trashed)")
    return nil
  end

  reportable.reported_content_url
rescue StandardError => e
  log_missing_reported_url("#{e.class}: #{e.message}")
  nil
end
```

`resource.reportable&.` だけでは①しか防げず、②が残ります。また `EngineRouter` は route helper を `method_missing` で呼ぶため、到達しうる例外は `NoMethodError` / `NameError` に限らず `ActionController::UrlGenerationError` も含みます。**例外クラスを列挙して絞ると別経路を取りこぼして同じ障害を繰り返す**ため、`StandardError` を広く受けます。

##### 「DB 障害を握り潰して空の URL を公開してしまうのでは」への回答

一時障害だけ再送出する案も検討しましたが、**PostgreSQL では一時障害と恒久障害を例外クラスで判別できません**。`PostgreSQLAdapter#translate_exception`（activerecord-7.0.10）が `ConnectionNotEstablished` に変換するのはメッセージが `/connection is closed/i` に一致した場合だけで、実際の接続断（`server closed the connection unexpectedly`）やデッドロックは素の `StatementInvalid` に落ちます。逆に `StatementInvalid` には `PG::UndefinedTable` のような恒久障害も含まれます。

また再送出自体が本 PR の目的と衝突します。プール枯渇はジョブが並走している現状では起きやすく、1レコードのために ZIP が落ち → 302 → 再投入 → さらに並走、という自己増幅になります。

代わりに、**DB 障害はこの rescue を抜けた先で必ず顕在化する**ことに依存します。`OpenDataExporter#data_for_all_resources` は `moderations` の後に `users` / `user_groups` / `taxonomies` と全コンポーネント・全空間を順に処理しており、いずれも DB アクセスを伴います。接続が落ちていればそちらで例外になり ZIP は生成されないため、壊れたデータが正常な成果物として公開されることはありません。

元実装が `resource.reportable.reported_content_url` を直接呼ぶ構造のため **`super` は使えません**（super の中で例外が起きる）。`serialize` 全体を差し替えています。#869 と同じ方針です。

`spec/config/initializers/open_data_moderation_serializer_override_spec.rb`（新規、13 examples）

- `reportable` あり → 従来どおり `reported_content_url` が入る
- **上流実装との突き合わせ** — `serialize` 全体を差し替えている都合上、上流がフィールドを追加したり値の算出を変えたりしても気づけない。ハードコードした一覧と比べても「今の形」同士の比較にしかならないため、`super_method` で上流実装を直接呼んで戻り値ごと比較する
- **①** `reportable` が物理削除 → 例外なし・`reported_url` が nil
- **①'** `reportable` がゴミ箱行き（`Proposal` / `Meeting` は `SoftDeletable`）→ 同上。**実運用では物理削除よりこちらが起きやすい**
- **②** `component` がソフトデリート → 例外なし・`reported_url` が nil（**実際の本番トリガー**）
- 到達しうる例外3種（`StatementInvalid` / `UrlGenerationError` / `NoMethodError`）で握って nil を返すこと
- いずれも moderation の属性（`id` / `reportable_id` / `reportable_type` / `hidden_at`）は変わらず出力される

#### :white_check_mark: 検証（Docker 環境で実施）

| 項目 | 結果 |
|---|---|
| `bin/rails runner` で prepend の適用確認 | ✅ `serialize` の owner が patch モジュール |
| **#869 の override との併存** | ✅ 両方とも正しく適用されている |
| **②の再現確認** | ✅ 修正前の実装で `NoMethodError: undefined method 'mounted_engine'` を再現 |
| `bundle exec rspec` | ✅ **13 examples, 0 failures**（`spec/config/initializers/` 全体で 55） |
| **spec の有効性** | ✅ `rescue` を外すと **2 failures**、戻すと 0 |
| `bundle exec rubocop` | ✅ **no offenses detected** |
| **spec の実効性** | ✅ override を外すと **13件中9件が失敗**（テストが実際に修正を検証している） |

#### :clipboard: Subtasks

- [x] Add `CHANGELOG` upgrade notes, if required（release-please 運用のため手編集なし）
- [x] If there's a new public field, add it to GraphQL API（対象外）
- [x] Add documentation regarding the feature（`docs/superpowers/prd-infra-issues-2026-08.md` の問題4 に一連の調査を記録）
- [x] Add/modify seeds（対象外）
- [x] Add tests

#### :mag: 残る失敗要因について（本 PR の範囲外）

デプロイ後の失敗にはもう1種類 `Errno::ENOENT` があります。調べたところ **`OpenDataJob` の `File.delete(path)` で発生**していました。

```
Errno::ENOENT (No such file or directory @ apply2files - /app/tmp/meta.diycities.jp-open-data-moderated_users.csv)
```

`tmp/<host>-open-data-<resource>.csv` というパスが**完全に決定的**なため、同じ `(organization, resource)` の組み合わせでジョブが並走すると、一方の `File.delete` がもう一方の処理中のファイルを消してしまいます。

これは `/open-data/download` が 302 を返すたびに `schedule_open_data_generation` がジョブを再投入していたことの副作用です。**エクスポートが成功して 200 が返るようになれば再投入ループが止まり、並走も収束する見込み**なので、本 PR の効果を測ってから対応要否を判断します（30日で27件、失敗全体の 0.5%）。
