### PR TITLE
fix: rake の一括登録で入力の取り違えを検知し、出力に BOM を付ける

### DIFF
--- a/docs/BULK_USER_IMPORT.md
+++ b/docs/BULK_USER_IMPORT.md
@@ -58,6 +58,8 @@ bundle exec rails runner '
 
 ヘッダ行の `email` 列は必須です。任意で `name` / `nickname` / `password` 列を追加でき、空の場合は自動生成されます。
 
+列名は完全一致で照合します。`Email` のように大文字が混ざっていたり、ヘッダ行が無かったりする場合は、処理を行わずに中断します（管理画面でもエラーを表示します）。
+
 ```csv
 email,name
 taro.yamada@example.com,山田 太郎
@@ -65,6 +67,8 @@ hanako@example.com,
 ```
 
 文字コードは UTF-8 です。Excel で保存した BOM 付き UTF-8 のCSVもそのまま渡せます（`encoding: "bom|utf-8"` で読み込むため、BOM は除去されます）。
+
+出力CSVには BOM を付けています。Excel でそのまま開いても日本語（`name` 列、発行タスクの `furigana` 列）が文字化けしません。
 
 ### 2.3 実行: 管理画面
 

--- a/lib/tasks/bulk_users.rake
+++ b/lib/tasks/bulk_users.rake
@@ -15,6 +15,10 @@
 # 出力CSV (OUT, 既定 tmp/bulk_users/created_users_<日時>.csv): email,nickname,name,password,status,error
 #   ※ 生成した平文パスワードが入る。0600 で作成される。配布が完了するまで保管し、不要になったら削除する。
 #   ※ 既存ファイルへは書き込まない（上書きすると発行済みパスワードが失われるため、存在する場合は中断する）。
+# 出力CSVは運用者が Excel で開いて配布に使う。BOM が無いと日本語（name 列、発行タスクの
+# フリガナ列）が文字化けするため、入力側の "bom|utf-8" と対で出力にも付ける。
+BULK_USERS_UTF8_BOM = "\xEF\xBB\xBF"
+
 namespace :bulk_users do
   desc "Create confirmed users in bulk from a CSV (IN= OUT= DECIDIM_ORGANIZATION_ID= or DECIDIM_ORGANIZATION_NAME=)"
   task import: :environment do
@@ -27,7 +31,21 @@ namespace :bulk_users do
     input = ENV.fetch("IN")
     output = ENV.fetch("OUT") { "tmp/bulk_users/created_users_#{Time.zone.now.strftime("%Y%m%d%H%M%S")}.csv" }
 
-    rows = CSV.read(input, headers: true, encoding: "bom|utf-8").map do |row|
+    table = CSV.read(input, headers: true, encoding: "bom|utf-8")
+
+    # ヘッダ名が違う（Excel が書き出す "Email"、日本語見出し、ヘッダ行なし等）と全行が
+    # blank email で skip され、created=0 skipped=N failed=0 を出して exit 0 で正常終了して
+    # しまう。組織未検出や出力先の重複では中断するのに、入力の取り違えだけ無言で no-op に
+    # なるのは非対称なので、ここで弾く。
+    #
+    # 出力ファイルを作る前に検証する。作ってしまうと、CSV を直して同じ OUT で再実行しようと
+    # しても「既に存在する」で中断され、別パスの指定を強いられるため。
+    unless table.headers.include?("email")
+      abort "入力CSV #{input} に email 列がありません（検出した列: #{table.headers.compact.join(", ").presence || "なし"}）。" \
+            "1行目をヘッダ行にして email 列を用意してください。"
+    end
+
+    rows = table.map do |row|
       { email: row["email"], name: row["name"], nickname: row["nickname"], password: row["password"] }
     end
 
@@ -47,6 +65,7 @@ namespace :bulk_users do
     end
 
     results = begin
+      io.write(BULK_USERS_UTF8_BOM)
       csv = CSV.new(io)
       csv << %w(email nickname name password status error)
       importer.import(rows) do |result|
@@ -130,6 +149,7 @@ namespace :bulk_users do
     end
 
     results = begin
+      io.write(BULK_USERS_UTF8_BOM)
       csv = CSV.new(io)
       csv << %w(space_slug role account_id email password furigana status error)
       issuer.issue(instructions) do |result|

