### PR TITLE
chore: drop the duplicate user-add-line icon registration

### DIFF
--- a/config/initializers/bulk_account_issuing.rb
+++ b/config/initializers/bulk_account_issuing.rb
@@ -30,10 +30,6 @@ Decidim::Assemblies::AdminEngine.routes.append do
   end
 end
 
-# remixicon には存在するがコアが登録していないアイコンは明示登録が必要（未登録だと dev/test で例外）。
-Decidim.icons.register(name: "user-add-line", icon: "user-add-line", category: "system",
-                       description: "", engine: :decidim_cfj)
-
 # /system のサイドメニュー。
 Decidim.menu :system_menu do |menu|
   menu.add_item :bulk_user_import_settings,


### PR DESCRIPTION
#### :tophat: What? Why?

`user-add-line`はDecidim v0.30.9ではすでに登録済みで、`Decidim.icons.register`で追加すると `DEPRECATION WARNING: user-add-line already registered.` という警告が出ます。

そのためconfig/initializers/bulk_account_issuing.rb での `Decidim.icons.register` を消します。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask
