### PR TITLE
fix: bulk-issued accounts blocked at sign-in and menu shown for unconfigured organizations

### DIFF
--- a/app/models/decidim/bulk_user_import_setting.rb
+++ b/app/models/decidim/bulk_user_import_setting.rb
@@ -13,8 +13,15 @@ module Decidim
                inverse_of: false
 
     # ドメインはログインID（メール形式）の一部としてそのまま配布されるため、
-    # Devise のメール形式（/\A[^@\s]+@[^@\s]+\z/）を壊す文字を弾いておく。
-    validates :email_domain, format: { with: /\A[a-z0-9][a-z0-9.-]*\z/ }, allow_blank: true
+    # 生成されるメールアドレスがログインフォームのフロント検証（Foundation Abide の
+    # email パターン）を通過できる形式に限定する。Abide はドメインにドット区切りの
+    # 2ラベル以上（TLD 相当）を要求するので、ドットなしのドメイン（例: chiba-mirai）だと
+    # 発行はできてもログイン画面で弾かれてしまう。実在するドメインと衝突しないよう、
+    # RFC 2606 で予約されていてグローバル DNS には委任されない .test の使用を推奨する
+    # （例: chiba-mirai.test。docs/BULK_SPACE_ACCOUNTS.md 参照）。
+    EMAIL_DOMAIN_FORMAT = /\A[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+\z/
+
+    validates :email_domain, format: { with: EMAIL_DOMAIN_FORMAT }, allow_blank: true
     validates :email_domain, presence: true, if: :enabled?
     validates :decidim_organization_id, uniqueness: true
   end

--- a/app/services/decidim/bulk_space_account_issuer.rb
+++ b/app/services/decidim/bulk_space_account_issuer.rb
@@ -7,7 +7,8 @@ module Decidim
   #
   #   - アカウントID（= nickname = 表示名 = メールのローカル部）は
   #     参加者: <slug>-<連番3桁> / 管理者: <slug>-a<連番3桁>
-  #   - メールアドレスは実在しないドメイン（組織ごとの設定 email_domain）で生成する
+  #   - メールアドレスは実在しないドメイン（組織ごとの設定 email_domain、例: chiba-mirai.test）で
+  #     生成する。ログインフォームのフロント検証を通すため TLD 相当のドットが必須
   #   - パスワードは BulkUserImporter に可読性優先の文字種（PASSWORD_CHARSET）で生成させる
   #   - 管理者にもプライベートユーザー登録を行う。ロール（AssemblyUserRole）は管理画面への
   #     アクセス権であって参加権ではなく、can_participate? は private_users しか見ないため、
@@ -60,6 +61,15 @@ module Decidim
 
     def initialize(organization:, email_domain:, dry_run: false)
       raise ArgumentError, "email_domain is blank" if email_domain.blank?
+
+      # ログインフォームのフロント検証（Foundation Abide）がドメインにドット区切りの
+      # 2ラベル以上を要求するため、ドットなしのドメインで発行するとログインできなくなる。
+      # 設定モデルと同じ形式チェックを rake 経由の実行にも適用する。
+      unless BulkUserImportSetting::EMAIL_DOMAIN_FORMAT.match?(email_domain)
+        raise ArgumentError, "email_domain must be a lowercase dotted domain such as chiba-mirai.test " \
+                             "(got #{email_domain.inspect}); without a dot the issued accounts cannot pass " \
+                             "the sign-in form validation"
+      end
 
       @organization = organization
       @email_domain = email_domain

--- a/app/views/decidim/system/bulk_user_import_settings/edit.html.erb
+++ b/app/views/decidim/system/bulk_user_import_settings/edit.html.erb
@@ -22,7 +22,7 @@
   <div class="form__wrapper">
     <div>
       <%= form.label :email_domain, t(".email_domain_label") %>
-      <%= form.text_field :email_domain, placeholder: "chiba-mirai" %>
+      <%= form.text_field :email_domain, placeholder: "chiba-mirai.test" %>
       <p class="help-text"><%= t(".email_domain_help") %></p>
     </div>
 

--- a/config/initializers/bulk_account_issuing.rb
+++ b/config/initializers/bulk_account_issuing.rb
@@ -45,15 +45,26 @@ end
 
 # アセンブリ管理画面のサイドメニュー。ブロックはレンダリング時にビューのコンテキストで評価される。
 # 権限チェーンはコントローラ側の専用クラスに任せ、ここでは表示条件だけを見る。
+#
+# 表示条件（MVP）: /system でこの組織の発行が有効 かつ このスペースが非公開、の両方を
+# 満たす場合のみ。将来別ケースに広げる場合もこの条件式に足す。
+#
+# 注意: MenuItem#visible? は if: が nil のとき「条件指定なし＝表示」と解釈する。
+# find_by(...)&.enabled? のような式は設定レコードが無い組織で nil になり、
+# 未設定の組織（マルチテナントの他組織を含む）に全表示される事故につながるため、
+# 各項を必ず true/false に確定させること。
 Decidim.menu :admin_assembly_menu do |menu|
+  issuing_available = current_user.present? && current_user.admin? &&
+                      current_participatory_space.private_space? &&
+                      Decidim::BulkUserImportSetting.exists?(decidim_organization_id: current_organization.id,
+                                                             enabled: true)
+
   menu.add_item :bulk_account_issue,
                 I18n.t("menu.bulk_account_issue", scope: "decidim.admin"),
                 decidim_admin_assemblies.new_assembly_bulk_account_issue_path(current_participatory_space),
                 icon_name: "user-add-line",
                 active: is_active_link?(decidim_admin_assemblies.new_assembly_bulk_account_issue_path(current_participatory_space)),
-                if: current_user&.admin? &&
-                    current_participatory_space.private_space? &&
-                    Decidim::BulkUserImportSetting.find_by(decidim_organization_id: current_organization.id)&.enabled?
+                if: issuing_available
 end
 
 # 管理ログで一括発行（action: "bulk_account_issue"）の行を専用の文言で表示する。

--- a/config/locales/bulk_account_issue.en.yml
+++ b/config/locales/bulk_account_issue.en.yml
@@ -1,4 +1,15 @@
 en:
+  activerecord:
+    attributes:
+      decidim/bulk_user_import_setting:
+        email_domain: Dummy email domain
+        enabled: Enabled
+    errors:
+      models:
+        decidim/bulk_user_import_setting:
+          attributes:
+            email_domain:
+              invalid: must be a lowercase dotted domain such as “chiba-mirai.test” (a TLD-like suffix is required to pass the sign-in form validation; the reserved, never-deliverable .test is recommended)
   decidim:
     admin:
       menu:
@@ -44,7 +55,7 @@ en:
       bulk_user_import_settings:
         edit:
           back: Back to the list
-          email_domain_help: Lowercase letters, digits, . and - only. It is handed out as part of the login id (email format), so keep it short and easy to type. No TLD (.jp etc.) is needed.
+          email_domain_help: Lowercase letters, digits, . and - only. It must contain a dot (a TLD-like suffix) such as “chiba-mirai.test” so that the issued addresses pass the sign-in form validation. The .test TLD (reserved by RFC 2606, never deliverable) is recommended. It is handed out as part of the login id (email format), so keep it short and easy to type.
           email_domain_label: Dummy email domain
           enabled_label: Enable bulk account issuing
           enabled_help: When enabled, the “Bulk account issuing” menu appears in the admin panel of this organization's private assemblies.

--- a/config/locales/bulk_account_issue.ja.yml
+++ b/config/locales/bulk_account_issue.ja.yml
@@ -1,4 +1,15 @@
 ja:
+  activerecord:
+    attributes:
+      decidim/bulk_user_import_setting:
+        email_domain: ダミーメールのドメイン
+        enabled: 有効フラグ
+    errors:
+      models:
+        decidim/bulk_user_import_setting:
+          attributes:
+            email_domain:
+              invalid: は「chiba-mirai.test」のような小文字のドット付きドメインにしてください（ログイン画面の形式チェックを通すため TLD 相当が必要です。実在しない .test を推奨）
   decidim:
     admin:
       menu:
@@ -44,7 +55,7 @@ ja:
       bulk_user_import_settings:
         edit:
           back: 一覧に戻る
-          email_domain_help: 小文字英数字と . - のみ。ログインID（メール形式）の一部として配布されるため、短く打ちやすい文字列にしてください。TLD（.jp など）は不要です。
+          email_domain_help: 小文字英数字と . - のみ。ログイン画面の形式チェックを通すため「chiba-mirai.test」のようにドット付き（TLD相当を含む）である必要があります。実在するドメインと紛れないよう、テスト用に予約されていて絶対に配送されない .test を推奨します。ログインID（メール形式）の一部として配布されるため、短く打ちやすい文字列にしてください。
           email_domain_label: ダミーメールのドメイン
           enabled_help: ONにすると、この組織の非公開アセンブリの管理画面に「アカウント一括発行」メニューが表示されます。
           enabled_label: 一括アカウント発行を有効にする

--- a/docs/BULK_SPACE_ACCOUNTS.md
+++ b/docs/BULK_SPACE_ACCOUNTS.md
@@ -18,11 +18,18 @@
 **/system（大元の管理画面）の「一括アカウント発行」ページ**から組織ごとに設定できます。rake でも設定できます。
 
 ```bash
-DECIDIM_ORGANIZATION_ID=1 bundle exec rails bulk_users:configure ENABLED=true EMAIL_DOMAIN=chiba-mirai
+DECIDIM_ORGANIZATION_ID=1 bundle exec rails bulk_users:configure ENABLED=true EMAIL_DOMAIN=chiba-mirai.test
 DECIDIM_ORGANIZATION_ID=1 bundle exec rails bulk_users:configure   # 現在値の表示
 ```
 
-`EMAIL_DOMAIN` は小文字英数字と `.` `-` のみです。TLD（`.jp` など）は不要で、`chiba-mirai` のような文字列がそのまま使えます。
+`EMAIL_DOMAIN` は小文字英数字と `.` `-` のみで、**`chiba-mirai.test` のようにドット付き（TLD 相当を含む）である必要があります**。
+ドットなしのドメイン（例: `chiba-mirai`）だと、発行はできてもログイン画面のメール形式チェック（Foundation Abide）で
+「このフィールドにはエラーがあります。」と弾かれ、参加者がログインできません。
+TLD 相当には、RFC 2606 で予約されていてグローバル DNS には委任されない
+（＝絶対に実在・配送されない）`.test` を推奨します。短くて打ちやすいのも利点です。
+`.example` / `.invalid`（同じく RFC 2606 予約）や `.internal`（ICANN がプライベート用途向けに予約）でも
+技術的には同等です。`.xx` のような根拠のない自作 TLD は、将来 gTLD として実在してしまう
+可能性があるため使わないでください。
 このドメインはログインID（メール形式）の一部として参加者に配布されるので、短く打ちやすいものにしてください。
 
 組織の利用規約バージョン（`tos_version`）が未設定の場合は実行できません（`BULK_USER_IMPORT.md` 2.1 を参照）。
@@ -73,7 +80,7 @@ DECIDIM_ORGANIZATION_ID=1 bundle exec rails bulk_users:issue IN=tmp/bulk/plan.cs
 
 ```
 space_slug,role,account_id,email,password,furigana,status,error
-a-high,participant,a-high-001,a-high-001@chiba-mirai,K7M2WX4NPR,ケー・ナナ・エム・ニ・ダブリュー・エックス・ヨン・エヌ・ピー・アール,created,
+a-high,participant,a-high-001,a-high-001@chiba-mirai.test,K7M2WX4NPR,ケー・ナナ・エム・ニ・ダブリュー・エックス・ヨン・エヌ・ピー・アール,created,
 ```
 
 - 1件処理するたびに書き出してフラッシュします。途中でプロセスが落ちても処理済み分の認証情報は残ります

--- a/lib/tasks/bulk_users.rake
+++ b/lib/tasks/bulk_users.rake
@@ -155,7 +155,7 @@ namespace :bulk_users do
   # 組織ごとの発行設定の確認・変更。/system の画面から編集できるようにするまでの暫定手段。
   #
   #   DECIDIM_ORGANIZATION_ID=<id> rails bulk_users:configure                              # 現在値の表示
-  #   DECIDIM_ORGANIZATION_ID=<id> rails bulk_users:configure ENABLED=true EMAIL_DOMAIN=chiba-mirai
+  #   DECIDIM_ORGANIZATION_ID=<id> rails bulk_users:configure ENABLED=true EMAIL_DOMAIN=chiba-mirai.test
   desc "Show or update bulk account issuing settings (EMAIL_DOMAIN= ENABLED=true|false)"
   task configure: :environment do
     organization = bulk_users_find_organization

--- a/spec/models/decidim/bulk_user_import_setting_spec.rb
+++ b/spec/models/decidim/bulk_user_import_setting_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Decidim::BulkUserImportSetting do
   subject(:settings) { described_class.new(organization:, email_domain:, enabled:) }
 
   let(:organization) { create(:organization) }
-  let(:email_domain) { "chiba-mirai" }
+  let(:email_domain) { "chiba-mirai.test" }
   let(:enabled) { true }
 
   it { is_expected.to be_valid }
@@ -33,8 +33,28 @@ RSpec.describe Decidim::BulkUserImportSetting do
     end
   end
 
+  # ドットなしのドメインだと発行したアカウントがログイン画面の
+  # メール形式チェック（Foundation Abide）で弾かれるため、TLD 相当を必須にする。
+  context "when the domain has no dot" do
+    ["chiba-mirai", "localhost"].each do |bad|
+      it "rejects #{bad.inspect}" do
+        settings.email_domain = bad
+        expect(settings).not_to be_valid
+      end
+    end
+  end
+
+  context "when the domain has a label edge that breaks the email format" do
+    ["chiba-.test", "chiba-mirai.", ".test", "chiba..test"].each do |bad|
+      it "rejects #{bad.inspect}" do
+        settings.email_domain = bad
+        expect(settings).not_to be_valid
+      end
+    end
+  end
+
   context "when the organization already has settings" do
-    before { described_class.create!(organization:, email_domain: "other", enabled: false) }
+    before { described_class.create!(organization:, email_domain: "other.test", enabled: false) }
 
     it { is_expected.not_to be_valid }
   end

--- a/spec/requests/decidim/assemblies/admin/bulk_account_issues_spec.rb
+++ b/spec/requests/decidim/assemblies/admin/bulk_account_issues_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Decidim::Assemblies::Admin BulkAccountIssuesController" do
     create(:assembly, organization:, slug: "a-high", private_space: true, is_transparent: false)
   end
   let!(:settings) do
-    Decidim::BulkUserImportSetting.create!(organization:, email_domain: "chiba-mirai", enabled: true)
+    Decidim::BulkUserImportSetting.create!(organization:, email_domain: "chiba-mirai.test", enabled: true)
   end
   let(:admin_user) { create(:user, :admin, :confirmed, organization:) }
   let(:new_path) { "/admin/assemblies/#{assembly.slug}/bulk_account_issue/new" }
@@ -22,6 +22,88 @@ RSpec.describe "Decidim::Assemblies::Admin BulkAccountIssuesController" do
 
   def issued_users
     Decidim::User.where(organization:).where("nickname LIKE ?", "a-high-%")
+  end
+
+  # サイドメニュー「アカウント一括発行」の表示条件（MVP）:
+  # /system でこの組織の発行が有効 かつ スペースが非公開、の両方を満たすときだけ表示する。
+  # メニュー（admin_assembly_menu）を描画する任意の管理ページで確認できる（ここでは添付ファイル一覧）。
+  describe "menu visibility" do
+    let(:menu_page_path) { "/admin/assemblies/#{assembly.slug}/attachments" }
+
+    before { sign_in admin_user }
+
+    it "shows the menu item when the organization is enabled and the space is private" do
+      get menu_page_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(new_path)
+    end
+
+    context "when the assembly is not a private space" do
+      before { assembly.update!(private_space: false) }
+
+      it "hides the menu item" do
+        get menu_page_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include(new_path)
+      end
+    end
+
+    context "when issuing is disabled for the organization" do
+      before { settings.update!(enabled: false) }
+
+      it "hides the menu item" do
+        get menu_page_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include(new_path)
+      end
+    end
+
+    # MenuItem#visible? は if: が nil のとき「条件指定なし＝表示」と解釈するため、
+    # 設定レコードが無い組織で find_by → nil が漏れると全表示になる（過去の不具合の回帰テスト）。
+    context "when the organization has no settings record" do
+      before { settings.destroy! }
+
+      it "hides the menu item" do
+        get menu_page_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include(new_path)
+      end
+    end
+
+    # マルチテナント: 他組織で有効になっていても、この組織には漏れないこと（逆方向も確認する）。
+    context "when only another organization has issuing enabled" do
+      let(:other_organization) { create(:organization, tos_version: Time.current) }
+
+      before do
+        settings.destroy!
+        Decidim::BulkUserImportSetting.create!(organization: other_organization,
+                                               email_domain: "other.test", enabled: true)
+      end
+
+      it "hides the menu item in this organization" do
+        get menu_page_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include(new_path)
+      end
+
+      it "still shows the menu item in the enabled organization" do
+        other_assembly = create(:assembly, organization: other_organization, slug: "b-high",
+                                           private_space: true, is_transparent: false)
+        other_admin = create(:user, :admin, :confirmed, organization: other_organization)
+
+        host! other_organization.host
+        sign_in other_admin
+        get "/admin/assemblies/#{other_assembly.slug}/attachments"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("/admin/assemblies/b-high/bulk_account_issue/new")
+      end
+    end
   end
 
   describe "GET new" do
@@ -53,7 +135,7 @@ RSpec.describe "Decidim::Assemblies::Admin BulkAccountIssuesController" do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("a-high-001")
         expect(response.body).to include("a-high-a001")
-        expect(response.body).to include("chiba-mirai")
+        expect(response.body).to include("chiba-mirai.test")
       end
 
       context "when issuing is disabled for the organization" do
@@ -69,6 +151,22 @@ RSpec.describe "Decidim::Assemblies::Admin BulkAccountIssuesController" do
 
       context "when the assembly is not a private space" do
         before { assembly.update!(private_space: false) }
+
+        it "redirects to the assemblies list with an explanation" do
+          get new_path
+
+          expect(response).to redirect_to("/admin/assemblies")
+          expect(flash[:alert]).to be_present
+        end
+      end
+
+      # 他組織の設定が current_organization の判定に漏れて有効化されないこと。
+      context "when issuing is enabled only for another organization" do
+        before do
+          settings.destroy!
+          Decidim::BulkUserImportSetting.create!(organization: create(:organization, tos_version: Time.current),
+                                                 email_domain: "other.test", enabled: true)
+        end
 
         it "redirects to the assemblies list with an explanation" do
           get new_path
@@ -175,6 +273,23 @@ RSpec.describe "Decidim::Assemblies::Admin BulkAccountIssuesController" do
     context "when issuing is disabled for the organization" do
       before do
         settings.update!(enabled: false)
+        sign_in admin_user
+      end
+
+      it "does not create any user" do
+        post(create_path, params:)
+
+        expect(response).to have_http_status(:redirect)
+        expect(issued_users.count).to eq(0)
+      end
+    end
+
+    # 他組織で有効でも、この組織では発行できないこと（設定の組織スコープの検証）。
+    context "when issuing is enabled only for another organization" do
+      before do
+        settings.destroy!
+        Decidim::BulkUserImportSetting.create!(organization: create(:organization, tos_version: Time.current),
+                                               email_domain: "other.test", enabled: true)
         sign_in admin_user
       end
 

--- a/spec/requests/decidim/system/bulk_user_import_settings_spec.rb
+++ b/spec/requests/decidim/system/bulk_user_import_settings_spec.rb
@@ -37,23 +37,23 @@ RSpec.describe "Decidim::System BulkUserImportSettingsController" do
     before { sign_in system_admin }
 
     it "lists the organizations with their settings" do
-      Decidim::BulkUserImportSetting.create!(organization:, email_domain: "chiba-mirai", enabled: true)
+      Decidim::BulkUserImportSetting.create!(organization:, email_domain: "chiba-mirai.test", enabled: true)
 
       get "/system/bulk_user_import_settings"
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(organization.host)
-      expect(response.body).to include("chiba-mirai")
+      expect(response.body).to include("chiba-mirai.test")
     end
 
     it "enables issuing with a domain" do
       patch "/system/bulk_user_import_settings/#{organization.id}",
-            params: { bulk_user_import_setting: { email_domain: "chiba-mirai", enabled: "1" } }
+            params: { bulk_user_import_setting: { email_domain: "chiba-mirai.test", enabled: "1" } }
 
       expect(response).to redirect_to("/system/bulk_user_import_settings")
       setting = Decidim::BulkUserImportSetting.find_by(decidim_organization_id: organization.id)
       expect(setting.enabled).to be(true)
-      expect(setting.email_domain).to eq("chiba-mirai")
+      expect(setting.email_domain).to eq("chiba-mirai.test")
     end
 
     it "rejects enabling without a domain" do
@@ -71,11 +71,18 @@ RSpec.describe "Decidim::System BulkUserImportSettingsController" do
       expect(response).to have_http_status(:unprocessable_entity)
     end
 
+    it "rejects a domain without a dot (it would fail the sign-in form validation)" do
+      patch "/system/bulk_user_import_settings/#{organization.id}",
+            params: { bulk_user_import_setting: { email_domain: "chiba-mirai", enabled: "1" } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
     it "can disable issuing while keeping the domain" do
-      Decidim::BulkUserImportSetting.create!(organization:, email_domain: "chiba-mirai", enabled: true)
+      Decidim::BulkUserImportSetting.create!(organization:, email_domain: "chiba-mirai.test", enabled: true)
 
       patch "/system/bulk_user_import_settings/#{organization.id}",
-            params: { bulk_user_import_setting: { email_domain: "chiba-mirai", enabled: "0" } }
+            params: { bulk_user_import_setting: { email_domain: "chiba-mirai.test", enabled: "0" } }
 
       expect(response).to have_http_status(:redirect)
       expect(Decidim::BulkUserImportSetting.find_by(decidim_organization_id: organization.id).enabled).to be(false)

--- a/spec/services/decidim/bulk_space_account_issuer_spec.rb
+++ b/spec/services/decidim/bulk_space_account_issuer_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Decidim::BulkSpaceAccountIssuer do
-  subject(:issuer) { described_class.new(organization:, email_domain: "chiba-mirai") }
+  subject(:issuer) { described_class.new(organization:, email_domain: "chiba-mirai.test") }
 
   let(:organization) { create(:organization, tos_version: Time.current) }
   let!(:assembly) do
@@ -21,7 +21,7 @@ RSpec.describe Decidim::BulkSpaceAccountIssuer do
       it "creates accounts with zero-padded sequential ids" do
         expect(results.map(&:status)).to eq([:created, :created])
         expect(results.map(&:account_id)).to eq(%w(a-high-001 a-high-002))
-        expect(results.map(&:email)).to eq(%w(a-high-001@chiba-mirai a-high-002@chiba-mirai))
+        expect(results.map(&:email)).to eq(%w(a-high-001@chiba-mirai.test a-high-002@chiba-mirai.test))
       end
 
       it "creates confirmed users that can sign in with the issued password" do
@@ -107,7 +107,7 @@ RSpec.describe Decidim::BulkSpaceAccountIssuer do
     end
 
     context "with dry_run" do
-      subject(:issuer) { described_class.new(organization:, email_domain: "chiba-mirai", dry_run: true) }
+      subject(:issuer) { described_class.new(organization:, email_domain: "chiba-mirai.test", dry_run: true) }
 
       it "plans ids without creating anything" do
         results = nil
@@ -164,7 +164,7 @@ RSpec.describe Decidim::BulkSpaceAccountIssuer do
     end
 
     context "when the generated email already exists with a different nickname" do
-      before { create(:user, organization:, email: "a-high-001@chiba-mirai", nickname: "someone-else") }
+      before { create(:user, organization:, email: "a-high-001@chiba-mirai.test", nickname: "someone-else") }
 
       it "fails that row instead of hijacking the existing account" do
         results = issuer.issue([instruction(role: "participant", count: 1)])
@@ -187,6 +187,13 @@ RSpec.describe Decidim::BulkSpaceAccountIssuer do
     it "requires an email domain" do
       expect { described_class.new(organization:, email_domain: "") }
         .to raise_error(ArgumentError, /email_domain/)
+    end
+
+    # ドットなしのドメインだと発行したアカウントがログイン画面の
+    # メール形式チェック（Foundation Abide）で弾かれる。
+    it "rejects a domain without a dot" do
+      expect { described_class.new(organization:, email_domain: "chiba-mirai") }
+        .to raise_error(ArgumentError, /dotted domain/)
     end
   end
 end


### PR DESCRIPTION
## 概要

#870 マージ後の検証で見つかった2つの問題の修正です。

## 1. 発行したアカウントがログイン画面で弾かれる

ログインフォームはフロントエンドで Foundation Abide の email パターンにより検証されており、このパターンはドメインにドット区切りのラベル（TLD 相当）を必須としています。そのためドットなしの `email_domain`（例: `chiba-mirai`）で発行したアカウント（`vol-001@chiba-mirai`）は、作成はできるもののログイン時に「このフィールドにはエラーがあります。」と弾かれ、参加者全員がログインできない状態でした。

- `BulkUserImportSetting` の `email_domain` に、Abide のドメインパターンと同等の「小文字・ドット付きドメイン」形式を必須化（/system の画面と `bulk_users:configure` の両方をカバー）
- `BulkSpaceAccountIssuer#initialize` にも同じガードを追加（直接呼び出し経路の保護）
- 推奨 TLD として、RFC 2606 で予約されておりグローバル DNS に委任されない（＝絶対に配送されない）`.test` を採用（例: `chiba-mirai.test`）。ヘルプ文言・placeholder・docs を更新
- Decidim 本体のバリデーションには手を入れていません

### 既存データの移行

ドットなしドメインで発行済みのアカウントがある環境では、設定とメールアドレスの更新が必要です:

```ruby
org = Decidim::Organization.find(<id>)
Decidim::BulkUserImportSetting.find_by(decidim_organization_id: org.id)
  &.update!(email_domain: "<domain>.test")

Decidim::User.where(organization: org).where("email LIKE ?", "%@<domain>").find_each do |u|
  u.update_columns(email: u.email.sub(/@<domain>\z/, "@<domain>.test"))
end
```

## 2. 未設定の組織でもメニューが表示される

`MenuItem#visible?` は `if:` が `nil` のとき「条件指定なし＝表示」と解釈します。メニューの表示条件が `find_by(...)&.enabled?` で終わっていたため、設定レコードが存在しない組織では条件式全体が `nil` になり、**/system で有効化していない組織（マルチテナントの他組織を含む）のすべての非公開アセンブリにメニューが表示されていました**。

- 条件式の各項を必ず true/false に確定させ、表示条件を MVP の「/system でこの組織の発行が有効 かつ スペースが非公開」に限定
- 表示条件ごとの request spec と、組織横断のスコープ検証（他組織で有効でもこの組織には出ない／有効な組織では出る、の双方向）を追加

なお、コントローラ・権限クラス・issuer・/system 設定は元から `current_organization` でスコープされており（他組織 admin の拒否は既存 spec あり）、漏れがあったのはメニュー表示のみです。

## テスト

- モデル spec: 14件成功（ドット必須の検証を含む）
- issuer spec: 全件成功（ドットなしドメイン拒否を含む）
- request spec（/system 設定・アセンブリ管理画面）: 35件成功（メニュー表示条件6件・組織横断3件を含む）
- RuboCop: 違反なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)