### PR TITLE
fix: PDF 出力に CJK フォントを導入し、日本語で落ちないようにする

### DIFF
--- a/.github/workflows/_check.yaml
+++ b/.github/workflows/_check.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: apt-get
         run: |
           sudo apt-get update -y
-          sudo apt-get -yqq install libpq-dev postgresql-client libfuse2  
+          sudo apt-get -yqq install libpq-dev postgresql-client libfuse2 fonts-ipaexfont-gothic  
 
       - name: check imagemagick
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN  apt-get update && \
         p7zip \
         wkhtmltopdf \
         chromium-driver \
+        fonts-ipaexfont-gothic \
         wget && \
     apt-get clean && \
     apt-get autoremove

--- a/config/initializers/pdf_cjk_font_override.rb
+++ b/config/initializers/pdf_cjk_font_override.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+# PDF 出力が日本語 (漢字) で例外を投げ、アンケート確認メールが送信されない問題への対処。
+#
+# decidim の PDF 出力は Source Sans Pro を埋め込むが、同梱されているのは
+# cyrillic / greek / latin / vietnamese のサブセットで CJK グリフを一切持たない。
+# ファイル名がそのまま実態を表している。
+#
+#   decidim-core/app/packs/fonts/decidim/
+#     source-sans-pro-v21-cyrillic_cyrillic-ext_greek_greek-ext_latin_latin-ext_vietnamese-700.ttf
+#
+# 本番コンテナでの実測 (0.30.9):
+#   font_name=SourceSansPro-Bold num_glyphs=1462
+#   'A' → Glyph  /  'あ' '年' '日' → いずれも InvalidGlyph
+#
+# HexaPDF は InvalidGlyph をエンコードする段階で MissingGlyphError を送出するため、
+# 漢字が 1 文字でも含まれると PDF 生成ごと失敗する。
+# Decidim::Surveys::SurveyConfirmationMailer は回答内容の PDF を添付するので
+# (survey_confirmation_mailer.rb:30)、日本語のアンケートでは確認メールが届かない。
+#
+# 本番ログでの実害 (直近 24 時間):
+#   Surveys::SurveyConfirmationMailer  完了 126 / 失敗 6  HexaPDF::MissingGlyphError
+#   例) No glyph for "年" / "質" / "🌱" in font 'Source Sans Pro Bold' found.
+#
+# 対処は 2 点。
+#
+#   1. IPAex ゴシック (Debian: fonts-ipaexfont-gothic) に差し替える
+#      単一ウェイトしか無いため regular と bold は同じ実体を使う。
+#      見出しが太字にならないが、メールが届かないよりは良いと判断した。
+#      HexaPDF 1.1.1 は TrueType コレクション (.ttc) を読めないため
+#      fonts-noto-cjk は使えない。単体 TTF を配る IPAex を選んでいる。
+#
+#   2. グリフが無い文字は代替文字に置換して継続する
+#      IPAex にも絵文字や一部の異体字 (𠮷 など) は無く、そこで再び全体が落ちる。
+#      1 文字のために PDF 全体を落とさない方針は open_data の override と同じ。
+#
+# decidim 0.30.9 / 0.31.7 / 0.32.1 / develop のいずれも同一実装のため
+# 上流追従では解消しない。
+module DecidimCfjPdfCjkFontPatch
+  # Dockerfile / CI で導入する fonts-ipaexfont-gothic の配置先 (Debian bookworm)。
+  CJK_FONT_PATH = "/usr/share/fonts/opentype/ipaexfont-gothic/ipaexg.ttf"
+
+  # グリフが無い文字の代替。先頭から順に、フォントが持っているものを使う。
+  # 〓 (ゲタ記号) は活字が無いことを示す日本語の慣習的な代替表記。
+  REPLACEMENT_CHARACTERS = %w(〓 ?).freeze
+
+  class << self
+    def font_available?
+      return @font_available if defined?(@font_available)
+
+      @font_available = File.exist?(CJK_FONT_PATH)
+    end
+
+    # HexaPDF の font.on_missing_glyph に渡す差し替え処理。
+    #
+    # InvalidGlyph をそのまま返しても TrueTypeWrapper#encode が
+    # MissingGlyphError を送出するため意味がない (実測で確認済み)。
+    # 実在するグリフを返して初めて継続できる。
+    def replacement_glyph(character, font_wrapper)
+      table = cmap_table(font_wrapper)
+      replacement = REPLACEMENT_CHARACTERS.find { |char| table[char.ord].to_i.positive? } if table
+
+      # 代替文字すら持たないフォントでは上流と同じ挙動 (例外) に戻す。
+      return HexaPDF::Font::InvalidGlyph.new(font_wrapper, character) if replacement.nil?
+
+      font_wrapper.decode_utf8(replacement).first
+    end
+
+    private
+
+    # decode_utf8 は欠落時に on_missing_glyph を呼ぶため、代替文字の有無を
+    # それで調べると無限再帰になる。cmap を直接引いて回避する。
+    def cmap_table(font_wrapper)
+      wrapped = font_wrapper.wrapped_font
+      return nil unless wrapped.respond_to?(:[])
+
+      wrapped[:cmap]&.preferred_table
+    rescue StandardError
+      nil
+    end
+  end
+
+  private
+
+  def font
+    return super unless DecidimCfjPdfCjkFontPatch.font_available?
+
+    @font ||= document.fonts.add(CJK_FONT_PATH)
+  end
+
+  def bold_font
+    return super unless DecidimCfjPdfCjkFontPatch.font_available?
+
+    @bold_font ||= document.fonts.add(CJK_FONT_PATH)
+  end
+
+  # フォントが無い環境では置換も行わない。
+  # 上流フォントのまま置換だけ有効にすると、日本語が丸ごと 〓 に化けた PDF が
+  # 「正常な成果物」として送信されてしまい、例外で気づけなくなるため。
+  def composer
+    return super unless DecidimCfjPdfCjkFontPatch.font_available?
+
+    @composer ||= super.tap do |built|
+      built.document.config["font.on_missing_glyph"] =
+        ->(character, font_wrapper) { DecidimCfjPdfCjkFontPatch.replacement_glyph(character, font_wrapper) }
+    end
+  end
+end
+
+unless DecidimCfjPdfCjkFontPatch.font_available?
+  Rails.logger.warn(
+    "[pdf] CJK フォントが見つかりません。日本語を含む PDF 出力は失敗します: " \
+    "#{DecidimCfjPdfCjkFontPatch::CJK_FONT_PATH} (fonts-ipaexfont-gothic)"
+  )
+end
+
+Rails.application.config.to_prepare do
+  # Decidim::Exporters::FormPDF (アンケート回答) の基底クラス。
+  Decidim::Exporters::PDF.prepend(DecidimCfjPdfCjkFontPatch)
+  # 基底クラスを継承せず同じ実装を複製しているため個別に当てる。
+  Decidim::Conferences::ConferenceDiplomaPDF.prepend(DecidimCfjPdfCjkFontPatch)
+end

