### PR TITLE
fix(system): backport password confirmation in system admin

### DIFF
--- a/config/initializers/system_admin_form_override.rb
+++ b/config/initializers/system_admin_form_override.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Backport of decidim/decidim#17332 for Decidim::System::AdminForm.
+#
+# Fixed upstream in 0.31 (#17341) and 0.32 (#17340). release/0.30-stable stopped
+# taking backports before it landed, so it has to live here.
+#
+# Only the edit-time half is added: the upstream validations already cover
+# creation, and duplicating them would show the message twice.
+#
+# Removal: delete this file and its spec once Decidim is 0.31 or newer. Upstream
+# then registers equivalent validations, and leaving these in place would report
+# the same error twice, so the guard below fails the boot on any other series.
+raise "system_admin_form_override.rb and its spec should be removed in 0.31.x (decidim/decidim#17332)" if Gem::Version.new(Decidim::Core.version).segments.first(2) != [0, 30]
+
+module DecidimCfjSystemAdminFormPasswordConfirmationPatch
+  # A confirmation typed on its own is a mismatch too, so it has to trigger the
+  # validation.
+  def password_submitted?
+    password.present? || password_confirmation.present?
+  end
+end
+
+Rails.application.config.to_prepare do
+  Decidim::System::AdminForm # rubocop:disable Lint/Void
+
+  unless Decidim::System::AdminForm.include?(DecidimCfjSystemAdminFormPasswordConfirmationPatch)
+    Decidim::System::AdminForm.include(DecidimCfjSystemAdminFormPasswordConfirmationPatch)
+
+    Decidim::System::AdminForm.validates(
+      :password,
+      confirmation: true,
+      if: -> { admin_exists? && password_submitted? }
+    )
+    Decidim::System::AdminForm.validates(
+      :password_confirmation,
+      presence: true,
+      if: -> { admin_exists? && password_submitted? }
+    )
+  end
+end

--- a/spec/forms/decidim/system/admin_form_spec.rb
+++ b/spec/forms/decidim/system/admin_form_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Covers config/initializers/system_admin_form_override.rb.
+#
+# Without the patch the mismatch passes validation on edit and blows up later in
+# Decidim::System::UpdateAdmin, where Devise's :validatable makes `update!`
+# raise.
+module Decidim
+  module System
+    describe AdminForm do
+      let(:password) { "decidim123456789" }
+      let(:password_confirmation) { password }
+      let(:id) { nil }
+
+      let(:form) do
+        described_class.from_params(
+          admin: {
+            id:,
+            email: "admin@example.org",
+            password:,
+            password_confirmation:
+          }
+        )
+      end
+
+      context "when creating an admin" do
+        it "is valid with a matching confirmation" do
+          expect(form).to be_valid
+        end
+
+        context "with a mismatched confirmation" do
+          let(:password_confirmation) { "typo123456789" }
+
+          it "reports the mismatch once" do
+            expect(form).not_to be_valid
+            expect(form.errors[:password_confirmation].size).to eq(1)
+          end
+        end
+      end
+
+      context "when editing an admin" do
+        let(:id) { 1 }
+
+        it "is valid with a matching confirmation" do
+          expect(form).to be_valid
+        end
+
+        context "with no password at all" do
+          let(:password) { "" }
+          let(:password_confirmation) { "" }
+
+          it "is valid, leaving the password untouched" do
+            expect(form).to be_valid
+          end
+        end
+
+        context "with a mismatched confirmation" do
+          let(:password_confirmation) { "typo123456789" }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+            expect(form.errors[:password_confirmation]).not_to be_empty
+          end
+        end
+
+        context "with only the confirmation filled in" do
+          let(:password) { "" }
+          let(:password_confirmation) { "typo123456789" }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+            expect(form.errors[:password_confirmation]).not_to be_empty
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

decidim/decidim#17332 のバックポートです。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
