### PR TITLE
fix(meetings): 管理画面のミーティング複製が必ず 500 になる問題を修正

### DIFF
--- a/config/initializers/meeting_copy_taxonomies_override.rb
+++ b/config/initializers/meeting_copy_taxonomies_override.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# 管理画面のミーティング「複製」が Decidim 0.30.x では必ず 500 になるため、その修正。
+#
+# Decidim::Meetings::Admin::CopyMeeting は Meeting.create! に
+# `taxonomies: form.taxonomies` を渡すが、フォーム側の
+# Decidim::HasTaxonomyFormAttributes は `attribute :taxonomies, Array[Integer]`
+# を宣言しているため、返るのは Decidim::Taxonomy ではなくタクソノミーの id 配列。
+# コンポーネントの設定にタクソノミーフィルタがあると複製フォームに select が出るので、
+# 選択の有無に関わらず ActiveRecord::AssociationTypeMismatch になる。
+#
+#   未選択  -> hidden の空文字が Integer キャストで nil -> "expected, got nil"
+#   選択済み -> id がそのまま Integer で渡る            -> "expected, got 18"
+#
+# CreateMeeting / UpdateMeeting は既に `form.taxonomizations` を使っており、
+# ここでも同じものを渡すようにする。
+#
+# 本家: decidim/decidim#15718 を decidim/decidim#15736 で修正済み。
+# v0.31.1 以降に入っているが release/0.30-stable にはバックポートされておらず
+# （0.30.9 が 0.30 系の最終リリース）、自前で持つしかない。
+#
+# 削除手順: Decidim 0.31.1 以上に上げたらこのファイルごと消す。
+Rails.application.config.to_prepare do
+  module DecidimCfjMeetingCopyTaxonomiesPatch
+    private
+
+    # Decidim::Meetings::Admin::CopyMeeting#copy_meeting! (v0.30.9) のコピーに、
+    # `taxonomies:` -> `taxonomizations:` の変更を入れたもの。
+    # Decidim を上げる際は本家の実装と差分が出ていないか確認すること。
+    def copy_meeting!
+      parsed_title = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.title, current_organization: meeting.organization).rewrite
+      parsed_description = Decidim::ContentProcessor.parse_with_processor(:hashtag, form.description, current_organization: meeting.organization).rewrite
+
+      @copied_meeting = Decidim.traceability.create!(
+        Decidim::Meetings::Meeting,
+        form.current_user,
+        taxonomizations: form.taxonomizations,
+        title: parsed_title,
+        description: parsed_description,
+        end_time: form.end_time,
+        start_time: form.start_time,
+        address: form.address,
+        latitude: form.latitude,
+        longitude: form.longitude,
+        location: form.location,
+        location_hints: form.location_hints,
+        component: meeting.component,
+        private_meeting: form.private_meeting,
+        transparent: form.transparent,
+        author: form.current_organization,
+        questionnaire: form.questionnaire,
+        online_meeting_url: form.online_meeting_url,
+        type_of_meeting: form.type_of_meeting,
+        iframe_embed_type: form.iframe_embed_type,
+        iframe_access_level: form.iframe_access_level,
+        comments_enabled: form.comments_enabled,
+        comments_start_time: form.comments_start_time,
+        comments_end_time: form.comments_end_time,
+        registration_type: form.registration_type,
+        registration_url: form.registration_url,
+        **fields_from_meeting
+      )
+    end
+  end
+
+  Decidim::Meetings::Admin::CopyMeeting.prepend(DecidimCfjMeetingCopyTaxonomiesPatch)
+end

--- a/config/initializers/meeting_copy_taxonomies_override.rb
+++ b/config/initializers/meeting_copy_taxonomies_override.rb
@@ -19,7 +19,17 @@
 # v0.31.1 以降に入っているが release/0.30-stable にはバックポートされておらず
 # （0.30.9 が 0.30 系の最終リリース）、自前で持つしかない。
 #