--- a/spec/config/initializers/pdf_cjk_font_override_spec.rb
+++ b/spec/config/initializers/pdf_cjk_font_override_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Decidim::Exporters::PDF CJK font override" do
+  # 実際に PDF を書き出して判定する。上流フォントでは書き出し時の
+  # エンコード段階で MissingGlyphError になるため、ここを通れることが要件そのもの。
+  let(:exporter_class) do
+    Class.new(Decidim::Exporters::PDF) do
+      attr_accessor :sample
+
+      def add_data!
+        composer.text(sample, style: :h1)
+      end
+
+      def styles
+        { h1: { font: bold_font, font_size: 18 } }
+      end
+    end
+  end
+
+  def render(text)
+    exporter = exporter_class.new([], nil)
+    exporter.sample = text
+    exporter.export.read
+  end
+
+  it "applies the override to both PDF generators" do
+    [Decidim::Exporters::PDF, Decidim::Conferences::ConferenceDiplomaPDF].each do |klass|
+      expect(klass.ancestors).to include(DecidimCfjPdfCjkFontPatch),
+                                 "#{klass} に override が適用されていない"
+    end
+  end
+
+  it "uses the CJK font instead of the upstream latin-only font" do
+    expect(File).to exist(DecidimCfjPdfCjkFontPatch::CJK_FONT_PATH)
+
+    exporter = exporter_class.new([], nil)
+    expect(exporter.send(:font).wrapped_font.font_name).to match(/IPAex/i)
+    expect(exporter.send(:bold_font).wrapped_font.font_name).to match(/IPAex/i)
+  end
+
+  # 上流フォント (Source Sans Pro のラテンサブセット) では全て失敗するケース。
+  # 漢字は本番で実際にアンケート確認メールを止めていた。
+  #
+  # 「例外が出ないこと」だけでは不十分。置換ガードが効いているため、
+  # フォントが上流のままでも日本語が丸ごと 〓 に化けて "成功" してしまう。
+  # 置換が一度も呼ばれないことまで確認して初めて、正しく描画されたと言える。
+  [
+    ["漢字", "2026年8月の回答"],
+    ["ひらがな・カタカナ", "こんにちは カタカナ"],
+    ["全角記号", "（株）①〜※"],
+    ["ラテンとの混在", "Q1: 好きな色は?"]
+  ].each do |label, text|
+    it "renders #{label} with real glyphs" do
+      expect(DecidimCfjPdfCjkFontPatch).not_to receive(:replacement_glyph)
+
+      expect { render(text) }.not_to raise_error
+    end
+  end
+
+  # IPAex にも無い文字。ここで落ちると結局メールが送れないため、
+  # 代替文字に置換して PDF 生成を継続する。
+  [
+    ["絵文字を含む", "回答: 環境🌱について"],
+    ["サロゲートペアの異体字", "𠮷野家"]
+  ].each do |label, text|
+    it "substitutes a replacement glyph for #{label}" do
+      expect(DecidimCfjPdfCjkFontPatch).to receive(:replacement_glyph).at_least(:once).and_call_original
+
+      expect { render(text) }.not_to raise_error
+    end
+  end
+
+  describe ".replacement_glyph" do
+    let(:font_wrapper) do
+      exporter = exporter_class.new([], nil)
+      exporter.send(:font)
+    end
+
+    it "returns a real glyph so that HexaPDF can encode it" do
+      glyph = described_class_module.replacement_glyph("🌱", font_wrapper)
+
+      expect(glyph).not_to be_a(HexaPDF::Font::InvalidGlyph)
+      expect { font_wrapper.encode(glyph) }.not_to raise_error
+    end
+
+    it "falls back to the upstream behaviour when the font has no replacement character" do
+      table = font_wrapper.wrapped_font[:cmap].preferred_table
+      allow(table).to receive(:[]).and_return(nil)
+
+      glyph = described_class_module.replacement_glyph("🌱", font_wrapper)
+
+      expect(glyph).to be_a(HexaPDF::Font::InvalidGlyph)
+    end
+  end
+
+  # フォント未導入の環境では置換も無効化し、上流と同じ挙動 (例外) に戻す。
+  # 日本語が丸ごと 〓 に化けた PDF を「成功」として送ってしまわないため。
+  context "when the CJK font is not installed" do
+    before do
+      allow(DecidimCfjPdfCjkFontPatch).to receive(:font_available?).and_return(false)
+    end
+
+    it "keeps the upstream font" do
+      exporter = exporter_class.new([], nil)
+
+      expect(exporter.send(:font).wrapped_font.font_name).to match(/SourceSansPro/i)
+    end
+
+    it "does not install the missing glyph handler" do
+      exporter = exporter_class.new([], nil)
+      handler = exporter.send(:composer).document.config["font.on_missing_glyph"]
+
+      expect(handler).to eq(HexaPDF::DefaultDocumentConfiguration["font.on_missing_glyph"])
+    end
+  end
+
+  # ここまでは override 単体の検証。以下は実際に本番で使われる経路
+  # (SurveyConfirmationMailer が添付する PDF) を実データで通す。
+  # engine.rb:64 が QuestionnaireUserAnswers.for(...) の戻り値をそのまま
+  # FormPDF に渡すため、同じ形の collection を組み立てている。
+  describe "Decidim::Exporters::FormPDF with real records" do
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user, :confirmed, organization:) }
+    let(:participatory_process) { create(:participatory_process, organization:) }
+    let(:questionnaire) do
+      create(:questionnaire, questionnaire_for: participatory_process, title: { ja: "市民アンケート2026", en: "Survey" })
+    end
+    let(:question) do
+      create(:questionnaire_question, questionnaire:, body: { ja: "好きな季節は？", en: "Season?" })
+    end
+    let(:collection) { Decidim::Forms::QuestionnaireUserAnswers.for(questionnaire) }
+
+    before { create(:answer, questionnaire:, question:, user:, body:) }
+
+    def export
+      Decidim::Exporters::FormPDF.new(collection, Decidim::Forms::UserAnswersSerializer).export.read
+    end
+
+    context "when the answer is written in japanese" do
+      let(:body) { "2026年8月に回答しました。質問1への回答です。" }
+
+      it "exports a pdf" do
+        expect(collection).to be_present
+        expect(export.byteslice(0, 5)).to eq("%PDF-")
+      end
+    end
+
+    context "when the answer contains an emoji" do
+      let(:body) { "回答: 環境🌱について" }
+
+      it "exports a pdf" do
+        expect(export.byteslice(0, 5)).to eq("%PDF-")
+      end
+    end
+  end
+
+  def described_class_module = DecidimCfjPdfCjkFontPatch
+end