--- a/spec/lib/tasks/bulk_users_spec.rb
+++ b/spec/lib/tasks/bulk_users_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+# lib/tasks/bulk_users.rake の入力・出力の扱いを検証する。
+# 実際の作成処理は Decidim::BulkUserImporter 側の spec でカバーしている。
+RSpec.describe "bulk_users rake tasks" do
+  let(:organization) { create(:organization, tos_version: Time.current) }
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:input) { File.join(tmpdir, "in.csv") }
+  let(:output) { File.join(tmpdir, "out.csv") }
+
+  before do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("bulk_users:import")
+    Rake::Task["bulk_users:import"].reenable
+    ENV["DECIDIM_ORGANIZATION_ID"] = organization.id.to_s
+    ENV["IN"] = input
+    ENV["OUT"] = output
+  end
+
+  after do
+    %w(DECIDIM_ORGANIZATION_ID IN OUT).each { |key| ENV.delete(key) }
+    FileUtils.remove_entry(tmpdir)
+  end
+
+  def run = Rake::Task["bulk_users:import"].invoke
+
+  context "when the CSV has no email header" do
+    # Excel が書き出す "Email" や日本語見出しでも、CSV::Row#[] は完全一致でしか引けない。
+    before { File.write(input, "Email\ntaro@example.org\n") }
+
+    it "aborts instead of reporting a successful no-op" do
+      expect { expect { run }.to raise_error(SystemExit) }.not_to change(Decidim::User, :count)
+    end
+
+    # 出力ファイルを作ってしまうと、CSV を直して同じ OUT で再実行できなくなる。
+    it "does not leave an output file behind" do
+      expect { run }.to raise_error(SystemExit)
+
+      expect(File).not_to exist(output)
+    end
+  end
+
+  context "when the CSV is valid" do
+    before { File.write(input, "email\ntaro@example.org\n") }
+
+    it "creates the user" do
+      expect { run }.to change(Decidim::User, :count).by(1)
+    end
+
+    # 運用者が Excel で開いて配布に使うため、日本語が化けないよう BOM を付ける。
+    it "writes the output with a UTF-8 BOM" do
+      run
+
+      expect(File.binread(output, 3)).to eq("\xEF\xBB\xBF".b)
+    end
+  end
+end


### PR DESCRIPTION
## 問題

管理画面（#866）には入っている2つの守りが、**同じ `Decidim::BulkUserImporter` を呼ぶ rake タスク側に無く**、入口によって挙動がずれていました。

| 検証 | 管理画面 | rake（修正前） |
|---|---|---|
| `email` ヘッダの存在 | ✅ `missing_email_header` | ❌ 無し |
| 出力CSVの BOM | ✅ 付与 | ❌ 無し |

## 1. `email` ヘッダの検証

`CSV::Row#[]` は列名を**完全一致**でしか引けません。次のような CSV を渡すと `row["email"]` が全行 `nil` になります。

- Excel が書き出した `Email`（大文字）
- `メールアドレス` のような日本語見出し
- ヘッダ行なしの CSV

その結果、全件が `skipped: blank email` として処理され、

```
created=0 skipped=N failed=0
```

を出して **exit 0 で正常終了**します。運用者は成功したと読みます。ヘッダ行なしの場合は、先頭のメールアドレスがヘッダとして食われて**完全に消えます**。

このタスクは組織未検出（`bulk_users_find_organization`）や出力先の重複では `abort` するのに、**入力の取り違えだけが無言の no-op** になるのは非対称です。

### 検証は出力ファイルを作る前に行います

作ってしまうと、CSV を直して同じ `OUT` で再実行しようとしても「既に存在する」で中断され、別パスの指定を強いられます。spec でも `does not leave an output file behind` として押さえています。

## 2. 出力CSVの BOM

入力側は `encoding: "bom|utf-8"` で Excel 由来の BOM をわざわざ吸収しているのに、出力側は BOM なし UTF-8 でした。

**運用者が `created.csv` を Excel で開いて配布に使うのは想定運用そのもの**で、`name` 列の日本語が化けます。

さらに発行タスク（`bulk_users:issue`）の出力は **`furigana` 列が常にカタカナ**なので、こちらは必ず化けます。両タスクに付けました。

## spec

rake タスクの spec はこれまで無かったため `spec/lib/tasks/` に新設しました。

```
4 examples, 0 failures
rubocop no offenses
```

実効性を確認しています。

| 壊した箇所 | 失敗数 |
|---|---:|
| ヘッダ検証を外す | 2 |
| BOM 書き込みを外す | 1 |

## 関連

- #864 のレビューで挙がった指摘のうち、rake 側に残っていた2件です
- 行数上限の件は #882 で別途対応しています