-# 削除手順: Decidim 0.31.1 以上に上げたらこのファイルごと消す。
+# 削除手順: Decidim 0.31.1 以上に上げたら、このファイルとスペックごと消す。
+#
+# 消し忘れると prepend が黙って勝つ。0.31 以降の copy_meeting! は
+# reminder_enabled / send_reminders_before_hours / reminder_message_custom_content の
+# 引き渡しとインライン画像処理が増えているため、このコピーが残っていると
+# 複製されたミーティングからそれらが抜け落ちる。例外は出ずスペックも通ってしまうので、
+# 0.30 系以外では起動時に落として気付けるようにしておく。
+if Gem::Version.new(Decidim::Core.version).segments.first(2) != [0, 30]
+  raise "meeting_copy_taxonomies_override.rb and related specs should be removed in 0.31.x (decidim/decidim#15736)"
+end
+
 Rails.application.config.to_prepare do
   module DecidimCfjMeetingCopyTaxonomiesPatch
     private

--- a/spec/config/initializers/meeting_copy_taxonomies_override_spec.rb
+++ b/spec/config/initializers/meeting_copy_taxonomies_override_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# decidim-meetings 0.30.9 の CopyMeeting は Meeting.create! に
+# `taxonomies: form.taxonomies` を渡すが、フォームが返すのは
+# Decidim::Taxonomy ではなくタクソノミーの id 配列なので、
+# コンポーネントにタクソノミーフィルタがあると必ず
+# ActiveRecord::AssociationTypeMismatch になる。
+RSpec.describe "Decidim::Meetings::Admin::CopyMeeting taxonomies override" do
+  subject(:command) { Decidim::Meetings::Admin::CopyMeeting.new(form, meeting) }
+
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :confirmed, :admin, organization:) }
+  let(:participatory_process) { create(:participatory_process, organization:) }
+  let(:current_component) do
+    create(:component, manifest_name: :meetings, participatory_space: participatory_process)
+  end
+  let!(:meeting) { create(:meeting, component: current_component) }
+
+  let(:root_taxonomy) { create(:taxonomy, organization:) }
+  let!(:taxonomy) { create(:taxonomy, parent: root_taxonomy, organization:) }
+  let(:taxonomy_filter) { create(:taxonomy_filter, root_taxonomy:) }
+  let!(:taxonomy_filter_item) { create(:taxonomy_filter_item, taxonomy_filter:, taxonomy_item: taxonomy) }
+
+  # 複製フォームの select は未選択でも hidden の空文字を送ってくるので、
+  # 本番と同じく先頭に "" が入った配列を渡す。
+  let(:submitted_taxonomies) { [""] }
+
+  let(:params) do
+    {
+      meeting: {
+        title: { ja: "懇親会", en: "Get-together" },
+        description: { ja: "<p>複製のテストです。</p>", en: "<p>A copy test.</p>" },
+        location: { ja: "会議室", en: "Meeting room" },
+        location_hints: { ja: "", en: "" },
+        type_of_meeting: "in_person",
+        address: "スマートシティAiCT",
+        latitude: 37.4922258,
+        longitude: 139.9301371,
+        start_time: 1.day.from_now,
+        end_time: 1.day.from_now + 2.hours,
+        taxonomies: submitted_taxonomies,
+        registration_type: "registration_disabled",
+        private_meeting: "0",
+        transparent: "0",
+        comments_enabled: "1"
+      }
+    }
+  end
+
+  let(:form) do
+    Decidim::Meetings::Admin::MeetingForm.from_params(params, current_component:).with_context(
+      current_organization: organization,
+      current_component:,
+      current_participatory_space: participatory_process,
+      current_user: user
+    )
+  end
+
+  before do
+    current_component.update!(settings: { taxonomy_filters: [taxonomy_filter.id] })
+  end
+
+  it "はフォームからタクソノミーの id 配列を受け取る" do
+    expect(form).to be_valid
+    expect(form.taxonomies).to all(be_nil.or(be_a(Integer)))
+  end
+
+  context "when no taxonomy is selected" do
+    it "は例外を出さずに複製する" do
+      expect { command.call }.to change(Decidim::Meetings::Meeting, :count).by(1)
+    end
+
+    it "はタクソノミーなしの複製を作る" do
+      command.call
+
+      copied_meeting = Decidim::Meetings::Meeting.order(:id).last
+      expect(copied_meeting.taxonomies).to be_empty
+      expect(translated(copied_meeting.title, locale: :ja)).to eq("懇親会")
+    end
+  end
+
+  context "when a taxonomy is selected" do
+    let(:submitted_taxonomies) { ["", taxonomy.id.to_s] }
+
+    it "は例外を出さずに複製する" do
+      expect { command.call }.to change(Decidim::Meetings::Meeting, :count).by(1)
+    end
+
+    it "は選択されたタクソノミーを複製先に引き継ぐ" do
+      command.call
+
+      copied_meeting = Decidim::Meetings::Meeting.order(:id).last
+      expect(copied_meeting.taxonomies).to eq([taxonomy])
+    end
+  end
+end