### PR DESCRIPTION
## 問題

**日本語のアンケートで、回答確認メールが送信されていません。**

`Decidim::Surveys::SurveyConfirmationMailer` は回答内容の PDF を添付しますが（`survey_confirmation_mailer.rb:30`）、その PDF 生成が漢字で例外を投げて失敗しています。

本番ログ（直近24時間）:

| メーラー | 完了 | 失敗 |
|---|---:|---:|
| `Surveys::SurveyConfirmationMailer` | 126 | **6** |

```
HexaPDF::MissingGlyphError (No glyph for "年" in font 'Source Sans Pro Bold' found.)
HexaPDF::MissingGlyphError (No glyph for "質" in font 'Source Sans Pro Bold' found.)
HexaPDF::MissingGlyphError (No glyph for "🌱" in font 'Source Sans Pro Bold' found.)
```

## 原因

decidim が PDF に埋め込むフォントは、ファイル名のとおり CJK を含まないサブセットです。

```ruby
# decidim-core/lib/decidim/exporters/pdf.rb:34-38
load_font("source-sans-pro-v21-cyrillic_cyrillic-ext_greek_greek-ext_latin_latin-ext_vietnamese-700.ttf")
```

本番コンテナでの実測:

```
font_name = SourceSansPro-Bold
num_glyphs = 1462
'A' → Glyph(id=2)
'あ' → InvalidGlyph(id=0)
'年' → InvalidGlyph(id=0)
'日' → InvalidGlyph(id=0)
```

