### PR TITLE
fix: keep the assembly sidebar on the bulk account issue page

### DIFF
--- a/app/controllers/decidim/assemblies/admin/bulk_account_issues_controller.rb
+++ b/app/controllers/decidim/assemblies/admin/bulk_account_issues_controller.rb
@@ -13,9 +13,18 @@ module Decidim
       class BulkAccountIssuesController < Decidim::Assemblies::Admin::ApplicationController
         include Concerns::AssemblyAdmin
 
-        # 独自リソースのため、コアの権限クラスは使わず専用クラスだけをチェーンに登録する。
-        # 理由は Decidim::BulkAccountIssuePermissions のコメントを参照。
+        # AssemblyAdmin と同じコアのクラスに、独自リソース用のクラスを足したチェーン。
+        #
+        # サイドメニューの各項目は allowed_to?(:read, :component, ...) のようにコアの権限を問い、
+        # 未設定は不許可として扱われる（NeedsPermission#allowed_to? が PermissionNotSetError を
+        # rescue して false を返す）。コアのクラスを外すとこの画面だけメニューが消えるため、
+        # 専用クラスだけに差し替えてはいけない。
+        #
+        # 独自の :bulk_account_issue はコアのどのクラスも状態を設定しないので、最後に置いた
+        # BulkAccountIssuePermissions が確定させる。逆にコアの subject には手を出さない。
         register_permissions(::Decidim::Assemblies::Admin::BulkAccountIssuesController,
+                             ::Decidim::Assemblies::Permissions,
+                             ::Decidim::Admin::Permissions,
                              ::Decidim::BulkAccountIssuePermissions)
 
         # 本番の CloudFront は既定30秒でオリジン応答を打ち切る。実測 0.19秒/件（bcrypt支配）から
@@ -60,8 +69,8 @@ module Decidim
 
         private
 
-        # このコントローラのチェーンは :bulk_account_issue 専用（AssemblyAdmin concern の
-        # chain_for(AssemblyAdmin) を上書きする。include より後に定義しているのでこちらが勝つ）。
+        # 上で登録したチェーンを使う（AssemblyAdmin concern の chain_for(AssemblyAdmin) を
+        # 上書きする。include より後に定義しているのでこちらが勝つ）。
         def permission_class_chain
           ::Decidim.permissions_registry.chain_for(::Decidim::Assemblies::Admin::BulkAccountIssuesController)
         end

--- a/app/permissions/decidim/bulk_account_issue_permissions.rb
+++ b/app/permissions/decidim/bulk_account_issue_permissions.rb
@@ -3,19 +3,19 @@
 module Decidim
   # アセンブリ管理画面の一括アカウント発行（Decidim::Assemblies::Admin::BulkAccountIssuesController）の権限。
   #
-  # :bulk_account_issue はこのリポジトリ独自のリソースで、コアの権限クラスは未知の subject に
-  # 状態を設定しない（= PermissionNotSetError で組織 admin でも弾かれる）。そのためコントローラの
-  # チェーンにはこのクラスだけを登録し、必ず allow!/disallow! を確定させる。
+  # このクラスの役割は以下の2点になる。
   #
-  # アカウント作成は組織レベルの権限と整理し、組織 admin に限定する（スペース管理者には開放しない。
-  # 開放するとスペース管理者が自分のスペースの管理者アカウントを自増できるため、広げる場合は要議論）。
+  # 1. :bulk_account_issue はこのリポジトリ独自の subject で、コアの権限クラスはどれも状態を
+  #    設定しない。未設定のままだと allowed_to? が false を返す（PermissionNotSetError を
+  #    rescue しているため）ので、誰も発行できない。このクラスが判定を確定させる。
+  # 2. この画面を組織 admin に限定する。スペース管理者には開放しない。
   class BulkAccountIssuePermissions < Decidim::DefaultPermissions
     def permissions
       return permission_action unless permission_action.scope == :admin
 
       # :read :participatory_space は AssemblyAdmin の participatory_space_admin_layout が
-      # before_action で強制する読み取り権限。専用チェーンに差し替えているため、ここで
-      # 明示的に判定しないと組織 admin でも弾かれる。
+      # before_action で強制する読み取り権限。コアはスペース管理者にも許可するので、ここで
+      # 組織 admin だけに絞り直す。これがこの画面の入口を塞ぐ判定になる。
       case [permission_action.action, permission_action.subject]
       when [:read, :participatory_space], [:create, :bulk_account_issue]
         toggle_allow(organization_admin?)

--- a/spec/requests/decidim/assemblies/admin/bulk_account_issues_spec.rb
+++ b/spec/requests/decidim/assemblies/admin/bulk_account_issues_spec.rb
@@ -126,6 +126,22 @@ RSpec.describe "Decidim::Assemblies::Admin BulkAccountIssuesController" do
       end
     end
 
+    context "with an admin of the assembly who is not an organization admin" do
+      let(:space_admin) { create(:user, :confirmed, organization:) }
+
+      before do
+        create(:assembly_user_role, user: space_admin, assembly:, role: :admin)
+        sign_in space_admin
+      end
+
+      it "does not let them reach the form" do
+        get new_path
+
+        expect(response).to have_http_status(:redirect)
+        expect(response.body).not_to include("a-high-001")
+      end
+    end
+
     context "with an organization admin" do
       before { sign_in admin_user }
 
@@ -136,6 +152,14 @@ RSpec.describe "Decidim::Assemblies::Admin BulkAccountIssuesController" do
         expect(response.body).to include("a-high-001")
         expect(response.body).to include("a-high-a001")
         expect(response.body).to include("example.test")
+      end
+
+      it "keeps the assembly admin sidebar" do
+        get new_path
+
+        %w(components user_roles moderations participatory_space_private_users share_tokens).each do |section|
+          expect(response.body).to include("/admin/assemblies/#{assembly.slug}/#{section}")
+        end
       end
 
       context "when issuing is disabled for the organization" do


### PR DESCRIPTION
#### :tophat: What? Why?

BulkAccountIssuesの画面では管理者用のサイドメニューが消えてしまっているようです。
そうならないよう、BulkAccountIssuesControllerのregister_permissionsの値を修正し、 ::Decidim::Assemblies::Permissionsと::Decidim::Admin::Permissionsを消さないようにします。

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` upgrade notes, if required
- [ ] If there's a new public field, add it to GraphQL API
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

Before:

<img width="992" height="790" alt="bulk_before" src="https://github.com/user-attachments/assets/c7d75e58-39bb-49c7-b879-29a16bd1b663" />

After:

<img width="988" height="767" alt="buld_after" src="https://github.com/user-attachments/assets/274417d5-02a7-4142-ae8e-5ede83ea159c" />