### PR DESCRIPTION
## 何を / なぜ

AiCT（aict.makeour.city）で「ミーティングを複製できない」という問い合わせがあり調査したところ、Decidim 0.30.x 本体のバグでした。

管理画面の複製フォームを送信すると、以下で 500 になります。

```
ActiveRecord::AssociationTypeMismatch (Decidim::Taxonomy(#973040) expected, got nil which is an instance of NilClass)
  decidim-meetings (0.30.9) app/commands/decidim/meetings/admin/copy_meeting.rb:44:in `copy_meeting!'
  decidim-meetings (0.30.9) app/controllers/decidim/meetings/admin/meeting_copies_controller.rb:22:in `create'
```

`CopyMeeting#copy_meeting!` が `Meeting.create!` に `taxonomies: form.taxonomies` を渡していますが、フォーム側の `Decidim::HasTaxonomyFormAttributes` は `attribute :taxonomies, Array[Integer]` を宣言しているため、返るのは `Decidim::Taxonomy` ではなくタクソノミーの **id 配列** です。

コンポーネントの設定にタクソノミーフィルタがある（＝複製フォームに select が出る）と、**選択の有無に関わらず**落ちます。

| 状態 | 渡る値 | エラー |
|---|---|---|
| 未選択 | hidden の空文字が Integer キャストで `nil` | `expected, got nil` |
| 選択済み | id がそのまま `Integer` | `expected, got 18` |

`CreateMeeting` / `UpdateMeeting` は既に `form.taxonomizations` を使っており、0.30.9 全体で `taxonomies: form.taxonomies` を使っているのは `CopyMeeting` のこの 1 箇所だけでした。

## どう直したか

`Decidim::Meetings::Admin::CopyMeeting` に prepend して `copy_meeting!` を差し替え、`taxonomies:` → `taxonomizations:` にしています。本家の修正と同じ内容です。

- 本家 Issue: decidim/decidim#15718
- 本家 PR: decidim/decidim#15736
- 修正が入っているのは **v0.31.1 以降**。`release/0.30-stable` にはバックポートされておらず（`no-backport` ラベル付き、0.30.9 が 0.30 系の最終リリース）、本番が 0.30.9 である以上こちらで持つしかありません。

`config/initializers/meeting_copy_taxonomies_override.rb` に削除条件をコメントで書いてあります。**Decidim 0.31.1 以上に上げた時点でファイルごと削除してください。**

## テスト

`spec/config/initializers/meeting_copy_taxonomies_override_spec.rb` を追加しました。実際の `MeetingForm.from_params` を通し、本番と同じ `taxonomies=[""]` / `["", "<id>"]` を投げています。

修正なし（initializer を外した状態）:

```
5 examples, 4 failures
  ActiveRecord::AssociationTypeMismatch (未選択・選択済みの両方で発生)
```

修正あり:

```
5 examples, 0 failures
```

RuboCop も通過済みです。