HexaPDF はエンコード段階で `MissingGlyphError` を送出するため、**漢字が1文字でも含まれると PDF 生成ごと失敗**します。

## 対処

### 1. IPAex ゴシックに差し替える

`fonts-ipaexfont-gothic` を Dockerfile と CI に追加し、`Decidim::Exporters::PDF#font` / `#bold_font` を override します。

単一ウェイトのため regular と bold は同じ実体を使います。**見出しが太字になりません**が、メールが届かないよりは良いと判断しました。

HexaPDF 1.1.1 は TrueType コレクション（`.ttc`）を読めないため `fonts-noto-cjk` は使えず、単体 TTF を配る IPAex を選んでいます（gem のソースに `ttcf` の処理が存在しないことを確認）。

### 2. グリフが無い文字は代替文字に置換して継続する

IPAex にも絵文字やサロゲートペアの異体字（`𠮷`）は無く、そこで再び全体が落ちます。**1文字のために出力全体を落とさない**方針は、先の open data の override と揃えました。

実装上の注意が2点あります。

- `InvalidGlyph` を返すだけでは `TrueTypeWrapper#encode` が結局例外を投げるため、**実在するグリフ**（`〓` → `?`）を返しています
- 代替文字の有無は **cmap を直接引いて**調べます。`decode_utf8` で調べると `on_missing_glyph` が再帰します

### 3. フォント未導入の環境では上流の挙動に戻す

差し替えも置換も行いません。上流フォントのまま置換だけ効かせると、**日本語が丸ごと `〓` に化けた PDF が「正常な成果物」として送信され**、例外で気づけなくなるためです。

## 適用範囲

| クラス | 対応 |
|---|---|
| `Decidim::Exporters::PDF` | ✅ `FormPDF`（アンケート回答）の基底クラス |
| `Decidim::Conferences::ConferenceDiplomaPDF` | ✅ 基底クラスを継承せず同じ実装を複製しているため個別に prepend |
| `Decidim::Initiatives::*PDF` | 対象外（decidim-initiatives 未導入） |

## 上流の状況

0.30.9 / 0.31.7 / 0.32.1 / develop のいずれも同一実装で、**上流追従では解消しません**。

## 検証

Docker 環境で実施しました。

```
rspec  spec/config/initializers/  →  78 examples, 0 failures
rubocop                           →  no offenses detected
```

spec が実際に劣化を検知することを、意図的に壊して確認しています。

| 壊した箇所 | 失敗数 |
|---|---:|
| フォント差し替えを外す | 5 |
| 欠落グリフの置換を外す | 3 |
| `ConferenceDiplomaPDF` への適用を外す | 1 |
| override 全体を外す | 実データの `FormPDF` spec が `MissingGlyphError` で失敗 |

「例外が出ないこと」だけでは不十分な点に注意しています。置換ガードが効いているため、**フォントが上流のままでも日本語が `〓` に化けて "成功" してしまう**ので、置換が一度も呼ばれないことまで検証しています。

spec には実データを使った検証も含めています。`engine.rb:64` と同じ形の collection を組み立て、実際の `Decidim::Exporters::FormPDF` で日本語・絵文字の PDF が生成できることを確認しています。